### PR TITLE
Add new image type 'minimal-rpm' for fedora

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -752,6 +752,8 @@ Installer:
           - rhos-01/rhel-8.7-nightly-x86_64
           - rhos-01/rhel-9.1-nightly-x86_64
           - rhos-01/centos-stream-9-x86_64
+          - rhos-01/fedora-35-x86_64
+          - rhos-01/fedora-36-x86_64
 
 Manifest-diff:
   stage: test

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -166,6 +166,24 @@ var (
 		basePartitionTables: iotBasePartitionTables,
 	}
 
+	minimalrpmImgType = imageType{
+		name:     "minimal-rpm",
+		filename: "minimal-rpm.img",
+		mimeType: "application/disk",
+		packageSets: map[string]packageSetFunc{
+			osPkgsKey: minimalrpmPackageSet,
+		},
+		rpmOstree:           true,
+		kernelOptions:       defaultKernelOptions,
+		bootable:            true,
+		defaultSize:         2 * common.GibiByte,
+		image:               liveImage,
+		buildPipelines:      []string{"build"},
+		payloadPipelines:    []string{"os", "image"},
+		exports:             []string{"image"},
+		basePartitionTables: defaultBasePartitionTables,
+	}
+
 	qcow2ImgType = imageType{
 		name:     "qcow2",
 		filename: "disk.qcow2",
@@ -888,6 +906,16 @@ func newDistro(version int) distro.Distro {
 		imageInstallerImgType,
 	)
 
+	x86_64.addImageTypes(
+		&platform.X86{
+			BIOS: true,
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_RAW,
+			},
+		},
+		minimalrpmImgType,
+	)
+
 	aarch64.addImageTypes(
 		&platform.Aarch64{
 			UEFIVendor: "fedora",
@@ -950,6 +978,15 @@ func newDistro(version int) distro.Distro {
 			UEFIVendor: "fedora",
 		},
 		imageInstallerImgType,
+	)
+	aarch64.addImageTypes(
+		&platform.Aarch64{
+			UEFIVendor: "fedora",
+			BasePlatform: platform.BasePlatform{
+				ImageFormat: platform.FORMAT_RAW,
+			},
+		},
+		minimalrpmImgType,
 	)
 
 	s390x.addImageTypes(nil)

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -130,6 +130,23 @@ var (
 		exports:          []string{"bootiso"},
 	}
 
+	imageInstallerImgType = imageType{
+		name:     "image-installer",
+		filename: "installer.iso",
+		mimeType: "application/x-iso9660-image",
+		packageSets: map[string]packageSetFunc{
+			osPkgsKey:        imageInstallerPackageSet,
+			installerPkgsKey: anacondaPackageSet,
+		},
+		rpmOstree:        false,
+		bootISO:          true,
+		bootable:         true,
+		image:            imageInstallerImage,
+		buildPipelines:   []string{"build"},
+		payloadPipelines: []string{"os", "anaconda-tree", "bootiso-tree", "bootiso"},
+		exports:          []string{"bootiso"},
+	}
+
 	iotRawImgType = imageType{
 		name:        "iot-raw-image",
 		nameAliases: []string{"fedora-iot-raw-image"},
@@ -863,6 +880,14 @@ func newDistro(version int) distro.Distro {
 		},
 		iotRawImgType,
 	)
+	x86_64.addImageTypes(
+		&platform.X86{
+			BIOS:       true,
+			UEFIVendor: "fedora",
+		},
+		imageInstallerImgType,
+	)
+
 	aarch64.addImageTypes(
 		&platform.Aarch64{
 			UEFIVendor: "fedora",
@@ -919,6 +944,12 @@ func newDistro(version int) distro.Distro {
 			UEFIVendor: "fedora",
 		},
 		iotRawImgType,
+	)
+	aarch64.addImageTypes(
+		&platform.Aarch64{
+			UEFIVendor: "fedora",
+		},
+		imageInstallerImgType,
 	)
 
 	s390x.addImageTypes(nil)

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -421,6 +421,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"iot-raw-image",
 				"oci",
 				"container",
+				"image-installer",
 			},
 		},
 		{
@@ -435,6 +436,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"iot-raw-image",
 				"oci",
 				"container",
+				"image-installer",
 			},
 		},
 	}

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -390,7 +390,7 @@ func TestDistro_ManifestError(t *testing.T) {
 			}
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, err := imgType.Manifest(bp.Customizations, imgOpts, nil, testPackageSpecSets, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" || imgTypeName == "minimal-rpm" {
 				assert.EqualError(t, err, "kernel boot parameter customizations are not supported for ostree types")
 			} else if imgTypeName == "iot-installer" {
 				assert.EqualError(t, err, fmt.Sprintf("boot ISO image type \"%s\" requires specifying a URL from which to retrieve the OSTree commit", imgTypeName))
@@ -422,6 +422,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"oci",
 				"container",
 				"image-installer",
+				"minimal-rpm",
 			},
 		},
 		{
@@ -437,6 +438,7 @@ func TestArchitecture_ListImageTypes(t *testing.T) {
 				"oci",
 				"container",
 				"image-installer",
+				"minimal-rpm",
 			},
 		},
 	}
@@ -528,7 +530,7 @@ func TestDistro_CustomFileSystemManifestError(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" || imgTypeName == "minimal-rpm" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else if imgTypeName == "iot-installer" {
 				continue
@@ -557,7 +559,7 @@ func TestDistro_TestRootMountPoint(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" || imgTypeName == "minimal-rpm" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else if imgTypeName == "iot-installer" {
 				continue
@@ -590,7 +592,7 @@ func TestDistro_CustomFileSystemSubDirectories(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, nil, 0)
-			if strings.HasPrefix(imgTypeName, "iot-") {
+			if strings.HasPrefix(imgTypeName, "iot-") || imgTypeName == "minimal-rpm" {
 				continue
 			} else {
 				assert.NoError(t, err)
@@ -629,7 +631,7 @@ func TestDistro_MountpointsWithArbitraryDepthAllowed(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, nil, 0)
-			if strings.HasPrefix(imgTypeName, "iot-") {
+			if strings.HasPrefix(imgTypeName, "iot-") || imgTypeName == "minimal-rpm" {
 				continue
 			} else {
 				assert.NoError(t, err)
@@ -663,7 +665,7 @@ func TestDistro_DirtyMountpointsNotAllowed(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, nil, 0)
-			if strings.HasPrefix(imgTypeName, "iot-") {
+			if strings.HasPrefix(imgTypeName, "iot-") || imgTypeName == "minimal-rpm" {
 				continue
 			} else {
 				assert.EqualError(t, err, "The following custom mountpoints are not supported [\"//\" \"/var//\" \"/var//log/audit/\"]")
@@ -693,7 +695,7 @@ func TestDistro_CustomFileSystemPatternMatching(t *testing.T) {
 		for _, imgTypeName := range arch.ListImageTypes() {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, nil, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" || imgTypeName == "minimal-rpm" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else if imgTypeName == "iot-installer" {
 				continue
@@ -722,7 +724,7 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 			imgType, _ := arch.GetImageType(imgTypeName)
 			testPackageSpecSets := distro_test_common.GetTestingImagePackageSpecSets("kernel", imgType)
 			_, err := imgType.Manifest(bp.Customizations, distro.ImageOptions{}, nil, testPackageSpecSets, nil, 0)
-			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" {
+			if imgTypeName == "iot-commit" || imgTypeName == "iot-container" || imgTypeName == "iot-raw-image" || imgTypeName == "minimal-rpm" {
 				assert.EqualError(t, err, "Custom mountpoints are not supported for ostree types")
 			} else if imgTypeName == "iot-installer" {
 				continue

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -318,3 +318,34 @@ func iotRawImage(workload workload.Workload,
 
 	return img, nil
 }
+
+func imageInstallerImage(workload workload.Workload,
+	t *imageType,
+	customizations *blueprint.Customizations,
+	options distro.ImageOptions,
+	packageSets map[string]rpmmd.PackageSet,
+	rng *rand.Rand) (image.ImageKind, error) {
+
+	d := t.arch.distro
+
+	img := image.NewImageInstaller()
+
+	img.Platform = t.platform
+	img.ExtraBasePackages = packageSets[installerPkgsKey]
+	img.Users = customizations.GetUsers()
+	img.Groups = customizations.GetGroups()
+
+	img.ISOLabelTempl = d.isolabelTmpl
+	img.Product = d.product
+	img.OSName = "fedora"
+	img.OSVersion = d.osVersion
+	img.Release = "202010217.n.0" // ???
+
+	img.OSCustomizations = osCustomizations(t, packageSets[osPkgsKey], customizations)
+	img.Environment = t.environment
+	img.Workload = workload
+
+	img.Filename = t.Filename()
+
+	return img, nil
+}

--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -525,3 +525,11 @@ func containerPackageSet(t *imageType) rpmmd.PackageSet {
 
 	return ps
 }
+
+func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@core",
+		},
+	}
+}

--- a/internal/distro/fedora/package_sets.go
+++ b/internal/distro/fedora/package_sets.go
@@ -533,3 +533,11 @@ func imageInstallerPackageSet(t *imageType) rpmmd.PackageSet {
 		},
 	}
 }
+
+func minimalrpmPackageSet(t *imageType) rpmmd.PackageSet {
+	return rpmmd.PackageSet{
+		Include: []string{
+			"@core",
+		},
+	}
+}

--- a/internal/image/image_installer.go
+++ b/internal/image/image_installer.go
@@ -1,0 +1,85 @@
+package image
+
+import (
+	"math/rand"
+
+	"github.com/osbuild/osbuild-composer/internal/artifact"
+	"github.com/osbuild/osbuild-composer/internal/blueprint"
+	"github.com/osbuild/osbuild-composer/internal/environment"
+	"github.com/osbuild/osbuild-composer/internal/manifest"
+	"github.com/osbuild/osbuild-composer/internal/platform"
+	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/runner"
+	"github.com/osbuild/osbuild-composer/internal/workload"
+)
+
+type ImageInstaller struct {
+	Base
+	Platform          platform.Platform
+	ExtraBasePackages rpmmd.PackageSet
+	Users             []blueprint.UserCustomization
+	Groups            []blueprint.GroupCustomization
+
+	OSCustomizations manifest.OSCustomizations
+	Environment      environment.Environment
+	Workload         workload.Workload
+
+	ISOLabelTempl string
+	Product       string
+	Variant       string
+	OSName        string
+	OSVersion     string
+	Release       string
+
+	Filename string
+}
+
+func NewImageInstaller() *ImageInstaller {
+	return &ImageInstaller{
+		Base: NewBase("image-installer"),
+	}
+}
+
+func (img *ImageInstaller) InstantiateManifest(m *manifest.Manifest,
+	repos []rpmmd.RepoConfig,
+	runner runner.Runner,
+	rng *rand.Rand) (*artifact.Artifact, error) {
+	buildPipeline := manifest.NewBuild(m, runner, repos)
+	buildPipeline.Checkpoint()
+
+	anacondaPipeline := manifest.NewAnaconda(m,
+		buildPipeline,
+		img.Platform,
+		repos, "kernel",
+		img.Product,
+		img.OSVersion)
+	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include
+	anacondaPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
+	anacondaPipeline.Users = len(img.Users)+len(img.Groups) > 0
+	anacondaPipeline.Variant = img.Variant
+	anacondaPipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)
+	anacondaPipeline.Checkpoint()
+
+	osPipeline := manifest.NewOS(m, buildPipeline, img.Platform, repos)
+	osPipeline.OSCustomizations = img.OSCustomizations
+	osPipeline.Environment = img.Environment
+	osPipeline.Workload = img.Workload
+
+	isoTreePipeline := manifest.NewISOTree(m,
+		buildPipeline,
+		anacondaPipeline,
+		nil,
+		osPipeline,
+		img.ISOLabelTempl)
+	isoTreePipeline.Release = img.Release
+	isoTreePipeline.OSName = img.OSName
+	isoTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
+	isoTreePipeline.Users = img.Users
+	isoTreePipeline.Groups = img.Groups
+
+	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline)
+	isoPipeline.Filename = img.Filename
+	artifact := isoPipeline.Export()
+
+	return artifact, nil
+}

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -61,9 +61,12 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline := manifest.NewISOTree(m,
 		buildPipeline,
 		anacondaPipeline,
-		img.OSTreeCommit,
-		img.OSTreeURL,
-		img.OSTreeRef,
+		&manifest.OSTreeRef{
+			Commit: img.OSTreeCommit,
+			URL:    img.OSTreeURL,
+			Ref:    img.OSTreeRef,
+		},
+		nil,
 		img.ISOLabelTempl)
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.OSName = img.OSName

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -9,6 +9,12 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 )
 
+type OSTreeRef struct {
+	Commit string
+	URL    string
+	Ref    string
+}
+
 // An ISOTree represents a tree containing the anaconda installer,
 // configuration in terms of a kickstart file, as well as an embedded
 // payload to be installed.
@@ -23,17 +29,15 @@ type ISOTree struct {
 
 	anacondaPipeline *Anaconda
 	isoLabel         string
-	osTreeCommit     string
-	osTreeURL        string
-	osTreeRef        string
+	osTree           *OSTreeRef
+	osPipeline       *OS
 }
 
 func NewISOTree(m *Manifest,
 	buildPipeline *Build,
 	anacondaPipeline *Anaconda,
-	osTreeCommit,
-	osTreeURL,
-	osTreeRef,
+	osTree *OSTreeRef,
+	osPipeline *OS,
 	isoLabelTmpl string) *ISOTree {
 	// TODO: replace isoLabelTmpl with more high-level properties
 	isoLabel := fmt.Sprintf(isoLabelTmpl, anacondaPipeline.platform.GetArch())
@@ -42,9 +46,8 @@ func NewISOTree(m *Manifest,
 		Base:             NewBase(m, "bootiso-tree", buildPipeline),
 		anacondaPipeline: anacondaPipeline,
 		isoLabel:         isoLabel,
-		osTreeCommit:     osTreeCommit,
-		osTreeURL:        osTreeURL,
-		osTreeRef:        osTreeRef,
+		osTree:           osTree,
+		osPipeline:       osPipeline,
 	}
 	buildPipeline.addDependent(p)
 	if anacondaPipeline.Base.manifest != m {
@@ -55,19 +58,30 @@ func NewISOTree(m *Manifest,
 }
 
 func (p *ISOTree) getOSTreeCommits() []osTreeCommit {
-	return []osTreeCommit{
-		{
-			checksum: p.osTreeCommit,
-			url:      p.osTreeURL,
-		},
+	if p.osTree != nil {
+		return []osTreeCommit{
+			{
+				checksum: p.osTree.Commit,
+				url:      p.osTree.URL,
+			},
+		}
 	}
+	return nil
 }
 
 func (p *ISOTree) getBuildPackages() []string {
 	packages := []string{
-		"rpm-ostree",
 		"squashfs-tools",
 	}
+
+	if p.osTree != nil {
+		packages = append(packages, "rpm-ostree")
+	}
+
+	if p.osPipeline != nil {
+		packages = append(packages, "tar")
+	}
+
 	return packages
 }
 
@@ -86,7 +100,21 @@ func (p *ISOTree) serialize() osbuild.Pipeline {
 		kspath),
 		osbuild.NewBootISOMonoStagePipelineTreeInputs(p.anacondaPipeline.Name())))
 
-	kickstartOptions, err := osbuild.NewKickstartStageOptions(kspath, "", p.Users, p.Groups, makeISORootPath(ostreeRepoPath), p.osTreeRef, p.OSName)
+	var tarPath string
+	var osTreeRef string
+	var osTreeURL string
+
+	if p.osTree != nil {
+		osTreeRef = p.osTree.Ref
+		osTreeURL = makeISORootPath(ostreeRepoPath)
+	}
+
+	if p.osPipeline != nil {
+		tarPath = "/liveimg.tar"
+	}
+
+	kickstartOptions, err := osbuild.NewKickstartStageOptions(kspath, tarPath, p.Users, p.Groups, osTreeURL, osTreeRef, p.OSName)
+
 	if err != nil {
 		panic("password encryption failed")
 	}
@@ -97,11 +125,17 @@ func (p *ISOTree) serialize() osbuild.Pipeline {
 		Release:  p.Release,
 	}))
 
-	pipeline.AddStage(osbuild.NewOSTreeInitStage(&osbuild.OSTreeInitStageOptions{Path: ostreeRepoPath}))
-	pipeline.AddStage(osbuild.NewOSTreePullStage(
-		&osbuild.OSTreePullStageOptions{Repo: ostreeRepoPath},
-		osbuild.NewOstreePullStageInputs("org.osbuild.source", p.osTreeCommit, p.osTreeRef),
-	))
+	if p.osTree != nil {
+		pipeline.AddStage(osbuild.NewOSTreeInitStage(&osbuild.OSTreeInitStageOptions{Path: ostreeRepoPath}))
+		pipeline.AddStage(osbuild.NewOSTreePullStage(
+			&osbuild.OSTreePullStageOptions{Repo: ostreeRepoPath},
+			osbuild.NewOstreePullStageInputs("org.osbuild.source", p.osTree.Commit, p.osTree.Ref),
+		))
+	}
+
+	if p.osPipeline != nil {
+		pipeline.AddStage(osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: tarPath}, osbuild.NewTarStagePipelineTreeInputs(p.osPipeline.name)))
+	}
 
 	return pipeline
 }

--- a/internal/store/json.go
+++ b/internal/store/json.go
@@ -350,6 +350,7 @@ var imageTypeCompatMapping = map[string]string{
 	"tar":              "Tar",
 	"gce":              "GCP",
 	"gce-rhui":         "GCE RHUI",
+	"minimal-rpm":      "minimal-rpm",
 }
 
 func imageTypeToCompatString(imgType distro.ImageType) string {

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -61,9 +61,9 @@ EOFKS
 
     echo "Writing new ISO"
     if nvrGreaterOrEqual "lorax" "34.9.18"; then
-        sudo mkksiso -c "console=ttyS0,115200" --ks "${newksfile}" "${iso}" "${newiso}"
+        sudo TMPDIR=/var/tmp/ mkksiso -c "console=ttyS0,115200" --ks "${newksfile}" "${iso}" "${newiso}"
     else
-        sudo mkksiso -c "console=ttyS0,115200" "${newksfile}" "${iso}" "${newiso}"
+        sudo TMPDIR=/var/tmp/ mkksiso -c "console=ttyS0,115200" "${newksfile}" "${iso}" "${newiso}"
     fi
 
     echo "==== NEW KICKSTART FILE ===="
@@ -129,6 +129,10 @@ case "${ID}-${VERSION_ID}" in
     centos-9)
         OS_VARIANT="centos-stream9"
         ;;
+    fedora-*)
+        OS_VARIANT="fedora-unknown"
+        ;;
+
     *)
         echo "unsupported distro: ${ID}-${VERSION_ID}"
         exit 1;;

--- a/test/cases/installers.sh
+++ b/test/cases/installers.sh
@@ -60,7 +60,7 @@ echo -e 'admin\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 EOFKS
 
     echo "Writing new ISO"
-    if nvrGreaterOrEqual "lorax" "34.9.18"; then
+    if [ "${ID}" != "fedora" && nvrGreaterOrEqual "lorax" "34.9.18" ]; then
         sudo TMPDIR=/var/tmp/ mkksiso -c "console=ttyS0,115200" --ks "${newksfile}" "${iso}" "${newiso}"
     else
         sudo TMPDIR=/var/tmp/ mkksiso -c "console=ttyS0,115200" "${newksfile}" "${iso}" "${newiso}"

--- a/test/data/manifests.plain/fedora_35-aarch64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_35-aarch64-minimal_rpm-boot.json
@@ -1,0 +1,10297 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "aarch64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora35",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93ef166ef633109718d61c580210a47a65a21eb8a178a11dd7bc577706595e27",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:097de2cb18e9011f37bf4fb4f093346ef1d786cdda1663b5ba9a66a977ac4ffe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.15.13-200.fc35.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm"
+          },
+          "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
+          },
+          "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
+          },
+          "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm"
+          },
+          "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm"
+          },
+          "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:097de2cb18e9011f37bf4fb4f093346ef1d786cdda1663b5ba9a66a977ac4ffe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.aarch64.rpm"
+          },
+          "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm"
+          },
+          "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm"
+          },
+          "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm"
+          },
+          "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
+          },
+          "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
+          },
+          "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm"
+          },
+          "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm"
+          },
+          "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm"
+          },
+          "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm"
+          },
+          "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
+          },
+          "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm"
+          },
+          "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm"
+          },
+          "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm"
+          },
+          "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm"
+          },
+          "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm"
+          },
+          "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm"
+          },
+          "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm"
+          },
+          "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm"
+          },
+          "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm"
+          },
+          "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm"
+          },
+          "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm"
+          },
+          "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm"
+          },
+          "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm"
+          },
+          "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm"
+          },
+          "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm"
+          },
+          "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
+          },
+          "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm"
+          },
+          "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:93ef166ef633109718d61c580210a47a65a21eb8a178a11dd7bc577706595e27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm"
+          },
+          "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
+          },
+          "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm"
+          },
+          "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm"
+          },
+          "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm"
+          },
+          "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
+          },
+          "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
+          },
+          "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm"
+          },
+          "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm"
+          },
+          "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm"
+          },
+          "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
+          },
+          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm"
+          },
+          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm"
+          },
+          "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm"
+          },
+          "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm"
+          },
+          "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm"
+          },
+          "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm"
+          },
+          "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm"
+          },
+          "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm"
+          },
+          "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm"
+          },
+          "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm"
+          },
+          "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
+          },
+          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm"
+          },
+          "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm"
+          },
+          "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm"
+          },
+          "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
+          },
+          "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm"
+          },
+          "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
+          },
+          "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm"
+          },
+          "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          },
+          "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
+        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm",
+        "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm",
+        "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "17.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm",
+        "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.70.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
+        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
+        "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm",
+        "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm",
+        "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
+        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
+        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm",
+        "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
+        "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
+        "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm",
+        "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:93ef166ef633109718d61c580210a47a65a21eb8a178a11dd7bc577706595e27",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm",
+        "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:097de2cb18e9011f37bf4fb4f093346ef1d786cdda1663b5ba9a66a977ac4ffe",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm",
+        "checksum": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests.plain/fedora_35-x86_64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_35-x86_64-minimal_rpm-boot.json
@@ -1,0 +1,10311 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "x86_64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-modular-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora35",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d85a31b893836536f151d1697cb4c693ff1c0445df84c3471d3d721f25c04d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d17182f998b2e5b2c11c97b03ac5c0a1924b7d66c6ee3a539357d8a923fdfc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8266ce704418cde8abe89215dc55aee64a37b4a273aa639ceb8d07c7f7e1c67d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f140ad437bba386c948ac0a37cd6c1119383fba4a42eb78214927a79e4e0d535",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d477896ce7c50c8ab915a4e0a95b462fbadb4a05a1dad5597899005f33b5315",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:086e4f8ca49ea270b2e8b12ef81b7b33815e614e5ad9a99cd28fecae864904ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:011444abd567c69e6fc589e7d74c883ae0749df41b6c3c460b97292bc5fe69ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90b4501a932693c1bed585b809ab15dca10edf4ecd0eadb34663ddba04ce89af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2bf24657611e4f1e988e55b24904d60abff918981e7cd1772bce29b116ab274",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:022cf3dbbd9dd9d3362c0bc6a42ea219c29abe1b22bcaf0972943b73abfa0550",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f693a388244b30744d1c219b26e00f5044c8f5e396a2a2dd3ce35864e646fe30",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6271b15b3b82e339216dec104060b6aac4a635c71ecc2517897684f021af3115",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1163282c68d42bed61523230431dc06e97c630f6f1e694e2f39bd1b53de5b00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70d7f22b24741ce3a874646f46e111fc6f450433da2e50a4721a686891c2c36b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c318ea2de3bcf9f76bb541eb62fdd38640906d4691f87f3d6a6cc6452e1b973c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "legacy": "i386-pc",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.15.13-200.fc35.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "ext4"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm"
+          },
+          "sha256:011444abd567c69e6fc589e7d74c883ae0749df41b6c3c460b97292bc5fe69ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm"
+          },
+          "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.x86_64.rpm"
+          },
+          "sha256:022cf3dbbd9dd9d3362c0bc6a42ea219c29abe1b22bcaf0972943b73abfa0550": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm"
+          },
+          "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm"
+          },
+          "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm"
+          },
+          "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:086e4f8ca49ea270b2e8b12ef81b7b33815e614e5ad9a99cd28fecae864904ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm"
+          },
+          "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.x86_64.rpm"
+          },
+          "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.x86_64.rpm"
+          },
+          "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm"
+          },
+          "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm"
+          },
+          "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.x86_64.rpm"
+          },
+          "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm"
+          },
+          "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm"
+          },
+          "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.x86_64.rpm"
+          },
+          "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm"
+          },
+          "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.x86_64.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm"
+          },
+          "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm"
+          },
+          "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm"
+          },
+          "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm"
+          },
+          "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm"
+          },
+          "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.x86_64.rpm"
+          },
+          "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.x86_64.rpm"
+          },
+          "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm"
+          },
+          "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm"
+          },
+          "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.x86_64.rpm"
+          },
+          "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.x86_64.rpm"
+          },
+          "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm"
+          },
+          "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm"
+          },
+          "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm"
+          },
+          "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/less-590-2.fc35.x86_64.rpm"
+          },
+          "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm"
+          },
+          "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm"
+          },
+          "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.x86_64.rpm"
+          },
+          "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm"
+          },
+          "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm"
+          },
+          "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm"
+          },
+          "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm"
+          },
+          "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.x86_64.rpm"
+          },
+          "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm"
+          },
+          "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.x86_64.rpm"
+          },
+          "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm"
+          },
+          "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm"
+          },
+          "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm"
+          },
+          "sha256:6271b15b3b82e339216dec104060b6aac4a635c71ecc2517897684f021af3115": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm"
+          },
+          "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm"
+          },
+          "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm"
+          },
+          "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:70d7f22b24741ce3a874646f46e111fc6f450433da2e50a4721a686891c2c36b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.x86_64.rpm"
+          },
+          "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.x86_64.rpm"
+          },
+          "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm"
+          },
+          "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.x86_64.rpm"
+          },
+          "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:7d17182f998b2e5b2c11c97b03ac5c0a1924b7d66c6ee3a539357d8a923fdfc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.x86_64.rpm"
+          },
+          "sha256:7d477896ce7c50c8ab915a4e0a95b462fbadb4a05a1dad5597899005f33b5315": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:7d85a31b893836536f151d1697cb4c693ff1c0445df84c3471d3d721f25c04d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:8266ce704418cde8abe89215dc55aee64a37b4a273aa639ceb8d07c7f7e1c67d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.x86_64.rpm"
+          },
+          "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm"
+          },
+          "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm"
+          },
+          "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm"
+          },
+          "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm"
+          },
+          "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.x86_64.rpm"
+          },
+          "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm"
+          },
+          "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:90b4501a932693c1bed585b809ab15dca10edf4ecd0eadb34663ddba04ce89af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm"
+          },
+          "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/parted-3.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm"
+          },
+          "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.x86_64.rpm"
+          },
+          "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm"
+          },
+          "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm"
+          },
+          "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm"
+          },
+          "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.x86_64.rpm"
+          },
+          "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm"
+          },
+          "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm"
+          },
+          "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm"
+          },
+          "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.x86_64.rpm"
+          },
+          "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm"
+          },
+          "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm"
+          },
+          "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.x86_64.rpm"
+          },
+          "sha256:b1163282c68d42bed61523230431dc06e97c630f6f1e694e2f39bd1b53de5b00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm"
+          },
+          "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm"
+          },
+          "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm"
+          },
+          "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm"
+          },
+          "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm"
+          },
+          "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm"
+          },
+          "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.x86_64.rpm"
+          },
+          "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm"
+          },
+          "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.x86_64.rpm"
+          },
+          "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm"
+          },
+          "sha256:c2bf24657611e4f1e988e55b24904d60abff918981e7cd1772bce29b116ab274": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm"
+          },
+          "sha256:c318ea2de3bcf9f76bb541eb62fdd38640906d4691f87f3d6a6cc6452e1b973c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm"
+          },
+          "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm"
+          },
+          "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm"
+          },
+          "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.x86_64.rpm"
+          },
+          "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.x86_64.rpm"
+          },
+          "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm"
+          },
+          "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm"
+          },
+          "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm"
+          },
+          "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm"
+          },
+          "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm"
+          },
+          "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.x86_64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm"
+          },
+          "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm"
+          },
+          "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm"
+          },
+          "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm"
+          },
+          "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm"
+          },
+          "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm"
+          },
+          "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.x86_64.rpm"
+          },
+          "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm"
+          },
+          "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.x86_64.rpm"
+          },
+          "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f140ad437bba386c948ac0a37cd6c1119383fba4a42eb78214927a79e4e0d535": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.x86_64.rpm"
+          },
+          "sha256:f693a388244b30744d1c219b26e00f5044c8f5e396a2a2dd3ce35864e646fe30": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm"
+          },
+          "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm"
+          },
+          "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
+        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.x86_64.rpm",
+        "checksum": "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.70.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7d85a31b893836536f151d1697cb4c693ff1c0445df84c3471d3d721f25c04d8",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.x86_64.rpm",
+        "checksum": "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.x86_64.rpm",
+        "checksum": "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7d17182f998b2e5b2c11c97b03ac5c0a1924b7d66c6ee3a539357d8a923fdfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.x86_64.rpm",
+        "checksum": "sha256:8266ce704418cde8abe89215dc55aee64a37b4a273aa639ceb8d07c7f7e1c67d",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f140ad437bba386c948ac0a37cd6c1119383fba4a42eb78214927a79e4e0d535",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.x86_64.rpm",
+        "checksum": "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:7d477896ce7c50c8ab915a4e0a95b462fbadb4a05a1dad5597899005f33b5315",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
+        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.x86_64.rpm",
+        "checksum": "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.x86_64.rpm",
+        "checksum": "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.x86_64.rpm",
+        "checksum": "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.x86_64.rpm",
+        "checksum": "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:086e4f8ca49ea270b2e8b12ef81b7b33815e614e5ad9a99cd28fecae864904ec",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.x86_64.rpm",
+        "checksum": "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
+        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.x86_64.rpm",
+        "checksum": "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
+        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:011444abd567c69e6fc589e7d74c883ae0749df41b6c3c460b97292bc5fe69ad",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
+        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/parted-3.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.x86_64.rpm",
+        "checksum": "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:90b4501a932693c1bed585b809ab15dca10edf4ecd0eadb34663ddba04ce89af",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:c2bf24657611e4f1e988e55b24904d60abff918981e7cd1772bce29b116ab274",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:022cf3dbbd9dd9d3362c0bc6a42ea219c29abe1b22bcaf0972943b73abfa0550",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:f693a388244b30744d1c219b26e00f5044c8f5e396a2a2dd3ce35864e646fe30",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6271b15b3b82e339216dec104060b6aac4a635c71ecc2517897684f021af3115",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:b1163282c68d42bed61523230431dc06e97c630f6f1e694e2f39bd1b53de5b00",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/less-590-2.fc35.x86_64.rpm",
+        "checksum": "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:70d7f22b24741ce3a874646f46e111fc6f450433da2e50a4721a686891c2c36b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.x86_64.rpm",
+        "checksum": "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c318ea2de3bcf9f76bb541eb62fdd38640906d4691f87f3d6a6cc6452e1b973c",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm",
+        "checksum": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests.plain/fedora_36-aarch64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_36-aarch64-minimal_rpm-boot.json
@@ -1,0 +1,11248 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "aarch64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.9-200.fc36.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm"
+          },
+          "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.aarch64.rpm"
+          },
+          "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm"
+          },
+          "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm"
+          },
+          "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.aarch64.rpm"
+          },
+          "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.aarch64.rpm"
+          },
+          "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.aarch64.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm"
+          },
+          "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.aarch64.rpm"
+          },
+          "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm"
+          },
+          "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm"
+          },
+          "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm"
+          },
+          "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm"
+          },
+          "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.aarch64.rpm"
+          },
+          "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.aarch64.rpm"
+          },
+          "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.aarch64.rpm"
+          },
+          "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm"
+          },
+          "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm"
+          },
+          "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm"
+          },
+          "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm"
+          },
+          "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm"
+          },
+          "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm"
+          },
+          "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm"
+          },
+          "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm"
+          },
+          "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm"
+          },
+          "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm"
+          },
+          "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm"
+          },
+          "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm"
+          },
+          "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.aarch64.rpm"
+          },
+          "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm"
+          },
+          "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm"
+          },
+          "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm"
+          },
+          "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm"
+          },
+          "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.aarch64.rpm"
+          },
+          "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm"
+          },
+          "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm"
+          },
+          "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm"
+          },
+          "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm"
+          },
+          "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.aarch64.rpm"
+          },
+          "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.aarch64.rpm"
+          },
+          "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.aarch64.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.aarch64.rpm"
+          },
+          "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm"
+          },
+          "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm"
+          },
+          "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm"
+          },
+          "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.aarch64.rpm"
+          },
+          "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm"
+          },
+          "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm"
+          },
+          "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm"
+          },
+          "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.aarch64.rpm"
+          },
+          "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm"
+          },
+          "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/less-590-3.fc36.aarch64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.aarch64.rpm"
+          },
+          "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jq-1.6-13.fc36.aarch64.rpm"
+          },
+          "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm"
+          },
+          "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm"
+          },
+          "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.aarch64.rpm"
+          },
+          "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm"
+          },
+          "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.aarch64.rpm"
+          },
+          "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.aarch64.rpm"
+          },
+          "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm"
+          },
+          "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm"
+          },
+          "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.aarch64.rpm"
+          },
+          "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.aarch64.rpm"
+          },
+          "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm"
+          },
+          "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm"
+          },
+          "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm"
+          },
+          "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm"
+          },
+          "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/parted-3.4-12.fc36.aarch64.rpm"
+          },
+          "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm"
+          },
+          "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm"
+          },
+          "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm"
+          },
+          "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.aarch64.rpm"
+          },
+          "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm"
+          },
+          "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.aarch64.rpm"
+          },
+          "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
+          },
+          "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.aarch64.rpm"
+          },
+          "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nano-6.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm"
+          },
+          "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm"
+          },
+          "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgudev-237-2.fc36.aarch64.rpm"
+          },
+          "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm"
+          },
+          "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/i/inih-55-1.fc36.aarch64.rpm"
+          },
+          "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.aarch64.rpm"
+          },
+          "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm"
+          },
+          "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm"
+          },
+          "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.aarch64.rpm"
+          },
+          "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm"
+          },
+          "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.aarch64.rpm"
+          },
+          "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm"
+          },
+          "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm"
+          },
+          "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.aarch64.rpm"
+          },
+          "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm"
+          },
+          "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm"
+          },
+          "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm"
+          },
+          "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.aarch64.rpm"
+          },
+          "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm"
+          },
+          "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm"
+          },
+          "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm"
+          },
+          "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.aarch64.rpm"
+          },
+          "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm",
+        "checksum": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm",
+        "checksum": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm",
+        "checksum": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm",
+        "checksum": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
+        "checksum": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm",
+        "checksum": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm",
+        "checksum": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm",
+        "checksum": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm",
+        "checksum": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm",
+        "checksum": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm",
+        "checksum": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm",
+        "checksum": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm",
+        "checksum": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm",
+        "checksum": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm",
+        "checksum": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm",
+        "checksum": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm",
+        "checksum": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm",
+        "checksum": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm",
+        "checksum": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm",
+        "checksum": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm",
+        "checksum": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm",
+        "checksum": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm",
+        "checksum": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm",
+        "checksum": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm",
+        "checksum": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
+        "checksum": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm",
+        "checksum": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm",
+        "checksum": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm",
+        "checksum": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.72.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.aarch64.rpm",
+        "checksum": "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm",
+        "checksum": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm",
+        "checksum": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.aarch64.rpm",
+        "checksum": "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm",
+        "checksum": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.15.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.aarch64.rpm",
+        "checksum": "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm",
+        "checksum": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.aarch64.rpm",
+        "checksum": "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.aarch64.rpm",
+        "checksum": "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jq-1.6-13.fc36.aarch64.rpm",
+        "checksum": "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm",
+        "checksum": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/less-590-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
+        "checksum": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "22.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.aarch64.rpm",
+        "checksum": "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm",
+        "checksum": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm",
+        "checksum": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.aarch64.rpm",
+        "checksum": "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
+        "checksum": "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm",
+        "checksum": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.aarch64.rpm",
+        "checksum": "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm",
+        "checksum": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.aarch64.rpm",
+        "checksum": "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.aarch64.rpm",
+        "checksum": "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgudev-237-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm",
+        "checksum": "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm",
+        "checksum": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm",
+        "checksum": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.aarch64.rpm",
+        "checksum": "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm",
+        "checksum": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.aarch64.rpm",
+        "checksum": "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm",
+        "checksum": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.aarch64.rpm",
+        "checksum": "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm",
+        "checksum": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
+        "checksum": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.aarch64.rpm",
+        "checksum": "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nano-6.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm",
+        "checksum": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm",
+        "checksum": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/parted-3.4-12.fc36.aarch64.rpm",
+        "checksum": "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.aarch64.rpm",
+        "checksum": "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm",
+        "checksum": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "8.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm",
+        "checksum": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm",
+        "checksum": "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
+        "checksum": "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm",
+        "checksum": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "31.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm",
+        "checksum": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm",
+        "checksum": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.aarch64.rpm",
+        "checksum": "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.aarch64.rpm",
+        "checksum": "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.aarch64.rpm",
+        "checksum": "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.14.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm",
+        "checksum": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm",
+        "checksum": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm",
+        "checksum": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.aarch64.rpm",
+        "checksum": "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "55",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/i/inih-55-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm",
+        "checksum": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm",
+        "checksum": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.aarch64.rpm",
+        "checksum": "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap-compat",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm",
+        "checksum": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm",
+        "checksum": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm",
+        "checksum": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm",
+        "checksum": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests.plain/fedora_36-x86_64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_36-x86_64-minimal_rpm-boot.json
@@ -1,0 +1,11385 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "x86_64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "legacy": "i386-pc",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.9-200.fc36.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "ext4"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm"
+          },
+          "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm"
+          },
+          "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm"
+          },
+          "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.x86_64.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm"
+          },
+          "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm"
+          },
+          "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm"
+          },
+          "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.x86_64.rpm"
+          },
+          "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.x86_64.rpm"
+          },
+          "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm"
+          },
+          "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm"
+          },
+          "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm"
+          },
+          "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm"
+          },
+          "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm"
+          },
+          "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm"
+          },
+          "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm"
+          },
+          "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.x86_64.rpm"
+          },
+          "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.x86_64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm"
+          },
+          "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm"
+          },
+          "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm"
+          },
+          "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm"
+          },
+          "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.x86_64.rpm"
+          },
+          "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm"
+          },
+          "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm"
+          },
+          "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm"
+          },
+          "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.x86_64.rpm"
+          },
+          "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm"
+          },
+          "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm"
+          },
+          "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nano-6.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm"
+          },
+          "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm"
+          },
+          "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.x86_64.rpm"
+          },
+          "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm"
+          },
+          "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm"
+          },
+          "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.x86_64.rpm"
+          },
+          "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.x86_64.rpm"
+          },
+          "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm"
+          },
+          "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.x86_64.rpm"
+          },
+          "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm"
+          },
+          "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm"
+          },
+          "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/i/inih-55-1.fc36.x86_64.rpm"
+          },
+          "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm"
+          },
+          "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.x86_64.rpm"
+          },
+          "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.x86_64.rpm"
+          },
+          "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm"
+          },
+          "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-modules-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm"
+          },
+          "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.x86_64.rpm"
+          },
+          "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.x86_64.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm"
+          },
+          "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.x86_64.rpm"
+          },
+          "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm"
+          },
+          "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.x86_64.rpm"
+          },
+          "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm"
+          },
+          "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.x86_64.rpm"
+          },
+          "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.x86_64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsmbios-2.4.3-5.fc36.x86_64.rpm"
+          },
+          "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.x86_64.rpm"
+          },
+          "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm"
+          },
+          "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm"
+          },
+          "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm"
+          },
+          "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm"
+          },
+          "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.x86_64.rpm"
+          },
+          "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjaylink-0.2.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm"
+          },
+          "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm"
+          },
+          "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.x86_64.rpm"
+          },
+          "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/less-590-3.fc36.x86_64.rpm"
+          },
+          "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pciutils-libs-3.7.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm"
+          },
+          "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.x86_64.rpm"
+          },
+          "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.x86_64.rpm"
+          },
+          "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
+          },
+          "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
+          },
+          "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm"
+          },
+          "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm"
+          },
+          "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm"
+          },
+          "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.x86_64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm"
+          },
+          "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm"
+          },
+          "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm"
+          },
+          "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm"
+          },
+          "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgudev-237-2.fc36.x86_64.rpm"
+          },
+          "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.x86_64.rpm"
+          },
+          "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/parted-3.4-12.fc36.x86_64.rpm"
+          },
+          "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm"
+          },
+          "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm"
+          },
+          "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm"
+          },
+          "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm"
+          },
+          "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.x86_64.rpm"
+          },
+          "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
+          },
+          "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm"
+          },
+          "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm"
+          },
+          "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm"
+          },
+          "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm"
+          },
+          "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.x86_64.rpm"
+          },
+          "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm"
+          },
+          "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.x86_64.rpm"
+          },
+          "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm"
+          },
+          "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.x86_64.rpm"
+          },
+          "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.x86_64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm"
+          },
+          "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm"
+          },
+          "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jq-1.6-13.fc36.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm",
+        "checksum": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm",
+        "checksum": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm",
+        "checksum": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm",
+        "checksum": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
+        "checksum": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm",
+        "checksum": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm",
+        "checksum": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm",
+        "checksum": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm",
+        "checksum": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm",
+        "checksum": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm",
+        "checksum": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm",
+        "checksum": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm",
+        "checksum": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm",
+        "checksum": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm",
+        "checksum": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm",
+        "checksum": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm",
+        "checksum": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm",
+        "checksum": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "32.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm",
+        "checksum": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm",
+        "checksum": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-modules-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm",
+        "checksum": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm",
+        "checksum": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm",
+        "checksum": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm",
+        "checksum": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm",
+        "checksum": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
+        "checksum": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm",
+        "checksum": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm",
+        "checksum": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm",
+        "checksum": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.72.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.x86_64.rpm",
+        "checksum": "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm",
+        "checksum": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm",
+        "checksum": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.x86_64.rpm",
+        "checksum": "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
+        "checksum": "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm",
+        "checksum": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.15.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm",
+        "checksum": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.x86_64.rpm",
+        "checksum": "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.x86_64.rpm",
+        "checksum": "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jq-1.6-13.fc36.x86_64.rpm",
+        "checksum": "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm",
+        "checksum": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/less-590-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "22.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.x86_64.rpm",
+        "checksum": "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.x86_64.rpm",
+        "checksum": "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
+        "checksum": "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm",
+        "checksum": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.x86_64.rpm",
+        "checksum": "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm",
+        "checksum": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm",
+        "checksum": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.x86_64.rpm",
+        "checksum": "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.x86_64.rpm",
+        "checksum": "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgudev-237-2.fc36.x86_64.rpm",
+        "checksum": "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm",
+        "checksum": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91",
+        "check_gpg": true
+      },
+      {
+        "name": "libjaylink",
+        "epoch": 0,
+        "version": "0.2.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjaylink-0.2.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.x86_64.rpm",
+        "checksum": "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm",
+        "checksum": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm",
+        "checksum": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.x86_64.rpm",
+        "checksum": "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm",
+        "checksum": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsmbios-2.4.3-5.fc36.x86_64.rpm",
+        "checksum": "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm",
+        "checksum": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm",
+        "checksum": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
+        "checksum": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.x86_64.rpm",
+        "checksum": "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nano-6.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
+        "checksum": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm",
+        "checksum": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/parted-3.4-12.fc36.x86_64.rpm",
+        "checksum": "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.x86_64.rpm",
+        "checksum": "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pciutils-libs-3.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm",
+        "checksum": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.x86_64.rpm",
+        "checksum": "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "8.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm",
+        "checksum": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
+        "checksum": "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm",
+        "checksum": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "31.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm",
+        "checksum": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm",
+        "checksum": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.x86_64.rpm",
+        "checksum": "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.x86_64.rpm",
+        "checksum": "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.x86_64.rpm",
+        "checksum": "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.x86_64.rpm",
+        "checksum": "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "32.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm",
+        "checksum": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.14.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm",
+        "checksum": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm",
+        "checksum": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm",
+        "checksum": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-modules-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "55",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/i/inih-55-1.fc36.x86_64.rpm",
+        "checksum": "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm",
+        "checksum": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap-compat",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm",
+        "checksum": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm",
+        "checksum": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.x86_64.rpm",
+        "checksum": "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests.plain/fedora_37-aarch64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_37-aarch64-minimal_rpm-boot.json
@@ -1,0 +1,11374 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "aarch64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-modular-development-20220831/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85154a1e7fdaf984f266807efe73bf220e6203a3d91df40c0dcc3f4c9d2b1fbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c8b0b0867c9cc919821ab4ec571fb01f4abeadd76e35c6de4e8382ff2b7bf74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad791a6e174f599232936759461d89df1f01e4e3b885488d27fabbce1b7e5e2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b328a0463b313c7ac25139caf855dd78194d0ad572cc95eaad8038494d7884db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e0fe8775d7980fc6f21f87522128a14a4160026a09599895171afa717e39e68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6115b0fb5152d6cf5d44ece67289551cf01aad2dab103b09a298d01409a371e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb8cb255fb3af97bb2de4462e20d237123e5c0eeb92785cf00e58570c62a62b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:471181983c6130950fe07ba9dcd7825559555bd1c055d67adfc3f7a21729d4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34565f7a706cf4111bb3c1c11f1b2f229a0d202ecf2daad8f98eb60cbc5214a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a156bf749c21addedb7b8423c78b5ff58d7ae1c8d80d47f86df3bdb0ac415f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4b264435d539525594bd8b9c60c4627aaba7e4c9606761b20153e0f17b710c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47d3b0f3b51974f6be0b900ee6472aa20fb214c494a3d3994cc9fbc854ce0f33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:344f2ca875b102496347055bb8e0231fec25a0245a538267e072e666581c2ba8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c59b2d38f31785022b5b4badb0d7b4efd255e8bdd31a4fd3636eee62dcb7a28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:898d0d0b74e205c2d9f9549cf82abcc9d1d5665f83255dfb416fece029897724",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b17ee7153e3916bef8bf01d9c02aa789150711fcf752930475d4a5ed8cd23e74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ddf01b8fc9bbc0dcfcc8075c5e6b0efb7a2e83d2086cd0ea43794ac4f2095e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f764f955353579bb120b720ad6db26740003a862093066ed22b400cfd249b6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed598abaec8c192c87f9906423468cb438aff653f7e35a036053f4ea09b884a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e75d60792d3b6afdb7f557590363cbaea8f030cf72b49eb5f192b2f743a8b38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9312c3b6a93ec5ef197e11cd9bfe1ce9739b197b9756ab3dc43db2861ef41e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ef69b3a01eef549a6757fe2aa7d2d234f7da70a4d001d4344938e3e84276422",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038cf4a81c5d368b86fe22d7424c0cc7005f40fb2d04f49e6f7fed10c59b9e40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efce366e113512afcb49ee1d64d553923b144c90df68d31c63b1eb61bd4d4f9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1439943133d9753b57246bf80b6b168266652831acc19f6b8d658ec65bc9614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3729513f5da9fd89e033e25be88b344a026c73bb5bb37def449ed94b65e61df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa303761d66b8f1e839004dab9bc0b6bc53cce6e0eba0e6000ea50d924658439",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ddb89f6a3955b0dc46c015025e5a2956d0c06bc93fbc0a3b3f087fbc6b0873a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:031dc58d9e841652a0c8f98750408d6b5e81dffb0baa20eabf26add7c41363d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5a9f472a5a88798376d935090fe11e65413016a878a88da8cf839199fba1b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76d048c6c3b1aa099ec34a7c2fdaee1487aafe738cf64e912b1b84bcd9440ff9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80e547e469c9e6df062633830a2ae9f54355236f91bdf0d83ff3222d60dcf836",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ba24cdbe2f39f0ee83b266399177343ee110035f635de2ee81426227b399998",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d78e738293b97817feea679546a1611ee76389bfd2c7b6f496d3cc90cf611ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73dc19a07f58022d78e6a8aaedf2c4631e90fb62f2050776d5ac0e8fc6b300e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:beb88184545c5c8d60bed49bdad82674a58868db381d55d9a517f35ac9cb24d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:722a9893ae7d36b0b6209c4cf5964903e1d74906af33953aae56ae120dbb9102",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1acc1bcd35e05606e201dc4ac1d4dcad96bacadea944dcf95d7aa61cc7289fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:247d834075c26fee903b27e499758cbce85837457cd9aee1ebc9b3b3a31aeb59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c99e1b512c78b34c5a4b48dba416d4128de106d4513b5593a8c1578ed418b568",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21024e762c7baf67cfb21ef765c56fb50a3a86d238567ddcb23fc60cdc2bcd97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:b25b2a6aa9d67b105201ef7f90154da99e683b8a3a64f6f1ec17d1300dcd2e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32bcbdcbabaf2bbe5e4e89a7eb2a9827c576f58fbc50cdc7f558e737d75bcb51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:006ad5476696d1e76dc6fc73bde307c6964ac503ac39b3a6675db63a949aa04f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fec9c3bbc378c458dea2ec3e8da500d6f3278d723cc94d8a27a1d0259ea3c89e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d77e701a27657e67bc9313a8301ca8408b981394fb930e9f9b7429efb147c7f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85154a1e7fdaf984f266807efe73bf220e6203a3d91df40c0dcc3f4c9d2b1fbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c8b0b0867c9cc919821ab4ec571fb01f4abeadd76e35c6de4e8382ff2b7bf74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:051378dae7a4f2a5628872a7f4e019258103d23edc6300d355ffe921508f2b08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c1347d36ff1258ef9bc3d015506677837976932928df4b8174e84667a161660",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad791a6e174f599232936759461d89df1f01e4e3b885488d27fabbce1b7e5e2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:376d49e2efda411c94ae6c6b24acf6e478f9f5c4220c590034be46528d7b8577",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b328a0463b313c7ac25139caf855dd78194d0ad572cc95eaad8038494d7884db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e0fe8775d7980fc6f21f87522128a14a4160026a09599895171afa717e39e68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e86ae6cbc732e3ea8ca4a3098f879ac64a12bac786b760b5273db25d554518e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7221f9c4b4c980552dffc75a08e413d794d2c52812b3778b6b0127f801c80eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ca54a2136e9234c3296e67c2cf8a058407f7741d9a19a09dd57924094277226",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f46592a35c4569e5d32364baa37081e1454761043a873e3ee20067ce5409a85a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1225d8d1f0752e8e529ef7257f235b9189c1f85fa361883a9d40f768da0eb2c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3845db664d89151f8a07f465f734705eaeb76c242c58866f91045db46f63b650",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c70e5ab3e25d6f78c9bc66d0f6b3a7f33457a63c2a17cd15efeb5ca6a0023c62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ef037a08f8b410305c305d9b77497d7fc557b66dd08927d31ba4beffc3faa1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6115b0fb5152d6cf5d44ece67289551cf01aad2dab103b09a298d01409a371e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04b86049e757ed9a6495bd67cb837c2e5236d3fadce93205211d74edbd71bfe1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:157ce90eb5ee5b4d7cd33f18a59108ecbc941f7910c65d0406aec56ffb3d8754",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb8cb255fb3af97bb2de4462e20d237123e5c0eeb92785cf00e58570c62a62b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:471181983c6130950fe07ba9dcd7825559555bd1c055d67adfc3f7a21729d4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34565f7a706cf4111bb3c1c11f1b2f229a0d202ecf2daad8f98eb60cbc5214a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11ef902abb560166f418e4f4bba230c7c5a3d0bf2f917fb771229fe923a767ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70b262c317b0a012fbe1fc1239f7972da097c45e15075c8165b26069a7f7267",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:393cc43a853a2f5f391d133acb032b0a50d5070aca8bd3ec132d949b6af157bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b269e1f4fbfcd3fcfc78f42b8045f5f32e98808b7e841940aa066a74fc49e2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dcf1b43b18affb19e794f20338c8bc7c6d05bd7a14217037a0a71147e8582fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f5f3953da57fbc1aab1d723cedfeca5c3536c66d479335af6173ca50c54bd5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d0abe5e642c9fe5f39f40489559188d759faedd7c606042b797bb2c74bece4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01328b5fa54399477e0c377e6b2968b6beac0dc2bdfcd05941983194d2a561a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9876f27ed35bfddf6e953a6f06f0695556df67315bf3286ed74150d6a82b28da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b71e545778baa7142f668a246bae82733188c259bd685e5a1af64bdc8604a12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a156bf749c21addedb7b8423c78b5ff58d7ae1c8d80d47f86df3bdb0ac415f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4b264435d539525594bd8b9c60c4627aaba7e4c9606761b20153e0f17b710c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47d3b0f3b51974f6be0b900ee6472aa20fb214c494a3d3994cc9fbc854ce0f33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:344f2ca875b102496347055bb8e0231fec25a0245a538267e072e666581c2ba8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1bad6b76f428e9594e9d17c5e843682d9b6b07d687194f263b5f3cc93aac61d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c59b2d38f31785022b5b4badb0d7b4efd255e8bdd31a4fd3636eee62dcb7a28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:898d0d0b74e205c2d9f9549cf82abcc9d1d5665f83255dfb416fece029897724",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b17ee7153e3916bef8bf01d9c02aa789150711fcf752930475d4a5ed8cd23e74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ddf01b8fc9bbc0dcfcc8075c5e6b0efb7a2e83d2086cd0ea43794ac4f2095e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdff19c6bac526516f8352e29c6ec41e88e4fa9ebb1e31f620e612e8ff7fd6ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b875744ecefb91efbe7d05df252768f666bf220d23f865d7df9b15e58dc86631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8408b9f0879ebd2ae84e7ef794abb23eb0901bb7a007d699cf7f234c953c8e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f764f955353579bb120b720ad6db26740003a862093066ed22b400cfd249b6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed598abaec8c192c87f9906423468cb438aff653f7e35a036053f4ea09b884a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:445cda1792047a2c4bd2172c4a2ef0c175096a848a856cb053bc42d6fb2c595b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44a972be5ba2b774ecbe02a5773ab63e64dae3961de4fc0b36667d42f1c0a4cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34e078e9be9cbe997458a72e35718feaff49a1cbaf8a8582b30fd0c744b03105",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c442df8e338070106f86ed4762397a89c5485c72d6796f97535ec3b7f3c816",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8053eaf425c8bf14a476049eab59e586dd2d6fef458bf8eeb27ad661fdaf3d0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941ce3e47a525ae3e39f79a7df7d8e11a313a30a45b5b773233fc5f0ce6fba84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3baa59082b57d8303f92d493ee2a4d85592b31a89b6598b3c8b1e01efbe2f15f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:925f753a571120c816ce36c82646cdc0f69be84d762ae61184eb6ef5680ccf4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2e0afdc7de2f8a16ce78b1d88ad600f4cd87b77483c06be924eb508ed30f597",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:040f180295b3e082728cc9725aa5a15556920bdddf6e229c7693b4ec80fd935a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ec90e98535f2ba20e2ebc46824e08834a7f6d0239d425c1868ddc7fc57cf677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17f5276639d9353dd06539d02d936a2b36793003d9ffd12ae0b557b35743290e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e75d60792d3b6afdb7f557590363cbaea8f030cf72b49eb5f192b2f743a8b38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d6782f1e07f1681965fcb7f3a2e1696c458bbc336a67fe3f03e95b0056a9591",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30d427c19f748c5742d5777e3f372c38bc611622f8797f37932d553405a50885",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec59f690cd61c14d11ed7e44908bd5ba689c23b2cad8539984e2fa94b8ef0443",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3063bbcd07caea5dcdb242471047b2a77264ed33bf004ddf7405cab70c6bfe1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b97c4e4b98b93adb07c985a362e7216298fb7527f1887626597cc2ef2796de8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef495449eaf292fe2bf17066a5bc006c357804d207f7bcdc16e65d40ec827206",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:124de1fdf02cd178ab02a3df77cc26059ca0254b5999f0f7f6032e38ac8119ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b2120af0fbbde74d84061d1a22091a5f48dbbba68d5884399117dee7c30fe5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2141e8e12fab7bf473c869b02d6857a6a2aee1f7fb30ed299add89f5a2a29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6131cc6f89273c0054332758df9314e5146bd9a311b8ed93452dd51426dc3a92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:548d5fc80ac537d663ce1130f95c0b24d6ddbd0da9ce5c6490306bb78ea5f1d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ed8b614d428d1a559b8af5c615692f3e2aa26327518bf14a6c3a29dc6c47128",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a10c1c094e8a82caf5ec0a6dbd98ac8dd9bd1169fe03fd53d98211c02086a89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc8ef19d0f2ce557fce1a49c78cda84865b2fa2e26713bbc3c7c73d507212de8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b6cbd8f1bcd9e058f975f5b2b2e19a075dd6c28e2e8a67feaa337737b542fbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6b0aa91236f4fe07ebd5fd5154cbcb8c7ecca90ba9af7808c8820454c173f75",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70702e8555203b90abd08f8c407a872640ed19a9e9d53869950cf56c594540e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46ffbcbb2b1f414985b2824965e759104fd9c108cb8140cab2a2e4ee421daf6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9312c3b6a93ec5ef197e11cd9bfe1ce9739b197b9756ab3dc43db2861ef41e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4092137b8adddb11ff22705fb37255f70a6cf1c26dd44a33410a1d0c3ab7c8a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e5d3c2263a0958574d26b7afe5c5341d7bf80c0986f5e6116e4dd4e312a03f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2090e6e4ab40eecb80944093cfd6dcee965cb27803e59c207c28692e8f4c5d7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56b548b06112a037121a913157b0e4c08dce4bb0511843f652e99960e657d13b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0843f8805c84f780715c402544d9ce7255f773d2cdbfe64f2aeb50a5085689ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ef69b3a01eef549a6757fe2aa7d2d234f7da70a4d001d4344938e3e84276422",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038cf4a81c5d368b86fe22d7424c0cc7005f40fb2d04f49e6f7fed10c59b9e40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bcdcac414f4e313ae3527d3993f17bf38d296fdc556c10e738177fb5621a245",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c91f35b8379c7238168e973a862811f053802541d4408b25fc646cc664b70e7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8aa41c3f317ac66bcb1f3b942ca73b054dd7b12574e8eed2af0b86fbd6fbf7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c635414b909a2b7ea49bd815c0261f4d30d13d871346906501d7316af3ba1772",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b2887375b6fb33413a5973435c3f648d1f7995907fa770e59fb064fa1f7cb3d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c9b9096e70c3bee0796496b9acbe5d48ef73425727a2c332f9cf2834957e086",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d582315683769a0456d5ec9f85939f75f8df5055f3ac4110f28cdbea9ca9cf69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:918357b6b1672becafec46a556a36e2b142d6926a036aa1a8deda3418f6e39b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0fec5b7c7c8482cb9642dad77eeedadefe7dda70ed7b53d44fb5a6bd1ea2749",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7287117da748fba67e225144984f0dcc1191f58d5719b9b48f515580be6b7f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95d136f0a45ecec0f319ac888010a2961d32d31a4cbc7c63aa5f5d128b9619e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:efce366e113512afcb49ee1d64d553923b144c90df68d31c63b1eb61bd4d4f9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4e372e626eca2c917309767102294dd75e83ae3d4583e90ee5ac4d1b5032e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80e767ec60eb6cbbe095ef2917e2a8d022d98a5f334df0c1c3a14e27bdf03f4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62dfa5a36a42f97393cf948694764acd5bf102eb91e0e85b1b2d565fa0450823",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc9ddf08ea0c691edaa5f2072667d11715a6349f5745f3d2b6e6713bda1858f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0944d0fd2d273c99f6ab808111d4db455fc9ba8489714aabdeda5729977c004",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38b9035b2449e7d152bf03e6e3b46243550ee29c2fae8730bfa11646fb04f6cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:002eb0cd50f7f38dad54f2fb4cb1fc445c7ae0d320d11201f43f582c12e17a8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1439943133d9753b57246bf80b6b168266652831acc19f6b8d658ec65bc9614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f39abba16ac8153a5e4fe5f44b875d0be983cb62b6ad7115cdf8ccd7fa325efc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a734e52f908f002006087a9e1cdaea29ec7f804a7f07df0a9c4de3d3af488307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1884edcfd3bf500adda863fff4a23f86dc7003bec41d1fd6e0b30d072d30c3fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1af086033468497e7a39f875a661c6db3b946e97b455cfac15319f7f75790bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3729513f5da9fd89e033e25be88b344a026c73bb5bb37def449ed94b65e61df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43f129f65128a6477ed7d55f7c8a0a1359bd6eec8bc162480ef21d2366e6de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adf4bb4c6f00d4d335a8cf6c6cbb3919aa3381752edde9a16bd810600e38f8aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed050e88e1fb2f8d2cdfb83075e79eb868decf66ec51ee4bca29d35e849f5247",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6ee284dcef741c4de7ef51f540ce8144cfc5f2937dd7da0c1c857d96cb5ecb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:157d58d20aa573cac45cc8d4c7292d5256981d4e16921ce08b47906a8df03259",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:020c07869e11cd2ff881e0917150c8467c8c1de54a5a7fcbb6f76a594f21597e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d62eec866919cfc099ea008e165effa38edd53c0489deb121d39839cc30a3e92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a27d291b03476f2e041cee4b0c91eebedf31a4d13cc2ed1030eaca5f77f93ddd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5059e977d0f0fb2f8e00201efc16c9e75198d23a5aaaef146e042d845a69e97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2536982a47df91b0763fd31226c2ff6f2247c1d028686e0201ba4b3aba45570b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:052d5277d62271b6d02095046f52a865e5a196be847e0e99d9e257d798c6167b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1301eed066ead5d0206b90f66167d010ca993da90baa2ecdd19e7e3075d9b86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a89bdeff8ea373ce88d147a5f017e7f342c1c79fdf615a88f2396e980638feda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f787566fa6d4c0a2f5067b98195f3697a4e9c65a8227b6598f0d0fd778da571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1a57b94b81b6f8a34d8b8afa81bc64c7b74900e24ab8bdc67c967702e5d21b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ee4cff1eb28623c2f3bca14d2d971c8d40f1c705adcccb345a005a0a6f547f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a755df3c6cba46dd73d8264ba5204f49700f8dc697aefa7c73eafeea8ba90641",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:948738abb47f1d630bee2fae87cdb00f65d2f5e25c31367a6394d3fddb082c35",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a79a510349b5fc98da763d60275700e6dbfd5823d47514bd6b20e815ab593940",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f6482af76be62483afff6de7a689e18d45881b91d13f11bbd3dcebe91d38504",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7844c090147f6e04cb219d39eb76341b08ec0bbea3b51c51aac925301fb7c677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eff91da3adf84b15e85b72b907d7b233adbea9d78ecf0db75d9c3a6c9c0e43da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d6c6889c78933703fc54b965fe1cebd52f08e7780093e71b21fbe10586f2aee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b56b7ca059afbe4a7ba86d30b7b324e639df618276cf45b46d3e315cf0718fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69ff7199c3b6dd205c09022bbc598851e21a9dd192ab5b63a7f25fbe706933bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b18c30e4e0d805ee80b71ac118d948437d0a81860355b3fd004226ee3f9db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36f273cf6011455969cf6ef2d8d6f64c95eaf7edd7c3789535f5b6a1f6a1bee3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2e7563405fc95534d5f6843349efcaa20574f015dead29921d04bc05362b35b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:466a7c0dfbb55b564f120dd39daeff9206b76ea8b1b93f4897c9153af9572236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa303761d66b8f1e839004dab9bc0b6bc53cce6e0eba0e6000ea50d924658439",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f23bbbb8abeccfae1758e2eef3a676c956f2df47ab4ab559eaff52afa1f809b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ead18c632b1aedd94d6d722f8317c2618165b9bc0532fea4ba5a10b642e4766",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaca4b21ecfe4860a8d3633ae57ca8bcbff0af8168db4b424e4293948b0dbf2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:066b24665dc145c4337c6332b2123bbe662b360d34dc53edbb6c14b59c8fb8f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e919037d0b4f9f434f845500c66155c753f86bc47dfcb9935d937304e7948b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ed6ead984746688cb4b95a4f4bc4ede898fe768b9129bc91df82ec9721ab37e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e9aaf2225e46e8ff4e63a387f2e4479fd40e0455135560388c220c148800ac0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89a9f1f450a4fa695100278afb7bf12fc00c3e423085a45b1a282ded7a685c33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ddb89f6a3955b0dc46c015025e5a2956d0c06bc93fbc0a3b3f087fbc6b0873a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65c0279da62825de54dfd036126233ee051808122875d4aa3dab7eff27f3f9d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c9c7520371594e7072d9cee9fe6df88e1de32c9f39eea0e6b13a447fc04ca86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:031dc58d9e841652a0c8f98750408d6b5e81dffb0baa20eabf26add7c41363d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e51a6aa0c2acf0913d7aa70eca38a11492de9ce863bd2f4955ae09c3ceda37a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9549982392bd6cd0c8fbcaab7a672bc94aac048f3f20a5c98fea083866748c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fc2b6910a5c954f8ef9c89e6ccb09df3a66ce5a323075775f65366ef649db95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a980a3db08191299cb1ae9640a924fce3631d34a7a931ba34b0a44daf2b53c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dec644503915a6e2e256de5993a746379f871b241d81d0a0296c3f9478bf84a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec395c3a160470a6da63ac1298a540a93a2adee4d29c4f78c24330dbbfba12b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b9a2c3db5e64b6c33eb7f5b2f2f63cf127626548540bb6333e0c1fbc415ab9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55ff17ec31466bd748005cf65cd687af61b0aeb3ad343e8d0c2d9a24f8a1286c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:378607a741f61282ed8243ca0f2164fa521ff02983e0eb1289d4350b7c781602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5a9f472a5a88798376d935090fe11e65413016a878a88da8cf839199fba1b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22768251ebf30802c0bce3fe0bd9d4092bf56bff6036dd655684612949c112af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f0fd19966edad2dcdea46d1a8f2dc77bd44494c3b3ab896c51af70d854bb62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:916f8e6515fb7fc4ddf0db6ae1bad1bb167d4629c4d198e2618dc5cafa172d8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76d048c6c3b1aa099ec34a7c2fdaee1487aafe738cf64e912b1b84bcd9440ff9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7068166d5807467f0da88303b489f6975b439a2530185094c631732d2a6da484",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80e547e469c9e6df062633830a2ae9f54355236f91bdf0d83ff3222d60dcf836",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ba24cdbe2f39f0ee83b266399177343ee110035f635de2ee81426227b399998",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a56d19f03448414d12e06d99f1ee3d7f802a7d4ab94348d7079be746c4d1cf0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1c78ac4292331b14107532eb08051c929248230df6b955af12d2eb4bccc0f5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d78e738293b97817feea679546a1611ee76389bfd2c7b6f496d3cc90cf611ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eed9d47041b04ea6c49408f4d71cc0190b699c51c1a89de4c6fdd676cd1777a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f50c3931775e5513506e04c0d65ba2bc7b19252f87eabb23b3911031a2309fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486f49b44bed738796297ec1cbc073ef4d571396e3f408e1cff77d938d1a2982",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7175bfcfbeeaee19bafc01c4709c825cb553db170934da4bfa7fee61ea5108fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:388def347af7b9811dc79872bbb55f1ae433bde1cc4b28e8b3ccc03eeab80a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c8c5a7d8a7bde6cd7413c745ea8f81f728169d2e4e96327a86f41019b8390de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73dc19a07f58022d78e6a8aaedf2c4631e90fb62f2050776d5ac0e8fc6b300e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:beb88184545c5c8d60bed49bdad82674a58868db381d55d9a517f35ac9cb24d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:722a9893ae7d36b0b6209c4cf5964903e1d74906af33953aae56ae120dbb9102",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1acc1bcd35e05606e201dc4ac1d4dcad96bacadea944dcf95d7aa61cc7289fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:247d834075c26fee903b27e499758cbce85837457cd9aee1ebc9b3b3a31aeb59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c99e1b512c78b34c5a4b48dba416d4128de106d4513b5593a8c1578ed418b568",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5eff8b70f05717621b31b0c0c8fbdfa6bfbec81d38c7b98cc214a33dba9bde67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:91448bcac8efd67b285cf12ef86cd97c44aba4194270624647ab6362377bb7df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b5506311d4d8aa6dba565bb89e43d96f9ac149fa3240252f1434edecade28be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e85f2257c7cb41df273ffdea56daef73e44bb7bfe79befa296f700e60c49548",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a73b3d5a5f472d8347a2f858a0061e3f338323dd962d5293b2d0982db9f20bee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10d589cbec758e5ee04e6277a0700f9e7118569ec5a6d37e5a3e0043fbb94eda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6fa6669abe6413582fb6edb939ff8e897a71c9e054a6839516cf9a6b11eb6c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788976a6dfe6796fa08ba5f52c17af923044473b481a75be9bb695e8fa7d5a16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e169c14f3c544cd0355633040eaee3ebeddde31bf022ab2d4441db084c5779b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:053723c498aa0e5fdcfaed2b5dd61d19bc00bfac4d69a45f4d02eb22d8ebe297",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21024e762c7baf67cfb21ef765c56fb50a3a86d238567ddcb23fc60cdc2bcd97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c7be4066ad8a69c7b4ef73706b1c0591361b522f22a1ad969f2e128992ecdd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.19.3-300.fc37.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:002eb0cd50f7f38dad54f2fb4cb1fc445c7ae0d320d11201f43f582c12e17a8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libreport-filesystem-2.17.2-1.fc37.noarch.rpm"
+          },
+          "sha256:006ad5476696d1e76dc6fc73bde307c6964ac503ac39b3a6675db63a949aa04f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/NetworkManager-libnm-1.39.90-1.fc37.aarch64.rpm"
+          },
+          "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm"
+          },
+          "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm"
+          },
+          "sha256:01328b5fa54399477e0c377e6b2968b6beac0dc2bdfcd05941983194d2a561a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:020c07869e11cd2ff881e0917150c8467c8c1de54a5a7fcbb6f76a594f21597e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxmlb-0.3.9-2.fc37.aarch64.rpm"
+          },
+          "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:031dc58d9e841652a0c8f98750408d6b5e81dffb0baa20eabf26add7c41363d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-3.11.0~rc1-2.fc37.aarch64.rpm"
+          },
+          "sha256:038cf4a81c5d368b86fe22d7424c0cc7005f40fb2d04f49e6f7fed10c59b9e40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgomp-12.2.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:040f180295b3e082728cc9725aa5a15556920bdddf6e229c7693b4ec80fd935a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:04b86049e757ed9a6495bd67cb837c2e5236d3fadce93205211d74edbd71bfe1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dracut-config-generic-057-2.fc37.aarch64.rpm"
+          },
+          "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm"
+          },
+          "sha256:051378dae7a4f2a5628872a7f4e019258103d23edc6300d355ffe921508f2b08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bluez-5.65-1.fc37.aarch64.rpm"
+          },
+          "sha256:052d5277d62271b6d02095046f52a865e5a196be847e0e99d9e257d798c6167b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:053723c498aa0e5fdcfaed2b5dd61d19bc00bfac4d69a45f4d02eb22d8ebe297": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zchunk-libs-1.2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:05c442df8e338070106f86ed4762397a89c5485c72d6796f97535ec3b7f3c816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm"
+          },
+          "sha256:066b24665dc145c4337c6332b2123bbe662b360d34dc53edbb6c14b59c8fb8f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm"
+          },
+          "sha256:0843f8805c84f780715c402544d9ce7255f773d2cdbfe64f2aeb50a5085689ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cpio-2.13-13.fc37.aarch64.rpm"
+          },
+          "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nettle-3.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:0c59b2d38f31785022b5b4badb0d7b4efd255e8bdd31a4fd3636eee62dcb7a28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-2.36-1.fc37.aarch64.rpm"
+          },
+          "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:0d0abe5e642c9fe5f39f40489559188d759faedd7c606042b797bb2c74bece4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:0e75d60792d3b6afdb7f557590363cbaea8f030cf72b49eb5f192b2f743a8b38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kbd-2.5.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:0ead18c632b1aedd94d6d722f8317c2618165b9bc0532fea4ba5a10b642e4766": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/passwd-0.80-13.fc37.aarch64.rpm"
+          },
+          "sha256:0ef69b3a01eef549a6757fe2aa7d2d234f7da70a4d001d4344938e3e84276422": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgcc-12.2.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:10d589cbec758e5ee04e6277a0700f9e7118569ec5a6d37e5a3e0043fbb94eda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/v/vim-minimal-9.0.213-1.fc37.aarch64.rpm"
+          },
+          "sha256:11ef902abb560166f418e4f4bba230c7c5a3d0bf2f917fb771229fe923a767ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-repos-modular-37-0.6.noarch.rpm"
+          },
+          "sha256:1225d8d1f0752e8e529ef7257f235b9189c1f85fa361883a9d40f768da0eb2c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:124de1fdf02cd178ab02a3df77cc26059ca0254b5999f0f7f6032e38ac8119ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm"
+          },
+          "sha256:157ce90eb5ee5b4d7cd33f18a59108ecbc941f7910c65d0406aec56ffb3d8754": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dracut-config-rescue-057-2.fc37.aarch64.rpm"
+          },
+          "sha256:157d58d20aa573cac45cc8d4c7292d5256981d4e16921ce08b47906a8df03259": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libuser-0.63-12.fc37.aarch64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:17f5276639d9353dd06539d02d936a2b36793003d9ffd12ae0b557b35743290e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/jq-1.6-14.fc37.aarch64.rpm"
+          },
+          "sha256:1884edcfd3bf500adda863fff4a23f86dc7003bec41d1fd6e0b30d072d30c3fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_nss_idmap-2.7.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:1b269e1f4fbfcd3fcfc78f42b8045f5f32e98808b7e841940aa066a74fc49e2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:1b97c4e4b98b93adb07c985a362e7216298fb7527f1887626597cc2ef2796de8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm"
+          },
+          "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:1d6c6889c78933703fc54b965fe1cebd52f08e7780093e71b21fbe10586f2aee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:1ddf01b8fc9bbc0dcfcc8075c5e6b0efb7a2e83d2086cd0ea43794ac4f2095e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-minimal-langpack-2.36-1.fc37.aarch64.rpm"
+          },
+          "sha256:1dec644503915a6e2e256de5993a746379f871b241d81d0a0296c3f9478bf84a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:1ef037a08f8b410305c305d9b77497d7fc557b66dd08927d31ba4beffc3faa1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:1f6482af76be62483afff6de7a689e18d45881b91d13f11bbd3dcebe91d38504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-util-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:1f787566fa6d4c0a2f5067b98195f3697a4e9c65a8227b6598f0d0fd778da571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:2090e6e4ab40eecb80944093cfd6dcee965cb27803e59c207c28692e8f4c5d7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm"
+          },
+          "sha256:21024e762c7baf67cfb21ef765c56fb50a3a86d238567ddcb23fc60cdc2bcd97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zlib-1.2.12-4.fc37.aarch64.rpm"
+          },
+          "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-identity-basic-37-0.12.noarch.rpm"
+          },
+          "sha256:22768251ebf30802c0bce3fe0bd9d4092bf56bff6036dd655684612949c112af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-nftables-1.0.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:247d834075c26fee903b27e499758cbce85837457cd9aee1ebc9b3b3a31aeb59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-resolved-251.4-53.fc37.aarch64.rpm"
+          },
+          "sha256:2536982a47df91b0763fd31226c2ff6f2247c1d028686e0201ba4b3aba45570b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/man-db-2.10.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-common-37-0.12.noarch.rpm"
+          },
+          "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-common-1.14.0-5.fc37.noarch.rpm"
+          },
+          "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nftables-1.0.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnftnl-1.2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:2b18c30e4e0d805ee80b71ac118d948437d0a81860355b3fd004226ee3f9db59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/oniguruma-6.9.8-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:2b2887375b6fb33413a5973435c3f648d1f7995907fa770e59fb064fa1f7cb3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libjcat-0.1.10-2.fc37.aarch64.rpm"
+          },
+          "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:2c1347d36ff1258ef9bc3d015506677837976932928df4b8174e84667a161660": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:2c9c7520371594e7072d9cee9fe6df88e1de32c9f39eea0e6b13a447fc04ca86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:2ca54a2136e9234c3296e67c2cf8a058407f7741d9a19a09dd57924094277226": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dhcp-client-4.4.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm"
+          },
+          "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:2ec90e98535f2ba20e2ebc46824e08834a7f6d0239d425c1868ddc7fc57cf677": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iputils-20211215-3.fc37.aarch64.rpm"
+          },
+          "sha256:2ed8b614d428d1a559b8af5c615692f3e2aa26327518bf14a6c3a29dc6c47128": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-part-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:2f764f955353579bb120b720ad6db26740003a862093066ed22b400cfd249b6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-tools-2.06-52.fc37.aarch64.rpm"
+          },
+          "sha256:30d427c19f748c5742d5777e3f372c38bc611622f8797f37932d553405a50885": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kernel-core-5.19.3-300.fc37.aarch64.rpm"
+          },
+          "sha256:32bcbdcbabaf2bbe5e4e89a7eb2a9827c576f58fbc50cdc7f558e737d75bcb51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/NetworkManager-1.39.90-1.fc37.aarch64.rpm"
+          },
+          "sha256:344f2ca875b102496347055bb8e0231fec25a0245a538267e072e666581c2ba8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-runtime-0.21-18.fc37.0.20220203.aarch64.rpm"
+          },
+          "sha256:34565f7a706cf4111bb3c1c11f1b2f229a0d202ecf2daad8f98eb60cbc5214a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-libs-0.187-6.fc37.aarch64.rpm"
+          },
+          "sha256:34e078e9be9cbe997458a72e35718feaff49a1cbaf8a8582b30fd0c744b03105": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/inih-56-2.fc37.aarch64.rpm"
+          },
+          "sha256:36f273cf6011455969cf6ef2d8d6f64c95eaf7edd7c3789535f5b6a1f6a1bee3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssh-8.8p1-6.fc37.aarch64.rpm"
+          },
+          "sha256:3729513f5da9fd89e033e25be88b344a026c73bb5bb37def449ed94b65e61df6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libstdc++-12.2.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:376d49e2efda411c94ae6c6b24acf6e478f9f5c4220c590034be46528d7b8577": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:378607a741f61282ed8243ca0f2164fa521ff02983e0eb1289d4350b7c781602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-libdnf-0.68.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm"
+          },
+          "sha256:3845db664d89151f8a07f465f734705eaeb76c242c58866f91045db46f63b650": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:388def347af7b9811dc79872bbb55f1ae433bde1cc4b28e8b3ccc03eeab80a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:38b9035b2449e7d152bf03e6e3b46243550ee29c2fae8730bfa11646fb04f6cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/librepo-1.14.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:393cc43a853a2f5f391d133acb032b0a50d5070aca8bd3ec132d949b6af157bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:3b43f129f65128a6477ed7d55f7c8a0a1359bd6eec8bc162480ef21d2366e6de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:3b71e545778baa7142f668a246bae82733188c259bd685e5a1af64bdc8604a12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gdisk-1.0.9-3.fc37.aarch64.rpm"
+          },
+          "sha256:3baa59082b57d8303f92d493ee2a4d85592b31a89b6598b3c8b1e01efbe2f15f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iproute-5.18.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm"
+          },
+          "sha256:3c8b0b0867c9cc919821ab4ec571fb01f4abeadd76e35c6de4e8382ff2b7bf74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bash-5.1.16-3.fc37.aarch64.rpm"
+          },
+          "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/file-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3d6782f1e07f1681965fcb7f3a2e1696c458bbc336a67fe3f03e95b0056a9591": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kernel-5.19.3-300.fc37.aarch64.rpm"
+          },
+          "sha256:3dcf1b43b18affb19e794f20338c8bc7c6d05bd7a14217037a0a71147e8582fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:3ed6ead984746688cb4b95a4f4bc4ede898fe768b9129bc91df82ec9721ab37e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/plymouth-22.02.122-2.fc37.aarch64.rpm"
+          },
+          "sha256:3ee4cff1eb28623c2f3bca14d2d971c8d40f1c705adcccb345a005a0a6f547f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:4092137b8adddb11ff22705fb37255f70a6cf1c26dd44a33410a1d0c3ab7c8a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:445cda1792047a2c4bd2172c4a2ef0c175096a848a856cb053bc42d6fb2c595b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/h/hostname-3.23-7.fc37.aarch64.rpm"
+          },
+          "sha256:44a972be5ba2b774ecbe02a5773ab63e64dae3961de4fc0b36667d42f1c0a4cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:466a7c0dfbb55b564f120dd39daeff9206b76ea8b1b93f4897c9153af9572236": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssh-server-8.8p1-6.fc37.aarch64.rpm"
+          },
+          "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:46ffbcbb2b1f414985b2824965e759104fd9c108cb8140cab2a2e4ee421daf6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:471181983c6130950fe07ba9dcd7825559555bd1c055d67adfc3f7a21729d4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-libelf-0.187-6.fc37.aarch64.rpm"
+          },
+          "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:47d3b0f3b51974f6be0b900ee6472aa20fb214c494a3d3994cc9fbc854ce0f33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-libs-0.21-18.fc37.0.20220203.aarch64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:486f49b44bed738796297ec1cbc073ef4d571396e3f408e1cff77d938d1a2982": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sssd-common-2.7.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:4b2120af0fbbde74d84061d1a22091a5f48dbbba68d5884399117dee7c30fe5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-crypto-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:4b6cbd8f1bcd9e058f975f5b2b2e19a075dd6c28e2e8a67feaa337737b542fbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-repos-37-0.6.noarch.rpm"
+          },
+          "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:4fc2b6910a5c954f8ef9c89e6ccb09df3a66ce5a323075775f65366ef649db95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm"
+          },
+          "sha256:548d5fc80ac537d663ce1130f95c0b24d6ddbd0da9ce5c6490306bb78ea5f1d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-mdraid-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:55ff17ec31466bd748005cf65cd687af61b0aeb3ad343e8d0c2d9a24f8a1286c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:56b548b06112a037121a913157b0e4c08dce4bb0511843f652e99960e657d13b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm"
+          },
+          "sha256:58b9a2c3db5e64b6c33eb7f5b2f2f63cf127626548540bb6333e0c1fbc415ab9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-hawkey-0.68.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pigz-2.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:5a980a3db08191299cb1ae9640a924fce3631d34a7a931ba34b0a44daf2b53c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:5b5506311d4d8aa6dba565bb89e43d96f9ac149fa3240252f1434edecade28be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/unbound-libs-1.16.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-unversioned-command-3.11.0~rc1-2.fc37.noarch.rpm"
+          },
+          "sha256:5c9b9096e70c3bee0796496b9acbe5d48ef73425727a2c332f9cf2834957e086": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libksba-1.6.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:5d78e738293b97817feea679546a1611ee76389bfd2c7b6f496d3cc90cf611ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/shadow-utils-4.11.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:5e0fe8775d7980fc6f21f87522128a14a4160026a09599895171afa717e39e68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-1.14.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:5e51a6aa0c2acf0913d7aa70eca38a11492de9ce863bd2f4955ae09c3ceda37a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dbus-1.2.18-5.fc37.aarch64.rpm"
+          },
+          "sha256:5e5d3c2263a0958574d26b7afe5c5341d7bf80c0986f5e6116e4dd4e312a03f1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libdnf-0.68.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:5eff8b70f05717621b31b0c0c8fbdfa6bfbec81d38c7b98cc214a33dba9bde67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:6115b0fb5152d6cf5d44ece67289551cf01aad2dab103b09a298d01409a371e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dracut-057-2.fc37.aarch64.rpm"
+          },
+          "sha256:6131cc6f89273c0054332758df9314e5146bd9a311b8ed93452dd51426dc3a92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-loop-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm"
+          },
+          "sha256:62dfa5a36a42f97393cf948694764acd5bf102eb91e0e85b1b2d565fa0450823": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm"
+          },
+          "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/npth-1.6-9.fc37.aarch64.rpm"
+          },
+          "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:65c0279da62825de54dfd036126233ee051808122875d4aa3dab7eff27f3f9d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/protobuf-c-1.4.0-6.fc37.aarch64.rpm"
+          },
+          "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sed-4.8-11.fc37.aarch64.rpm"
+          },
+          "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:69ff7199c3b6dd205c09022bbc598851e21a9dd192ab5b63a7f25fbe706933bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nvidia-gpu-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:6bcdcac414f4e313ae3527d3993f17bf38d296fdc556c10e738177fb5621a245": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgudev-237-3.fc37.aarch64.rpm"
+          },
+          "sha256:6c1a57b94b81b6f8a34d8b8afa81bc64c7b74900e24ab8bdc67c967702e5d21b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nspr-4.34.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:6c7be4066ad8a69c7b4ef73706b1c0591361b522f22a1ad969f2e128992ecdd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm"
+          },
+          "sha256:7068166d5807467f0da88303b489f6975b439a2530185094c631732d2a6da484": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:70702e8555203b90abd08f8c407a872640ed19a9e9d53869950cf56c594540e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:7175bfcfbeeaee19bafc01c4709c825cb553db170934da4bfa7fee61ea5108fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sssd-kcm-2.7.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:7221f9c4b4c980552dffc75a08e413d794d2c52812b3778b6b0127f801c80eff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm"
+          },
+          "sha256:722a9893ae7d36b0b6209c4cf5964903e1d74906af33953aae56ae120dbb9102": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-networkd-251.4-53.fc37.aarch64.rpm"
+          },
+          "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:73dc19a07f58022d78e6a8aaedf2c4631e90fb62f2050776d5ac0e8fc6b300e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-251.4-53.fc37.aarch64.rpm"
+          },
+          "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:76d048c6c3b1aa099ec34a7c2fdaee1487aafe738cf64e912b1b84bcd9440ff9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:7844c090147f6e04cb219d39eb76341b08ec0bbea3b51c51aac925301fb7c677": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:788976a6dfe6796fa08ba5f52c17af923044473b481a75be9bb695e8fa7d5a16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xfsprogs-5.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:7a10c1c094e8a82caf5ec0a6dbd98ac8dd9bd1169fe03fd53d98211c02086a89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-swap-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7e169c14f3c544cd0355633040eaee3ebeddde31bf022ab2d4441db084c5779b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/y/yum-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:7e86ae6cbc732e3ea8ca4a3098f879ac64a12bac786b760b5273db25d554518e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-libs-1.14.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:7e9aaf2225e46e8ff4e63a387f2e4479fd40e0455135560388c220c148800ac0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/plymouth-core-libs-22.02.122-2.fc37.aarch64.rpm"
+          },
+          "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm"
+          },
+          "sha256:7f5f3953da57fbc1aab1d723cedfeca5c3536c66d479335af6173ca50c54bd5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:8053eaf425c8bf14a476049eab59e586dd2d6fef458bf8eeb27ad661fdaf3d0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/intel-gpu-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/selinux-policy-37.8-1.fc37.noarch.rpm"
+          },
+          "sha256:80e547e469c9e6df062633830a2ae9f54355236f91bdf0d83ff3222d60dcf836": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:80e767ec60eb6cbbe095ef2917e2a8d022d98a5f334df0c1c3a14e27bdf03f4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:85154a1e7fdaf984f266807efe73bf220e6203a3d91df40c0dcc3f4c9d2b1fbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/audit-libs-3.0.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-common-2.06-52.fc37.noarch.rpm"
+          },
+          "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm"
+          },
+          "sha256:898d0d0b74e205c2d9f9549cf82abcc9d1d5665f83255dfb416fece029897724": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-common-2.36-1.fc37.aarch64.rpm"
+          },
+          "sha256:89a9f1f450a4fa695100278afb7bf12fc00c3e423085a45b1a282ded7a685c33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/plymouth-scripts-22.02.122-2.fc37.aarch64.rpm"
+          },
+          "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm"
+          },
+          "sha256:8b56b7ca059afbe4a7ba86d30b7b324e639df618276cf45b46d3e315cf0718fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm"
+          },
+          "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grep-3.7-4.fc37.aarch64.rpm"
+          },
+          "sha256:8c8c5a7d8a7bde6cd7413c745ea8f81f728169d2e4e96327a86f41019b8390de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm"
+          },
+          "sha256:8ddb89f6a3955b0dc46c015025e5a2956d0c06bc93fbc0a3b3f087fbc6b0873a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/popt-1.19~rc1-3.fc37.aarch64.rpm"
+          },
+          "sha256:8e85f2257c7cb41df273ffdea56daef73e44bb7bfe79befa296f700e60c49548": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/readline-8.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:8f50c3931775e5513506e04c0d65ba2bc7b19252f87eabb23b3911031a2309fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sssd-client-2.7.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:91448bcac8efd67b285cf12ef86cd97c44aba4194270624647ab6362377bb7df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/unbound-anchor-1.16.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:916f8e6515fb7fc4ddf0db6ae1bad1bb167d4629c4d198e2618dc5cafa172d8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-unbound-1.16.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:918357b6b1672becafec46a556a36e2b142d6926a036aa1a8deda3418f6e39b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmaxminddb-1.6.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:925f753a571120c816ce36c82646cdc0f69be84d762ae61184eb6ef5680ccf4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ipset-7.15-4.fc37.aarch64.rpm"
+          },
+          "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm"
+          },
+          "sha256:941ce3e47a525ae3e39f79a7df7d8e11a313a30a45b5b773233fc5f0ce6fba84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:948738abb47f1d630bee2fae87cdb00f65d2f5e25c31367a6394d3fddb082c35": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:9549982392bd6cd0c8fbcaab7a672bc94aac048f3f20a5c98fea083866748c47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:95d136f0a45ecec0f319ac888010a2961d32d31a4cbc7c63aa5f5d128b9619e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libndp-1.8-4.fc37.aarch64.rpm"
+          },
+          "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:9876f27ed35bfddf6e953a6f06f0695556df67315bf3286ed74150d6a82b28da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:98f0fd19966edad2dcdea46d1a8f2dc77bd44494c3b3ab896c51af70d854bb62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm"
+          },
+          "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:9ba24cdbe2f39f0ee83b266399177343ee110035f635de2ee81426227b399998": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm"
+          },
+          "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/polkit-121-4.fc37.aarch64.rpm"
+          },
+          "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:a1301eed066ead5d0206b90f66167d010ca993da90baa2ecdd19e7e3075d9b86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mozjs102-102.2.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:a1439943133d9753b57246bf80b6b168266652831acc19f6b8d658ec65bc9614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libssh-0.9.6-5.fc37.aarch64.rpm"
+          },
+          "sha256:a156bf749c21addedb7b8423c78b5ff58d7ae1c8d80d47f86df3bdb0ac415f9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-0.21-18.fc37.0.20220203.aarch64.rpm"
+          },
+          "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a27d291b03476f2e041cee4b0c91eebedf31a4d13cc2ed1030eaca5f77f93ddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/linux-firmware-whence-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:a2e7563405fc95534d5f6843349efcaa20574f015dead29921d04bc05362b35b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssh-clients-8.8p1-6.fc37.aarch64.rpm"
+          },
+          "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm"
+          },
+          "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm"
+          },
+          "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:a4b264435d539525594bd8b9c60c4627aaba7e4c9606761b20153e0f17b710c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-envsubst-0.21-18.fc37.0.20220203.aarch64.rpm"
+          },
+          "sha256:a56d19f03448414d12e06d99f1ee3d7f802a7d4ab94348d7079be746c4d1cf0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:a734e52f908f002006087a9e1cdaea29ec7f804a7f07df0a9c4de3d3af488307": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_idmap-2.7.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:a73b3d5a5f472d8347a2f858a0061e3f338323dd962d5293b2d0982db9f20bee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/v/vim-data-9.0.213-1.fc37.noarch.rpm"
+          },
+          "sha256:a755df3c6cba46dd73d8264ba5204f49700f8dc697aefa7c73eafeea8ba90641": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-softokn-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:a79a510349b5fc98da763d60275700e6dbfd5823d47514bd6b20e815ab593940": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-sysinit-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:a89bdeff8ea373ce88d147a5f017e7f342c1c79fdf615a88f2396e980638feda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nano-6.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kmod-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/t/tzdata-2022c-1.fc37.noarch.rpm"
+          },
+          "sha256:abb2141e8e12fab7bf473c869b02d6857a6a2aee1f7fb30ed299add89f5a2a29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-fs-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:ad791a6e174f599232936759461d89df1f01e4e3b885488d27fabbce1b7e5e2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm"
+          },
+          "sha256:adf4bb4c6f00d4d335a8cf6c6cbb3919aa3381752edde9a16bd810600e38f8aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:b17ee7153e3916bef8bf01d9c02aa789150711fcf752930475d4a5ed8cd23e74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-gconv-extra-2.36-1.fc37.aarch64.rpm"
+          },
+          "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm"
+          },
+          "sha256:b25b2a6aa9d67b105201ef7f90154da99e683b8a3a64f6f1ec17d1300dcd2e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:b2e0afdc7de2f8a16ce78b1d88ad600f4cd87b77483c06be924eb508ed30f597": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ipset-libs-7.15-4.fc37.aarch64.rpm"
+          },
+          "sha256:b328a0463b313c7ac25139caf855dd78194d0ad572cc95eaad8038494d7884db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/curl-7.84.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:b6b0aa91236f4fe07ebd5fd5154cbcb8c7ecca90ba9af7808c8820454c173f75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/polkit-libs-121-4.fc37.aarch64.rpm"
+          },
+          "sha256:b875744ecefb91efbe7d05df252768f666bf220d23f865d7df9b15e58dc86631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm"
+          },
+          "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm"
+          },
+          "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm"
+          },
+          "sha256:bc8ef19d0f2ce557fce1a49c78cda84865b2fa2e26713bbc3c7c73d507212de8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-utils-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:bdff19c6bac526516f8352e29c6ec41e88e4fa9ebb1e31f620e612e8ff7fd6ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gobject-introspection-1.73.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:beb88184545c5c8d60bed49bdad82674a58868db381d55d9a517f35ac9cb24d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-libs-251.4-53.fc37.aarch64.rpm"
+          },
+          "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-2.48-5.fc37.aarch64.rpm"
+          },
+          "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gzip-1.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm"
+          },
+          "sha256:c3063bbcd07caea5dcdb242471047b2a77264ed33bf004ddf7405cab70c6bfe1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/less-590-5.fc37.aarch64.rpm"
+          },
+          "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:c4e372e626eca2c917309767102294dd75e83ae3d4583e90ee5ac4d1b5032e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:c635414b909a2b7ea49bd815c0261f4d30d13d871346906501d7316af3ba1772": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:c6fa6669abe6413582fb6edb939ff8e897a71c9e054a6839516cf9a6b11eb6c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm"
+          },
+          "sha256:c70e5ab3e25d6f78c9bc66d0f6b3a7f33457a63c2a17cd15efeb5ca6a0023c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:c8408b9f0879ebd2ae84e7ef794abb23eb0901bb7a007d699cf7f234c953c8e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-efi-aa64-2.06-52.fc37.aarch64.rpm"
+          },
+          "sha256:c91f35b8379c7238168e973a862811f053802541d4408b25fc646cc664b70e7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgusb-0.3.10-3.fc37.aarch64.rpm"
+          },
+          "sha256:c99e1b512c78b34c5a4b48dba416d4128de106d4513b5593a8c1578ed418b568": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-udev-251.4-53.fc37.aarch64.rpm"
+          },
+          "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:cc9ddf08ea0c691edaa5f2072667d11715a6349f5745f3d2b6e6713bda1858f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm"
+          },
+          "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:d1bad6b76f428e9594e9d17c5e843682d9b6b07d687194f263b5f3cc93aac61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glib2-2.73.2-8.fc37.aarch64.rpm"
+          },
+          "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-37-0.12.noarch.rpm"
+          },
+          "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:d5059e977d0f0fb2f8e00201efc16c9e75198d23a5aaaef146e042d845a69e97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm"
+          },
+          "sha256:d582315683769a0456d5ec9f85939f75f8df5055f3ac4110f28cdbea9ca9cf69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:d62eec866919cfc099ea008e165effa38edd53c0489deb121d39839cc30a3e92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/linux-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:d6ee284dcef741c4de7ef51f540ce8144cfc5f2937dd7da0c1c857d96cb5ecb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:d7287117da748fba67e225144984f0dcc1191f58d5719b9b48f515580be6b7f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmnl-1.0.4-16.fc37.aarch64.rpm"
+          },
+          "sha256:d77e701a27657e67bc9313a8301ca8408b981394fb930e9f9b7429efb147c7f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/audit-3.0.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:d9312c3b6a93ec5ef197e11cd9bfe1ce9739b197b9756ab3dc43db2861ef41e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcurl-7.84.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-gpg-keys-37-0.6.noarch.rpm"
+          },
+          "sha256:e1acc1bcd35e05606e201dc4ac1d4dcad96bacadea944dcf95d7aa61cc7289fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-pam-251.4-53.fc37.aarch64.rpm"
+          },
+          "sha256:e1c78ac4292331b14107532eb08051c929248230df6b955af12d2eb4bccc0f5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:e8aa41c3f317ac66bcb1f3b942ca73b054dd7b12574e8eed2af0b86fbd6fbf7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libicu-71.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm"
+          },
+          "sha256:e919037d0b4f9f434f845500c66155c753f86bc47dfcb9935d937304e7948b8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pinentry-1.2.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm"
+          },
+          "sha256:eaca4b21ecfe4860a8d3633ae57ca8bcbff0af8168db4b424e4293948b0dbf2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcsc-lite-1.9.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:eb8cb255fb3af97bb2de4462e20d237123e5c0eeb92785cf00e58570c62a62b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.aarch64.rpm"
+          },
+          "sha256:ec395c3a160470a6da63ac1298a540a93a2adee4d29c4f78c24330dbbfba12b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:ec59f690cd61c14d11ed7e44908bd5ba689c23b2cad8539984e2fa94b8ef0443": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kernel-modules-5.19.3-300.fc37.aarch64.rpm"
+          },
+          "sha256:ed050e88e1fb2f8d2cdfb83075e79eb868decf66ec51ee4bca29d35e849f5247": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:ed598abaec8c192c87f9906423468cb438aff653f7e35a036053f4ea09b884a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-tools-minimal-2.06-52.fc37.aarch64.rpm"
+          },
+          "sha256:eed9d47041b04ea6c49408f4d71cc0190b699c51c1a89de4c6fdd676cd1777a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:ef495449eaf292fe2bf17066a5bc006c357804d207f7bcdc16e65d40ec827206": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:efce366e113512afcb49ee1d64d553923b144c90df68d31c63b1eb61bd4d4f9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnghttp2-1.48.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:eff91da3adf84b15e85b72b907d7b233adbea9d78ecf0db75d9c3a6c9c0e43da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:f0944d0fd2d273c99f6ab808111d4db455fc9ba8489714aabdeda5729977c004": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm"
+          },
+          "sha256:f0fec5b7c7c8482cb9642dad77eeedadefe7dda70ed7b53d44fb5a6bd1ea2749": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:f1af086033468497e7a39f875a661c6db3b946e97b455cfac15319f7f75790bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_sudo-2.7.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:f23bbbb8abeccfae1758e2eef3a676c956f2df47ab4ab559eaff52afa1f809b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/parted-3.5-6.fc37.aarch64.rpm"
+          },
+          "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm"
+          },
+          "sha256:f39abba16ac8153a5e4fe5f44b875d0be983cb62b6ad7115cdf8ccd7fa325efc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_certmap-2.7.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:f46592a35c4569e5d32364baa37081e1454761043a873e3ee20067ce5409a85a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm"
+          },
+          "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grubby-8.40-66.fc37.aarch64.rpm"
+          },
+          "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/json-c-0.16-2.fc37.aarch64.rpm"
+          },
+          "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm"
+          },
+          "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:f5a9f472a5a88798376d935090fe11e65413016a878a88da8cf839199fba1b29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-libs-3.11.0~rc1-2.fc37.aarch64.rpm"
+          },
+          "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:f70b262c317b0a012fbe1fc1239f7972da097c45e15075c8165b26069a7f7267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm"
+          },
+          "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm"
+          },
+          "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/selinux-policy-targeted-37.8-1.fc37.noarch.rpm"
+          },
+          "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:fa303761d66b8f1e839004dab9bc0b6bc53cce6e0eba0e6000ea50d924658439": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssl-pkcs11-0.4.12-1.fc37.aarch64.rpm"
+          },
+          "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:fec9c3bbc378c458dea2ec3e8da500d6f3278d723cc94d8a27a1d0259ea3c89e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/amd-gpu-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm",
+        "checksum": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/audit-libs-3.0.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:85154a1e7fdaf984f266807efe73bf220e6203a3d91df40c0dcc3f4c9d2b1fbc",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bash-5.1.16-3.fc37.aarch64.rpm",
+        "checksum": "sha256:3c8b0b0867c9cc919821ab4ec571fb01f4abeadd76e35c6de4e8382ff2b7bf74",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:ad791a6e174f599232936759461d89df1f01e4e3b885488d27fabbce1b7e5e2d",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/curl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b328a0463b313c7ac25139caf855dd78194d0ad572cc95eaad8038494d7884db",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm",
+        "checksum": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-1.14.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5e0fe8775d7980fc6f21f87522128a14a4160026a09599895171afa717e39e68",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-common-1.14.0-5.fc37.noarch.rpm",
+        "checksum": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dracut-057-2.fc37.aarch64.rpm",
+        "checksum": "sha256:6115b0fb5152d6cf5d44ece67289551cf01aad2dab103b09a298d01409a371e2",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:eb8cb255fb3af97bb2de4462e20d237123e5c0eeb92785cf00e58570c62a62b0",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-libelf-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:471181983c6130950fe07ba9dcd7825559555bd1c055d67adfc3f7a21729d4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-libs-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:34565f7a706cf4111bb3c1c11f1b2f229a0d202ecf2daad8f98eb60cbc5214a9",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-gpg-keys-37-0.6.noarch.rpm",
+        "checksum": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-37-0.12.noarch.rpm",
+        "checksum": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-common-37-0.12.noarch.rpm",
+        "checksum": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-identity-basic-37-0.12.noarch.rpm",
+        "checksum": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-repos-37-0.6.noarch.rpm",
+        "checksum": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:a156bf749c21addedb7b8423c78b5ff58d7ae1c8d80d47f86df3bdb0ac415f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-envsubst-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:a4b264435d539525594bd8b9c60c4627aaba7e4c9606761b20153e0f17b710c6",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-libs-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:47d3b0f3b51974f6be0b900ee6472aa20fb214c494a3d3994cc9fbc854ce0f33",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-runtime-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:344f2ca875b102496347055bb8e0231fec25a0245a538267e072e666581c2ba8",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0c59b2d38f31785022b5b4badb0d7b4efd255e8bdd31a4fd3636eee62dcb7a28",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-common-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:898d0d0b74e205c2d9f9549cf82abcc9d1d5665f83255dfb416fece029897724",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-gconv-extra-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b17ee7153e3916bef8bf01d9c02aa789150711fcf752930475d4a5ed8cd23e74",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-minimal-langpack-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1ddf01b8fc9bbc0dcfcc8075c5e6b0efb7a2e83d2086cd0ea43794ac4f2095e8",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-common-2.06-52.fc37.noarch.rpm",
+        "checksum": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-tools-2.06-52.fc37.aarch64.rpm",
+        "checksum": "sha256:2f764f955353579bb120b720ad6db26740003a862093066ed22b400cfd249b6b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-tools-minimal-2.06-52.fc37.aarch64.rpm",
+        "checksum": "sha256:ed598abaec8c192c87f9906423468cb438aff653f7e35a036053f4ea09b884a6",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grubby-8.40-66.fc37.aarch64.rpm",
+        "checksum": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kbd-2.5.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0e75d60792d3b6afdb7f557590363cbaea8f030cf72b49eb5f192b2f743a8b38",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcurl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d9312c3b6a93ec5ef197e11cd9bfe1ce9739b197b9756ab3dc43db2861ef41e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgcc-12.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0ef69b3a01eef549a6757fe2aa7d2d234f7da70a4d001d4344938e3e84276422",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgomp-12.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:038cf4a81c5d368b86fe22d7424c0cc7005f40fb2d04f49e6f7fed10c59b9e40",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnghttp2-1.48.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:efce366e113512afcb49ee1d64d553923b144c90df68d31c63b1eb61bd4d4f9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libssh-0.9.6-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a1439943133d9753b57246bf80b6b168266652831acc19f6b8d658ec65bc9614",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libstdc++-12.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3729513f5da9fd89e033e25be88b344a026c73bb5bb37def449ed94b65e61df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssl-pkcs11-0.4.12-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fa303761d66b8f1e839004dab9bc0b6bc53cce6e0eba0e6000ea50d924658439",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/popt-1.19~rc1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:8ddb89f6a3955b0dc46c015025e5a2956d0c06bc93fbc0a3b3f087fbc6b0873a",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-unversioned-command-3.11.0~rc1-2.fc37.noarch.rpm",
+        "checksum": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-3.11.0~rc1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:031dc58d9e841652a0c8f98750408d6b5e81dffb0baa20eabf26add7c41363d5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-libs-3.11.0~rc1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f5a9f472a5a88798376d935090fe11e65413016a878a88da8cf839199fba1b29",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/readline-8.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:76d048c6c3b1aa099ec34a7c2fdaee1487aafe738cf64e912b1b84bcd9440ff9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:80e547e469c9e6df062633830a2ae9f54355236f91bdf0d83ff3222d60dcf836",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:9ba24cdbe2f39f0ee83b266399177343ee110035f635de2ee81426227b399998",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/selinux-policy-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/selinux-policy-targeted-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/shadow-utils-4.11.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5d78e738293b97817feea679546a1611ee76389bfd2c7b6f496d3cc90cf611ea",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:73dc19a07f58022d78e6a8aaedf2c4631e90fb62f2050776d5ac0e8fc6b300e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-libs-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:beb88184545c5c8d60bed49bdad82674a58868db381d55d9a517f35ac9cb24d8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-networkd-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:722a9893ae7d36b0b6209c4cf5964903e1d74906af33953aae56ae120dbb9102",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-pam-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:e1acc1bcd35e05606e201dc4ac1d4dcad96bacadea944dcf95d7aa61cc7289fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-resolved-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:247d834075c26fee903b27e499758cbce85837457cd9aee1ebc9b3b3a31aeb59",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-udev-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:c99e1b512c78b34c5a4b48dba416d4128de106d4513b5593a8c1578ed418b568",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022c",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/t/tzdata-2022c-1.fc37.noarch.rpm",
+        "checksum": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zlib-1.2.12-4.fc37.aarch64.rpm",
+        "checksum": "sha256:21024e762c7baf67cfb21ef765c56fb50a3a86d238567ddcb23fc60cdc2bcd97",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b25b2a6aa9d67b105201ef7f90154da99e683b8a3a64f6f1ec17d1300dcd2e22",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.39.90",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/NetworkManager-1.39.90-1.fc37.aarch64.rpm",
+        "checksum": "sha256:32bcbdcbabaf2bbe5e4e89a7eb2a9827c576f58fbc50cdc7f558e737d75bcb51",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.39.90",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/NetworkManager-libnm-1.39.90-1.fc37.aarch64.rpm",
+        "checksum": "sha256:006ad5476696d1e76dc6fc73bde307c6964ac503ac39b3a6675db63a949aa04f",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm",
+        "checksum": "sha256:539903a5db9dac34cd633a95db47af0c932118567e759108ec8b05f91992857f",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/amd-gpu-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:fec9c3bbc378c458dea2ec3e8da500d6f3278d723cc94d8a27a1d0259ea3c89e",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/audit-3.0.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d77e701a27657e67bc9313a8301ca8408b981394fb930e9f9b7429efb147c7f6",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/audit-libs-3.0.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:85154a1e7fdaf984f266807efe73bf220e6203a3d91df40c0dcc3f4c9d2b1fbc",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:178c233d007c00f14ec0c0a5083907f3cf2889b998c8e7eefe25c8b04ebe1aef",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5e2ac5ec02616313b2c7a6d6ba73d860c4cc2380c2a7aa6336b3ed89c67c1392",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bash-5.1.16-3.fc37.aarch64.rpm",
+        "checksum": "sha256:3c8b0b0867c9cc919821ab4ec571fb01f4abeadd76e35c6de4e8382ff2b7bf74",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bluez-5.65-1.fc37.aarch64.rpm",
+        "checksum": "sha256:051378dae7a4f2a5628872a7f4e019258103d23edc6300d355ffe921508f2b08",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d86fcd8817424d684eaae4eb343eec10e7f793b8aa7284d95d4ec71d517084fd",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:01028db4dd1f22a1743fc692e78b6f4671995fcce623c2d1fa2d357a87badad6",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2c1347d36ff1258ef9bc3d015506677837976932928df4b8174e84667a161660",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:1050a9675979c8ea71d673034094281225dfb6252814a6a4b959cc89a3fa467a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:6d57265c3bb44d183f7f619d7bf92f375bcbbc30e242d6df66e2533e5e9f84f0",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0b7ee5d1382aab5880b54dd6aec42deb5dcbaf2777395734eed1a2e552ca6057",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:ad791a6e174f599232936759461d89df1f01e4e3b885488d27fabbce1b7e5e2d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:376d49e2efda411c94ae6c6b24acf6e478f9f5c4220c590034be46528d7b8577",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5ad7f1bfee28c80f9d4282aa9f0e5d8fada533111fc03fd9c33e988766c6c380",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/curl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b328a0463b313c7ac25139caf855dd78194d0ad572cc95eaad8038494d7884db",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.aarch64.rpm",
+        "checksum": "sha256:7f23b5d4ec58e377a7a960c57fd0219167ec68665bd2cb7dc461f8cf58fb9af7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-1.14.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5e0fe8775d7980fc6f21f87522128a14a4160026a09599895171afa717e39e68",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:04d878eeb31722ad495b34edd6bacafeffd5d13d39dfea5edff49daee5f28c58",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-common-1.14.0-5.fc37.noarch.rpm",
+        "checksum": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dbus-libs-1.14.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:7e86ae6cbc732e3ea8ca4a3098f879ac64a12bac786b760b5273db25d554518e",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7221f9c4b4c980552dffc75a08e413d794d2c52812b3778b6b0127f801c80eff",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:a43b58aa929c4b4da2a8fea3b378b89a822fc7122114e380ca74ba80a413231b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:9e8b44fa83d4f4faeff5f854f64f04284bc40f8b775de0548aa1b2f211b40ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dhcp-client-4.4.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2ca54a2136e9234c3296e67c2cf8a058407f7741d9a19a09dd57924094277226",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm",
+        "checksum": "sha256:f46592a35c4569e5d32364baa37081e1454761043a873e3ee20067ce5409a85a",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2b34436e8003d7d1ab95f9a16db3ee455f571c56bf06a4833771046810dd5368",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:1225d8d1f0752e8e529ef7257f235b9189c1f85fa361883a9d40f768da0eb2c6",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:3845db664d89151f8a07f465f734705eaeb76c242c58866f91045db46f63b650",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:c70e5ab3e25d6f78c9bc66d0f6b3a7f33457a63c2a17cd15efeb5ca6a0023c62",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:1ef037a08f8b410305c305d9b77497d7fc557b66dd08927d31ba4beffc3faa1a",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:caf01590a095a0ded437ff9a6100de6b2a9d5c638c0d8df218685e9ca049a257",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dracut-057-2.fc37.aarch64.rpm",
+        "checksum": "sha256:6115b0fb5152d6cf5d44ece67289551cf01aad2dab103b09a298d01409a371e2",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dracut-config-generic-057-2.fc37.aarch64.rpm",
+        "checksum": "sha256:04b86049e757ed9a6495bd67cb837c2e5236d3fadce93205211d74edbd71bfe1",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/d/dracut-config-rescue-057-2.fc37.aarch64.rpm",
+        "checksum": "sha256:157ce90eb5ee5b4d7cd33f18a59108ecbc941f7910c65d0406aec56ffb3d8754",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27650426ffdfc647cace3b369fdfe8dd654e4a2003f852081e559100c4beadd6",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff7ef9ea4d3e07244c4d93170b39987ef351b4140d9e0429ac9d924df7c0d87c",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:65b90711945117ae85bd363a3426f6a850c31200ffb77f15ddfc1181c961f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3bdc032c960668daf5ba86e7d695924879a21e939aee174858b5cbe2f4f0d3f9",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm",
+        "checksum": "sha256:130fca628d199df219a2c49dac899bd881abe73839e839e78d0e6754fe3336bf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:eb8cb255fb3af97bb2de4462e20d237123e5c0eeb92785cf00e58570c62a62b0",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-libelf-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:471181983c6130950fe07ba9dcd7825559555bd1c055d67adfc3f7a21729d4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/elfutils-libs-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:34565f7a706cf4111bb3c1c11f1b2f229a0d202ecf2daad8f98eb60cbc5214a9",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:76df070766b1d7460c3edf04cb404046a9b999e68dde6598c090140995a49dde",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-gpg-keys-37-0.6.noarch.rpm",
+        "checksum": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-37-0.12.noarch.rpm",
+        "checksum": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-common-37-0.12.noarch.rpm",
+        "checksum": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-release-identity-basic-37-0.12.noarch.rpm",
+        "checksum": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-repos-37-0.6.noarch.rpm",
+        "checksum": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fedora-repos-modular-37-0.6.noarch.rpm",
+        "checksum": "sha256:11ef902abb560166f418e4f4bba230c7c5a3d0bf2f917fb771229fe923a767ae",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d50fe5b4ddb1855fd70978c0aa785737fb305a26a6a38cffa7a64cb2e84c3c6",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:de2b99792ba078ae19056abe7ba5f2734cd681ff381ceb033ae6af65f96801c6",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f376033e06a30de4687fd388f9c734347c9929c20f56b7c8390c7d40eea6b923",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d0dbd08108358b53f15858ce43eb21a7c24d659ec8e54527c40587e5b3c651b4",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:f70b262c317b0a012fbe1fc1239f7972da097c45e15075c8165b26069a7f7267",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:393cc43a853a2f5f391d133acb032b0a50d5070aca8bd3ec132d949b6af157bb",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:1b269e1f4fbfcd3fcfc78f42b8045f5f32e98808b7e841940aa066a74fc49e2b",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:49b9693743b00b46f40e1671eabe2f8a1d8ca423817939ceebad2eb3a3dfc6a5",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3dcf1b43b18affb19e794f20338c8bc7c6d05bd7a14217037a0a71147e8582fe",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7f5f3953da57fbc1aab1d723cedfeca5c3536c66d479335af6173ca50c54bd5f",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0d0abe5e642c9fe5f39f40489559188d759faedd7c606042b797bb2c74bece4a",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:01328b5fa54399477e0c377e6b2968b6beac0dc2bdfcd05941983194d2a561a4",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9876f27ed35bfddf6e953a6f06f0695556df67315bf3286ed74150d6a82b28da",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ffe1739ed85c4c17cbfdd38a2fe460ded8cfad87df19cc4610a225bdfd2e151c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cd3e93119ad2a5c608e7ce46329f98add5140a8f18d00e42a0df33ace03922c1",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:9bb7b207aa60ce91c87e22a5a3987c699cd9ac582f9af3880dbe1caef63ab1af",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gdisk-1.0.9-3.fc37.aarch64.rpm",
+        "checksum": "sha256:3b71e545778baa7142f668a246bae82733188c259bd685e5a1af64bdc8604a12",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:a156bf749c21addedb7b8423c78b5ff58d7ae1c8d80d47f86df3bdb0ac415f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-envsubst-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:a4b264435d539525594bd8b9c60c4627aaba7e4c9606761b20153e0f17b710c6",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-libs-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:47d3b0f3b51974f6be0b900ee6472aa20fb214c494a3d3994cc9fbc854ce0f33",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gettext-runtime-0.21-18.fc37.0.20220203.aarch64.rpm",
+        "checksum": "sha256:344f2ca875b102496347055bb8e0231fec25a0245a538267e072e666581c2ba8",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.73.2",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glib2-2.73.2-8.fc37.aarch64.rpm",
+        "checksum": "sha256:d1bad6b76f428e9594e9d17c5e843682d9b6b07d687194f263b5f3cc93aac61d",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0c59b2d38f31785022b5b4badb0d7b4efd255e8bdd31a4fd3636eee62dcb7a28",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-common-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:898d0d0b74e205c2d9f9549cf82abcc9d1d5665f83255dfb416fece029897724",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-gconv-extra-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b17ee7153e3916bef8bf01d9c02aa789150711fcf752930475d4a5ed8cd23e74",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/glibc-minimal-langpack-2.36-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1ddf01b8fc9bbc0dcfcc8075c5e6b0efb7a2e83d2086cd0ea43794ac4f2095e8",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:214a8c44915598c151ab2d7b1b4074fabb619274574ed4cd4ff1b291a5fcd07d",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:be9a015662acc23d54474a01f81a8f321359006b22850edcb41fdddc6f01b1cf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0c18091220a104278225bea1573077d807d205e2392f693bcb63a70c4387f141",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b1c0880f9180fd54c99e2340fc9a0001bc489f5ff3ed8ab405cce9e35707c01b",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.73.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gobject-introspection-1.73.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:bdff19c6bac526516f8352e29c6ec41e88e4fa9ebb1e31f620e612e8ff7fd6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:99bc383fa8558a73027e63ff75f0978e4e2ff6b26be55f384c3f52e5aee97527",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:8b96394a0a90e311f7043c7d504e4637e0a073a70f7aac6ed4fcfcc5b98280ed",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm",
+        "checksum": "sha256:b875744ecefb91efbe7d05df252768f666bf220d23f865d7df9b15e58dc86631",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-common-2.06-52.fc37.noarch.rpm",
+        "checksum": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-efi-aa64-2.06-52.fc37.aarch64.rpm",
+        "checksum": "sha256:c8408b9f0879ebd2ae84e7ef794abb23eb0901bb7a007d699cf7f234c953c8e9",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-tools-2.06-52.fc37.aarch64.rpm",
+        "checksum": "sha256:2f764f955353579bb120b720ad6db26740003a862093066ed22b400cfd249b6b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grub2-tools-minimal-2.06-52.fc37.aarch64.rpm",
+        "checksum": "sha256:ed598abaec8c192c87f9906423468cb438aff653f7e35a036053f4ea09b884a6",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/grubby-8.40-66.fc37.aarch64.rpm",
+        "checksum": "sha256:f4986d5e5dc7a56179778dd4e07471926e3ba3bca7b87c640c06000b203a52a5",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c15b41f9ed53a146a40746505f0b340aa3ffab1b377c8bc3522a13bc22a4e2b7",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/h/hostname-3.23-7.fc37.aarch64.rpm",
+        "checksum": "sha256:445cda1792047a2c4bd2172c4a2ef0c175096a848a856cb053bc42d6fb2c595b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:44a972be5ba2b774ecbe02a5773ab63e64dae3961de4fc0b36667d42f1c0a4cb",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/inih-56-2.fc37.aarch64.rpm",
+        "checksum": "sha256:34e078e9be9cbe997458a72e35718feaff49a1cbaf8a8582b30fd0c744b03105",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm",
+        "checksum": "sha256:05c442df8e338070106f86ed4762397a89c5485c72d6796f97535ec3b7f3c816",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/intel-gpu-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:8053eaf425c8bf14a476049eab59e586dd2d6fef458bf8eeb27ad661fdaf3d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:941ce3e47a525ae3e39f79a7df7d8e11a313a30a45b5b773233fc5f0ce6fba84",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iproute-5.18.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3baa59082b57d8303f92d493ee2a4d85592b31a89b6598b3c8b1e01efbe2f15f",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ipset-7.15-4.fc37.aarch64.rpm",
+        "checksum": "sha256:925f753a571120c816ce36c82646cdc0f69be84d762ae61184eb6ef5680ccf4b",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/ipset-libs-7.15-4.fc37.aarch64.rpm",
+        "checksum": "sha256:b2e0afdc7de2f8a16ce78b1d88ad600f4cd87b77483c06be924eb508ed30f597",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ccf0d18c15586c0a7ad9e7e69551fa9b997c25970701b5e635a981878c8a9dfe",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:040f180295b3e082728cc9725aa5a15556920bdddf6e229c7693b4ec80fd935a",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/i/iputils-20211215-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2ec90e98535f2ba20e2ebc46824e08834a7f6d0239d425c1868ddc7fc57cf677",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a3db34fee176285b0e73890ac0864c748bb091c256df197f885b31455dbb041f",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/jq-1.6-14.fc37.aarch64.rpm",
+        "checksum": "sha256:17f5276639d9353dd06539d02d936a2b36793003d9ffd12ae0b557b35743290e",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f53bd8e9f409439671de3762d5cf348fbffd7d97885c5de3953964fd7a148ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2dd5dd23c799bcec2ddccba07a99aff77a244c3a85717a307592ca6d3bc5f202",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kbd-2.5.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0e75d60792d3b6afdb7f557590363cbaea8f030cf72b49eb5f192b2f743a8b38",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.19.3",
+        "release": "300.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kernel-5.19.3-300.fc37.aarch64.rpm",
+        "checksum": "sha256:3d6782f1e07f1681965fcb7f3a2e1696c458bbc336a67fe3f03e95b0056a9591",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.19.3",
+        "release": "300.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kernel-core-5.19.3-300.fc37.aarch64.rpm",
+        "checksum": "sha256:30d427c19f748c5742d5777e3f372c38bc611622f8797f37932d553405a50885",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.19.3",
+        "release": "300.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kernel-modules-5.19.3-300.fc37.aarch64.rpm",
+        "checksum": "sha256:ec59f690cd61c14d11ed7e44908bd5ba689c23b2cad8539984e2fa94b8ef0443",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8f327cad2e5a64ce3d64acbc6769c2cea106085da3f9a3641ea4891d812df2dc",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a9352de1264288edbec9f6d415c925de2fe7f7c5aca221e7a9867f8f76d86696",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:872d6bb14b22f44217f4a7979019299632feaa0da81ea0d0302f5693bbcee8d6",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/kpartx-0.9.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:88b28b9729a393374ffbce10301fc1829133dba58487caa525aaebc8fa070f56",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:b9d09656e98dd744599be50d553e059d5b3c5236b617c5d05de9f0b2f505ff86",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/less-590-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c3063bbcd07caea5dcdb242471047b2a77264ed33bf004ddf7405cab70c6bfe1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:89341be9481efb5e7eea718b1165250a0dfbb9f9d5b33e7b0363360af228fdf9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2e40045d6d88a1a5bedeaf60f1391cad60bce787dda76fc5ad297fe3c98bf168",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a36a5c8c84e1382391d400704eac3af7d75639be231177f33a950c321069fd9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4718a79261fa3420e90a53b57cc5d25ef92e11e6ff30d089cce717114fce679c",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm",
+        "checksum": "sha256:1b97c4e4b98b93adb07c985a362e7216298fb7527f1887626597cc2ef2796de8",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5951d606e867fd62729173c8632a27c9bcd957328acb2bae37886a72d08eab3",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e5b166ac66d3edc433433f4bcc98325df08019e9664f9dbe7e6b5436af9542ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:ef495449eaf292fe2bf17066a5bc006c357804d207f7bcdc16e65d40ec827206",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9821ddb3b538def19c4157f9512e792faa4df5b9606ef3cc331c04fbc65cd913",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:124de1fdf02cd178ab02a3df77cc26059ca0254b5999f0f7f6032e38ac8119ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-crypto-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4b2120af0fbbde74d84061d1a22091a5f48dbbba68d5884399117dee7c30fe5c",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-fs-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:abb2141e8e12fab7bf473c869b02d6857a6a2aee1f7fb30ed299add89f5a2a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-loop-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:6131cc6f89273c0054332758df9314e5146bd9a311b8ed93452dd51426dc3a92",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-mdraid-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:548d5fc80ac537d663ce1130f95c0b24d6ddbd0da9ce5c6490306bb78ea5f1d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-part-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2ed8b614d428d1a559b8af5c615692f3e2aa26327518bf14a6c3a29dc6c47128",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-swap-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7a10c1c094e8a82caf5ec0a6dbd98ac8dd9bd1169fe03fd53d98211c02086a89",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libblockdev-utils-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:bc8ef19d0f2ce557fce1a49c78cda84865b2fa2e26713bbc3c7c73d507212de8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a95f512c5833e267e42cc030e465836ab4835f0d85e0cf48e89edba3b81c24f8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:8b5c3434109563ae0ffae763345df1a05134aaa3874ba2cbe216f53fcabd105b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4b6cbd8f1bcd9e058f975f5b2b2e19a075dd6c28e2e8a67feaa337737b542fbc",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:c137a0c92a0eeb58525609e4978a7e406950df356893496d7e5522a9dda4a692",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1bbb1efd8dc87844d9824ad3be09ae9703b87961eaba464508900f5fc77d0735",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:b6b0aa91236f4fe07ebd5fd5154cbcb8c7ecca90ba9af7808c8820454c173f75",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0679a49636c647f03a24709800aa78b03c42729b9e90c7ceea1e92814c13eb52",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:70702e8555203b90abd08f8c407a872640ed19a9e9d53869950cf56c594540e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:9c4779c47c68fe6a3d13a8c9d2b890dfc2c71abe543eda198f49cc3de2ce5c31",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:46ffbcbb2b1f414985b2824965e759104fd9c108cb8140cab2a2e4ee421daf6a",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libcurl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:d9312c3b6a93ec5ef197e11cd9bfe1ce9739b197b9756ab3dc43db2861ef41e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:bab57f8945eae4fa8a7728c5dec7f0a12a1b9532a64878a5b3fd39435653be99",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:4092137b8adddb11ff22705fb37255f70a6cf1c26dd44a33410a1d0c3ab7c8a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libdnf-0.68.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:5e5d3c2263a0958574d26b7afe5c5341d7bf80c0986f5e6116e4dd4e312a03f1",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:024f1c454aa07579d4891798097f3447015352a9b7ebd5457eb0af30a7190f62",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm",
+        "checksum": "sha256:add56e5fb7330c434a8f6e2fcccf6bf817ae396b9c3c419e2b3c5eb2046b6812",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8d77fe0cdaa209b0179965f3cd741fc11a2e220b04ab64ecc1d3fb46d0bea269",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fcc9aeea8c5c782e55b79fcca092a84c64febb30bc72872d8c5ac5dfb7a7bbcb",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:c71a3884722bdeeccbbcef5d9fcffa4c265d6486acb0f164d70c682bd91e1fdc",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:254c1bfd7f0dc1345601bd4df973833273c291b007efd8b34227260fc3774517",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm",
+        "checksum": "sha256:2090e6e4ab40eecb80944093cfd6dcee965cb27803e59c207c28692e8f4c5d7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:56b548b06112a037121a913157b0e4c08dce4bb0511843f652e99960e657d13b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0843f8805c84f780715c402544d9ce7255f773d2cdbfe64f2aeb50a5085689ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgcc-12.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0ef69b3a01eef549a6757fe2aa7d2d234f7da70a4d001d4344938e3e84276422",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:f55ce59e067b48e1148a5e40b09c7223804540bf1593fb3bcb687c252a074c40",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgomp-12.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:038cf4a81c5d368b86fe22d7424c0cc7005f40fb2d04f49e6f7fed10c59b9e40",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f9176c93af66866fce7b6c0ddc2426bbb88d83d6d091da663ad8c4cb8f8b2615",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgudev-237-3.fc37.aarch64.rpm",
+        "checksum": "sha256:6bcdcac414f4e313ae3527d3993f17bf38d296fdc556c10e738177fb5621a245",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libgusb-0.3.10-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c91f35b8379c7238168e973a862811f053802541d4408b25fc646cc664b70e7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7a78e507d71c85c273d3aa7e0d7f151b342a508fbfe85717cf760ee172ef9d37",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libicu-71.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:e8aa41c3f317ac66bcb1f3b942ca73b054dd7b12574e8eed2af0b86fbd6fbf7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e1c8670422ebe5aab49614e5264a61bc90ecc67e8ace5258ac94a04c8d8ecb7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:c635414b909a2b7ea49bd815c0261f4d30d13d871346906501d7316af3ba1772",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libjcat-0.1.10-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2b2887375b6fb33413a5973435c3f648d1f7995907fa770e59fb064fa1f7cb3d",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libkcapi-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f1d551839fa2f7956be9dd3084d518f9f4dbabe7af19d27342c8cbaf9e72f7ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c30cf3c3745e0240c1cb4db3906ab71abb555cc648bc67d2e106911b06ba19af",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libksba-1.6.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5c9b9096e70c3bee0796496b9acbe5d48ef73425727a2c332f9cf2834957e086",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d582315683769a0456d5ec9f85939f75f8df5055f3ac4110f28cdbea9ca9cf69",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmaxminddb-1.6.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:918357b6b1672becafec46a556a36e2b142d6926a036aa1a8deda3418f6e39b4",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f0fec5b7c7c8482cb9642dad77eeedadefe7dda70ed7b53d44fb5a6bd1ea2749",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmnl-1.0.4-16.fc37.aarch64.rpm",
+        "checksum": "sha256:d7287117da748fba67e225144984f0dcc1191f58d5719b9b48f515580be6b7f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:e40e9aaada115819d974b933bb33e6600d39fe13a91a9b4d5aa27c4decb06155",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:597cac421d14829d8b80d816f4f149c794aefe4e860a16142fb3b3995061d1bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libndp-1.8-4.fc37.aarch64.rpm",
+        "checksum": "sha256:95d136f0a45ecec0f319ac888010a2961d32d31a4cbc7c63aa5f5d128b9619e8",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm",
+        "checksum": "sha256:932f1548d9ca07579d56cf1ce527b34786cfebe8e07fc86106ac9d7a803ccfbb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:4b3936a76dfa4094d9133ee6fbb8f0a58d41d54dc81f874bdb9086f06711112d",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnftnl-1.2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2a96cd1a8ad454befdee1c14e9224dcc35949cce18f197f2f0841e03ac4d6e65",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnghttp2-1.48.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:efce366e113512afcb49ee1d64d553923b144c90df68d31c63b1eb61bd4d4f9b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3f5d9782065476a664f6e4d450404858e175f75b055f844f8a939623854ef615",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:7f7fa57ce7208d4b6f1c85ac8b78df7f3e9c049ebd518408d3a8ac12d173136d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:c4e372e626eca2c917309767102294dd75e83ae3d4583e90ee5ac4d1b5032e12",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:6a16500df314e37275aaab3de6fff5f4211d65b44fa9c6ee9ba74e718101a10e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:80e767ec60eb6cbbe095ef2917e2a8d022d98a5f334df0c1c3a14e27bdf03f4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:7422411a5daf5542da179460695b3782c1cb0e56a85797424bc89a2348c7e036",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:0131393ab117eb26be5e55451753229122f6ca97aa5b7872e65c9d691c0059d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:62dfa5a36a42f97393cf948694764acd5bf102eb91e0e85b1b2d565fa0450823",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:cc9ddf08ea0c691edaa5f2072667d11715a6349f5745f3d2b6e6713bda1858f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm",
+        "checksum": "sha256:f0944d0fd2d273c99f6ab808111d4db455fc9ba8489714aabdeda5729977c004",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/librepo-1.14.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:38b9035b2449e7d152bf03e6e3b46243550ee29c2fae8730bfa11646fb04f6cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libreport-filesystem-2.17.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:002eb0cd50f7f38dad54f2fb4cb1fc445c7ae0d320d11201f43f582c12e17a8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:27f9316ac91cebdc84bb4654404b3d7cbd0cebb2ce26d930756a5149f4fab196",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:dcf4b614ac88e26b9b344e0d6f3da257555f4402742e27abca969b0f439d6211",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4be185da5192918b485b25030b36f3e478bdc4bde19ebed1f80476931233ad30",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a2b276a42f94d7982e5e2ef72d59b73b9313ea83792ea9bb35e2e5cb4fa5988d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:72906b5aa7cc9f416f704bb0071972ddce6a08d251b1dcdf7253478153e8a20e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a6aaae0fb24af1e41f043b5f782f0bd02bc88eb6d8de53c849d628bb03671b6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5cfd777694ded1793af8efcfc198e72ea841844c16e6cf90e1fc88a36f7f444",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a595cce7e7d15de2e80c9a1057e8259234b232782118cb07c307fa67b672fb60",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm",
+        "checksum": "sha256:58b9082cd1e6c405c75d7cfe43595b066a80226942da5ddc714b1e6309bcf44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4f457a6be4482daa62e4aabf417180436798aad243879ce9af807025ba92a7b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libssh-0.9.6-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a1439943133d9753b57246bf80b6b168266652831acc19f6b8d658ec65bc9614",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_certmap-2.7.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f39abba16ac8153a5e4fe5f44b875d0be983cb62b6ad7115cdf8ccd7fa325efc",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_idmap-2.7.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a734e52f908f002006087a9e1cdaea29ec7f804a7f07df0a9c4de3d3af488307",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_nss_idmap-2.7.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1884edcfd3bf500adda863fff4a23f86dc7003bec41d1fd6e0b30d072d30c3fe",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libsss_sudo-2.7.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f1af086033468497e7a39f875a661c6db3b946e97b455cfac15319f7f75790bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libstdc++-12.2.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3729513f5da9fd89e033e25be88b344a026c73bb5bb37def449ed94b65e61df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:3b43f129f65128a6477ed7d55f7c8a0a1359bd6eec8bc162480ef21d2366e6de",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4cc7e6a19b5627e3e3bf941d5bef3ded55458eb226ed6e523e9a0d6a836b249f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:adf4bb4c6f00d4d335a8cf6c6cbb3919aa3381752edde9a16bd810600e38f8aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ed050e88e1fb2f8d2cdfb83075e79eb868decf66ec51ee4bca29d35e849f5247",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:8a08019ab8471eb8e8bb8382acc0b8ea145852369d63293466a4af8ff2221263",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:d6ee284dcef741c4de7ef51f540ce8144cfc5f2937dd7da0c1c857d96cb5ecb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4a6b322edd293c5e0ef5bf605f948d94dd63a836b944592e909419412da9a39f",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm",
+        "checksum": "sha256:37ccd2182f8ca4f3843cd79dffd129efe19691b963f80d06cc990d74284e7674",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libuser-0.63-12.fc37.aarch64.rpm",
+        "checksum": "sha256:157d58d20aa573cac45cc8d4c7292d5256981d4e16921ce08b47906a8df03259",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:e6ff8fea0b6b2dfc84dbd21d7c24eb6f9c6f4dd5b6078bdb4d3f8ede0fce4e47",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4a10b359b41ce7ba023f4c9ba93317ffd596b2c10d9c4c36d6e265680ce29384",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:4ec341b6380d94440297cafbbd344e54d4160bb5aefebb1c430445d89faa5cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxcrypt-4.4.28-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e8cc5b5b5df546ba2a71ff6fd25adbeb01a27c7c503d53946463cc6108d4ff9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:4f22691f1d6ba6a35adcb8f04310c0cf2b1c619b9e250c27bc2b3a56eccaa945",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ff00ca33d2a696f3b438a85da657f900df56d743f06a0163df3b051e74d9d9dc",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libxmlb-0.3.9-2.fc37.aarch64.rpm",
+        "checksum": "sha256:020c07869e11cd2ff881e0917150c8467c8c1de54a5a7fcbb6f76a594f21597e",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm",
+        "checksum": "sha256:f5466c4dc934d5abc1eb1a8ed1028e1f78fd4eea87ecc5954fa491a0879c0fe5",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f81833addc3924f97efebcf3390fd375339a7e752e7b6ba9003162a248ec7b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/linux-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:d62eec866919cfc099ea008e165effa38edd53c0489deb121d39839cc30a3e92",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/linux-firmware-whence-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:a27d291b03476f2e041cee4b0c91eebedf31a4d13cc2ed1030eaca5f77f93ddd",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm",
+        "checksum": "sha256:d5059e977d0f0fb2f8e00201efc16c9e75198d23a5aaaef146e042d845a69e97",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:97b664f921653bc6d22abec3d906ff58a7a1d568a4e2f24a638b15f46ed8e058",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:61eb54379561ee89f973c58c10b8507f64fc0d1b3bf11cb5624b236365eecc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/man-db-2.10.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2536982a47df91b0763fd31226c2ff6f2247c1d028686e0201ba4b3aba45570b",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:052d5277d62271b6d02095046f52a865e5a196be847e0e99d9e257d798c6167b",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:2a4871abac524999f0a81cbfd87286871de5a6c067d9467ff2b51613cf787def",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a34c6b913b7810ddef0831adefe154fb68150ead286b750a3dc3e15b56c75e9d",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:76ed672b87d410a259b09885e8ad7a88b28f181a268c3b401356a43e41d38141",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.2.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mozjs102-102.2.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a1301eed066ead5d0206b90f66167d010ca993da90baa2ecdd19e7e3075d9b86",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1a86bf76dd2ec9944487fdb47d82dd73b788bb6836ffcea6b17cae823fc1fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:ff038de7f7a3e3ccadde1d9e9a37667813e3f7ad22baef23432f831b4ce78def",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nano-6.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a89bdeff8ea373ce88d147a5f017e7f342c1c79fdf615a88f2396e980638feda",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:1f787566fa6d4c0a2f5067b98195f3697a4e9c65a8227b6598f0d0fd778da571",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:c712e9a4fdd669f1bd5be16b453b5fe22ca6c7265845833086334ab73144fc89",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nettle-3.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0c4160ab5e8672d41f10f4fe52f0b59cc28b21cd3a681ecd2ccd8dbcab56ed73",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nftables-1.0.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:28392dd7269733e1b069c3111b9eee10ec590f7d58408c0b7e46e78923bc5fc1",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/npth-1.6-9.fc37.aarch64.rpm",
+        "checksum": "sha256:64a7dd77389ef15d39b87388aa8c1b51186accd702fb91989ddbe729060adb55",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nspr-4.34.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:6c1a57b94b81b6f8a34d8b8afa81bc64c7b74900e24ab8bdc67c967702e5d21b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3ee4cff1eb28623c2f3bca14d2d971c8d40f1c705adcccb345a005a0a6f547f2",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-softokn-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a755df3c6cba46dd73d8264ba5204f49700f8dc697aefa7c73eafeea8ba90641",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:948738abb47f1d630bee2fae87cdb00f65d2f5e25c31367a6394d3fddb082c35",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-sysinit-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a79a510349b5fc98da763d60275700e6dbfd5823d47514bd6b20e815ab593940",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nss-util-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1f6482af76be62483afff6de7a689e18d45881b91d13f11bbd3dcebe91d38504",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7844c090147f6e04cb219d39eb76341b08ec0bbea3b51c51aac925301fb7c677",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:eff91da3adf84b15e85b72b907d7b233adbea9d78ecf0db75d9c3a6c9c0e43da",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:1d6c6889c78933703fc54b965fe1cebd52f08e7780093e71b21fbe10586f2aee",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8b56b7ca059afbe4a7ba86d30b7b324e639df618276cf45b46d3e315cf0718fc",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/n/nvidia-gpu-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:69ff7199c3b6dd205c09022bbc598851e21a9dd192ab5b63a7f25fbe706933bb",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/oniguruma-6.9.8-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:2b18c30e4e0d805ee80b71ac118d948437d0a81860355b3fd004226ee3f9db59",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openldap-2.6.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:0d060e4e89bafa0e342cfdca9136c72c8d3f6af2adaecf2ef47e530c5edc8985",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssh-8.8p1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:36f273cf6011455969cf6ef2d8d6f64c95eaf7edd7c3789535f5b6a1f6a1bee3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssh-clients-8.8p1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:a2e7563405fc95534d5f6843349efcaa20574f015dead29921d04bc05362b35b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssh-server-8.8p1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:466a7c0dfbb55b564f120dd39daeff9206b76ea8b1b93f4897c9153af9572236",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f2b8068fbb2231a515c60c491eb5b08808af1eb6d497eb33039125aac3eb7d63",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/openssl-pkcs11-0.4.12-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fa303761d66b8f1e839004dab9bc0b6bc53cce6e0eba0e6000ea50d924658439",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:6e71dfea8a327a33d284594dfc9eac7f6d839abed90149759f32d1bec882e57d",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:da0a4b3516b227a4503bcfc3a9eb805553515376079ae3e95278d338b4afe592",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5a6e4a06f4c76f4731efa849fb1d3cd246a64a02ea7e89f2d568a21c283f89e3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:467868427524487bb63ba6e831a43e70acef9a6f87e5a1260fcb9d9a2b7c979f",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:18eba0ba7d33f38f79b127e1fd39ba0c4ce4ebfd5ff6a41067f015e49e9f2dd0",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/parted-3.5-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f23bbbb8abeccfae1758e2eef3a676c956f2df47ab4ab559eaff52afa1f809b9",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/passwd-0.80-13.fc37.aarch64.rpm",
+        "checksum": "sha256:0ead18c632b1aedd94d6d722f8317c2618165b9bc0532fea4ba5a10b642e4766",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:c2e72f5c760db66c861e2f6e95741dd329b051038a14a8c38895414c729f0f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:e280e292f0e042eddd0e7981bdb2b4faac63b9f94e6b50b3163ca4b5928b6ff6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcsc-lite-1.9.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:eaca4b21ecfe4860a8d3633ae57ca8bcbff0af8168db4b424e4293948b0dbf2e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85746399da551cfc335f2a4b156460b4903a277861077cf919b3f5ecd7689e97",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:066b24665dc145c4337c6332b2123bbe662b360d34dc53edbb6c14b59c8fb8f6",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:59324bb800c745c5b4cdc60905d25543d3b6d9cea3d5c82a76d0e22a46feb0b1",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/pinentry-1.2.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:e919037d0b4f9f434f845500c66155c753f86bc47dfcb9935d937304e7948b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/plymouth-22.02.122-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3ed6ead984746688cb4b95a4f4bc4ede898fe768b9129bc91df82ec9721ab37e",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/plymouth-core-libs-22.02.122-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7e9aaf2225e46e8ff4e63a387f2e4479fd40e0455135560388c220c148800ac0",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/plymouth-scripts-22.02.122-2.fc37.aarch64.rpm",
+        "checksum": "sha256:89a9f1f450a4fa695100278afb7bf12fc00c3e423085a45b1a282ded7a685c33",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9f91971d2e252f6fd49c40b9feb62beda46c268f0ce1903e6396f7a0d35cc39",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/polkit-121-4.fc37.aarch64.rpm",
+        "checksum": "sha256:9cfbaf8447ef22431bcefb1542a31badae1a33de764e4cbb88e90faf42827519",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/polkit-libs-121-4.fc37.aarch64.rpm",
+        "checksum": "sha256:b7f51a01499b5ad345c10a790688ff8837d894b8608daf0fd27250d8a20afa77",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:d3011b8c219f9f86fadd7bf1ae600db59364b5e425ae47117d090635812dccbf",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/popt-1.19~rc1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:8ddb89f6a3955b0dc46c015025e5a2956d0c06bc93fbc0a3b3f087fbc6b0873a",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm",
+        "checksum": "sha256:f9013badfcf2a78e4dd4a1f6ada593f3d1f9dd5935814abde7dd7de1fa9bb8c3",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/protobuf-c-1.4.0-6.fc37.aarch64.rpm",
+        "checksum": "sha256:65c0279da62825de54dfd036126233ee051808122875d4aa3dab7eff27f3f9d5",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:2c9c7520371594e7072d9cee9fe6df88e1de32c9f39eea0e6b13a447fc04ca86",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python-unversioned-command-3.11.0~rc1-2.fc37.noarch.rpm",
+        "checksum": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-3.11.0~rc1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:031dc58d9e841652a0c8f98750408d6b5e81dffb0baa20eabf26add7c41363d5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dbus-1.2.18-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5e51a6aa0c2acf0913d7aa70eca38a11492de9ce863bd2f4955ae09c3ceda37a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:9549982392bd6cd0c8fbcaab7a672bc94aac048f3f20a5c98fea083866748c47",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:4fc2b6910a5c954f8ef9c89e6ccb09df3a66ce5a323075775f65366ef649db95",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:5a980a3db08191299cb1ae9640a924fce3631d34a7a931ba34b0a44daf2b53c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:1dec644503915a6e2e256de5993a746379f871b241d81d0a0296c3f9478bf84a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:ec395c3a160470a6da63ac1298a540a93a2adee4d29c4f78c24330dbbfba12b3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-hawkey-0.68.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:58b9a2c3db5e64b6c33eb7f5b2f2f63cf127626548540bb6333e0c1fbc415ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:55ff17ec31466bd748005cf65cd687af61b0aeb3ad343e8d0c2d9a24f8a1286c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-libdnf-0.68.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:378607a741f61282ed8243ca0f2164fa521ff02983e0eb1289d4350b7c781602",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-libs-3.11.0~rc1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f5a9f472a5a88798376d935090fe11e65413016a878a88da8cf839199fba1b29",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-nftables-1.0.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:22768251ebf30802c0bce3fe0bd9d4092bf56bff6036dd655684612949c112af",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:98f0fd19966edad2dcdea46d1a8f2dc77bd44494c3b3ab896c51af70d854bb62",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/p/python3-unbound-1.16.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:916f8e6515fb7fc4ddf0db6ae1bad1bb167d4629c4d198e2618dc5cafa172d8e",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:acf150d7ae57ceacaac26eede194f85d55f089e3df4cd63f43d6840e0998476a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/readline-8.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:8eaa5255d8f5cd3a8f854c4de6082158fd6294bf779b654d5bc270906a425ebe",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:76d048c6c3b1aa099ec34a7c2fdaee1487aafe738cf64e912b1b84bcd9440ff9",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:7068166d5807467f0da88303b489f6975b439a2530185094c631732d2a6da484",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:80e547e469c9e6df062633830a2ae9f54355236f91bdf0d83ff3222d60dcf836",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:9ba24cdbe2f39f0ee83b266399177343ee110035f635de2ee81426227b399998",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:a56d19f03448414d12e06d99f1ee3d7f802a7d4ab94348d7079be746c4d1cf0a",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:e1c78ac4292331b14107532eb08051c929248230df6b955af12d2eb4bccc0f5a",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:660bdec3e0ac8daba38f5f26b58a63fd4677d052bcd1389e9bb8e5152bbdeefe",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/selinux-policy-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/selinux-policy-targeted-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/shadow-utils-4.11.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5d78e738293b97817feea679546a1611ee76389bfd2c7b6f496d3cc90cf611ea",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:eed9d47041b04ea6c49408f4d71cc0190b699c51c1a89de4c6fdd676cd1777a2",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:5e6fb2a961d9e9823380d329642b68e752d56018b6f5ad0a7856a8fda723a9e3",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:e2dac60f8875f9ae0aff2da3840d9e878a48650aa4c6d04ae6cc0b668aa7ba2b",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sssd-client-2.7.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:8f50c3931775e5513506e04c0d65ba2bc7b19252f87eabb23b3911031a2309fc",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sssd-common-2.7.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:486f49b44bed738796297ec1cbc073ef4d571396e3f408e1cff77d938d1a2982",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sssd-kcm-2.7.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7175bfcfbeeaee19bafc01c4709c825cb553db170934da4bfa7fee61ea5108fd",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:388def347af7b9811dc79872bbb55f1ae433bde1cc4b28e8b3ccc03eeab80a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:8c8c5a7d8a7bde6cd7413c745ea8f81f728169d2e4e96327a86f41019b8390de",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:73dc19a07f58022d78e6a8aaedf2c4631e90fb62f2050776d5ac0e8fc6b300e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-libs-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:beb88184545c5c8d60bed49bdad82674a58868db381d55d9a517f35ac9cb24d8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-networkd-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:722a9893ae7d36b0b6209c4cf5964903e1d74906af33953aae56ae120dbb9102",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-pam-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:e1acc1bcd35e05606e201dc4ac1d4dcad96bacadea944dcf95d7aa61cc7289fe",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-resolved-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:247d834075c26fee903b27e499758cbce85837457cd9aee1ebc9b3b3a31aeb59",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/s/systemd-udev-251.4-53.fc37.aarch64.rpm",
+        "checksum": "sha256:c99e1b512c78b34c5a4b48dba416d4128de106d4513b5593a8c1578ed418b568",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:db2227729ac01ec1712cb3630ae3ac81fbe6094b5d40f9a91690b1b8dd413eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022c",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/t/tzdata-2022c-1.fc37.noarch.rpm",
+        "checksum": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5eff8b70f05717621b31b0c0c8fbdfa6bfbec81d38c7b98cc214a33dba9bde67",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/unbound-anchor-1.16.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:91448bcac8efd67b285cf12ef86cd97c44aba4194270624647ab6362377bb7df",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/unbound-libs-1.16.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5b5506311d4d8aa6dba565bb89e43d96f9ac149fa3240252f1434edecade28be",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:8e85f2257c7cb41df273ffdea56daef73e44bb7bfe79befa296f700e60c49548",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:fd094e9e45ac07963427305e35e27bf6917176886406ee81595d9f54621b5a57",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:774d5475480f02c9cef3a319d3f9b5f086e8b6e5273a2c4e6dbf1cee07d45c97",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/v/vim-data-9.0.213-1.fc37.noarch.rpm",
+        "checksum": "sha256:a73b3d5a5f472d8347a2f858a0061e3f338323dd962d5293b2d0982db9f20bee",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/v/vim-minimal-9.0.213-1.fc37.aarch64.rpm",
+        "checksum": "sha256:10d589cbec758e5ee04e6277a0700f9e7118569ec5a6d37e5a3e0043fbb94eda",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm",
+        "checksum": "sha256:c6fa6669abe6413582fb6edb939ff8e897a71c9e054a6839516cf9a6b11eb6c0",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xfsprogs-5.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:788976a6dfe6796fa08ba5f52c17af923044473b481a75be9bb695e8fa7d5a16",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:660c430d505999d24d2c0cc023d6b6af1c691db8bfaf62d10d38963627b4a664",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:fbf24d19205ce8b9c2da7655d859f4c4e7753b5794bc90db3aabdf3e7784bc84",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/y/yum-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:7e169c14f3c544cd0355633040eaee3ebeddde31bf022ab2d4441db084c5779b",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zchunk-libs-1.2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:053723c498aa0e5fdcfaed2b5dd61d19bc00bfac4d69a45f4d02eb22d8ebe297",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zlib-1.2.12-4.fc37.aarch64.rpm",
+        "checksum": "sha256:21024e762c7baf67cfb21ef765c56fb50a3a86d238567ddcb23fc60cdc2bcd97",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:6c7be4066ad8a69c7b4ef73706b1c0591361b522f22a1ad969f2e128992ecdd8",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-aarch64-fedora-development-20220831/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests.plain/fedora_37-x86_64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_37-x86_64-minimal_rpm-boot.json
@@ -1,0 +1,11511 @@
+{
+  "compose-request": {
+    "distro": "fedora-37",
+    "arch": "x86_64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-modular-development-20220831/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora37",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62df028d47d6465b65db421089805f8da363980b3e2425d21de7561a69b967ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1baa8a7b21c0b7afbf606c4fe14ef95f68adf446f80caf4093756d187b05d134",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1c518fabdd55099686918e292d1cbf29adca46d1a83baace30066ceaf93b86c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5cd8989ab70e06e0246ed8668d9553155ae48355059a200ca016cf7c1251930",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8dc6f57f2942758833a5e08295e8b83dcd285b35700d28e79f5e34ed02b3e97d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:084350137f900095704a4dad7855c20cfa12fe540caca8b7db7fdc4c20218860",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3a06680422d09103dc2f602376da3708751695bb23ad947adce07275236e263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f31a8421c338393c824e461b49ae05a3f8c9350fed2347aa8de8df00dcb94631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0129362310d1fc9a4faa7300888eb6a476d1568f3ec5b4f144cb42fb4a6183e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c864716f0efc6e66f2819dea425a34913d4d1a7e56d7a890d254202caca4f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e39ff78d65d980546c9b1d0e33d19854888cc70bf000e3a160b1fd327bf25c77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2fafeb3f4035726e27a0039356164e1d732d0e870e2c4314869ebd80b71236b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22aad91a73901b4723ca1b6e97fbdc3a919139be73c758e6ff0f04767d2cc1f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6922ba2992ea7c110f49eda9b1fa7da61165d35b23d03d42db07a770c57fd096",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fb56b6d4ca6cc84bfb896275aaa0c397bad50a39e0fa36bf6739e1f1968115c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc36b54dc5cfe21316477f9e519194909fe3978c238d1f5f4c283ef4f90f7c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27e762ebbb816ee1fb731cfc81df32846bec48933e5540daa53509a379196d7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e23f712d3b15bd50bb12b01f209bad2bcc316977a1c45994711932447bc4262",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfe83a7faa009718f0ca5d9cafa5d61e4aa6cb4e439fdf2a9d3209d8057dc323",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba23ecf289572c7a1f3907b8bfab88630d00ca25d427156ed5a1ffa010ff5203",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4270cd73a7289c58ea736423756b244237b545d5523ba34b129877cf6443e06f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd584aa1a20378403d9253726ac23d78585f95155da02473aef9904460564912",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d4fa9fa98c029560b4cad221eae6825f87c8191ce54b3a374ebb9edd0b0ffa3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52a60aced835f862b077e74808f17124aad5bdfe79f42dba7d7983577c6614b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c813e74f44061f164236a0bc1d5e3e2aab1ece94ad2b190213b90c407c95cd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77798df08cf783df929249944ed44ebe8ecf1e2eaf7a12e0aea5657b78612e13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e857999c674a0a6154074042c3864c6e8e7411ee6da3e4cb41c7760177b8b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be94dbe638c7e0a02fbc9bc73355dff9bea812d87b72eb45c1e7b75ef731b42a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01ae93cdb80ef99a9dcf56ab6e1929d78606bd345fe7189a3a7d00921847c36f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e88be19e5a5ae7f2b310f52470c454979a5c6627325e2e528a38360bb5e4655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01bf6ae14456eda9a669b2b754b496e9ee1a79d18d03276b9baec216757df054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded733a845f66010ff47249a502d406038cff2a6ddd17886e3e4c11290ae9b1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6abf8009d5cbf395ec36ba465aab3d5ba641bfbab940a949a4c98577844735ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4dc7042fb07030a20b8349fe31120d08156be5257e4ed272666c061cbc40fc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddd95d0cc09f558e8f3defa1ac0396d56b02964530404e99813200c0afd4633f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47c1c0854206fb50fa5a933f621642b2b304da3bc8a5b0b462ff751457073645",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b2d309ebe0f57e515b402130cd1b63e412798deacd0118c10cbb2320bfd6eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2633fba63aecad94afd7eab596f5d4971c483148168114a58e633bcfc386663",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd10dbfb5b6bb286cac3d50e6dc187e1b2ae48df6798fea19a59387d53a34308",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:895cce126d2da91e85900c7a83d85a9978b2e29f2e9a6d611185f77f90d886c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f58c30365cc31d0b5f8013a8561417d58d5c7682f4a075cbb2ecb9c6b8f9bb25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9025dee2752b6bd4138e19f856a05a0f1a68347db49e1fbb47a2b61ffaf937d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d4f57d5d26265b3090e6ede9efb9f2bc3996e9032f6693e60fe02cb5d9a6a58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:e56dc2a37766276593c4f40c9d588defc5ba66ab29ae90ee03480c8bcfba459b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6ab731e69c9782e4b5b733145949214f01999692c724781e35512606bcffe56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db2088f9a2f250d9e1c01c85dc9cb3fef32788d92ac2be2beb6c6f6bda85ce5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fec9c3bbc378c458dea2ec3e8da500d6f3278d723cc94d8a27a1d0259ea3c89e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac84aded77545e1725104e25cef9ef4c6389567f551042fe57a05dcd19b40636",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62df028d47d6465b65db421089805f8da363980b3e2425d21de7561a69b967ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1baa8a7b21c0b7afbf606c4fe14ef95f68adf446f80caf4093756d187b05d134",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1da1c93fd682aa10d39362e393971ef6a0b5a9fd62f3b24d75b14ef1004843c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:558476ce7be43951868fef0c6216a99ff0a5ecfbb69e68785172b3a9a627b28b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1c518fabdd55099686918e292d1cbf29adca46d1a83baace30066ceaf93b86c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15dae5e79467e6f5155297b1cba8d9df68f92c29ddd55570caafdd115a602534",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5cd8989ab70e06e0246ed8668d9553155ae48355059a200ca016cf7c1251930",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8dc6f57f2942758833a5e08295e8b83dcd285b35700d28e79f5e34ed02b3e97d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e8a30665f945fa47886a9f147b43f6db0db0f0f104f20e8b1301035b9de0b2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ec2fe94d7573b61068710179c7588dec264198fd55a04247bb1cf9a1f925cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73cacc81fbf8f6a632b05ca5880f51e245fbdaa92ca590a5dc153196714f44bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f46592a35c4569e5d32364baa37081e1454761043a873e3ee20067ce5409a85a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19b7e1385a12e9196622d1549ebee9a2254656300a530a9abb824737950571ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3845db664d89151f8a07f465f734705eaeb76c242c58866f91045db46f63b650",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c70e5ab3e25d6f78c9bc66d0f6b3a7f33457a63c2a17cd15efeb5ca6a0023c62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ef037a08f8b410305c305d9b77497d7fc557b66dd08927d31ba4beffc3faa1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:084350137f900095704a4dad7855c20cfa12fe540caca8b7db7fdc4c20218860",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b99c481853fd3a81ac704283154d0323b621d4c799cd15db8021d5ee4f48bf2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c35c69329756f69abf8520f3be0a831f59018c69f4b3b987e1ebf1122162e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3a06680422d09103dc2f602376da3708751695bb23ad947adce07275236e263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f31a8421c338393c824e461b49ae05a3f8c9350fed2347aa8de8df00dcb94631",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0129362310d1fc9a4faa7300888eb6a476d1568f3ec5b4f144cb42fb4a6183e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11ef902abb560166f418e4f4bba230c7c5a3d0bf2f917fb771229fe923a767ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70b262c317b0a012fbe1fc1239f7972da097c45e15075c8165b26069a7f7267",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:393cc43a853a2f5f391d133acb032b0a50d5070aca8bd3ec132d949b6af157bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3d72ee9f04141387d75d3e8ec9fe3a720ad40eaa815ffcb9e18f5e98e2353d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e73a0ffebc89d0f00df64fb1556f632eddea245eaa5254c8d76cc9bf85117cd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f863051b731a75ea7443c096b1a0e236fa4b285b08b3dd7175d68c228eea1dbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7983ac68f01f7ff72010401d03584c226d3c55fdddaa4c900a562494e470cad9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eda13519d50710e3566c367510bcc69178609af0b30cfe9074082ee10de2fee1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f26f097818a1eeb5bd4b9a97dafd97dd8793f9bf704ff9467129701e03479ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:911355f71b817f8fba1c98169646759d85f2d20a6d139f54cd46b4664b294529",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c864716f0efc6e66f2819dea425a34913d4d1a7e56d7a890d254202caca4f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e39ff78d65d980546c9b1d0e33d19854888cc70bf000e3a160b1fd327bf25c77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2fafeb3f4035726e27a0039356164e1d732d0e870e2c4314869ebd80b71236b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22aad91a73901b4723ca1b6e97fbdc3a919139be73c758e6ff0f04767d2cc1f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3253a8869d584382e519cbe6576f39bf6a81bbf55aabd1f6befc23f5a3ba74bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6922ba2992ea7c110f49eda9b1fa7da61165d35b23d03d42db07a770c57fd096",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fb56b6d4ca6cc84bfb896275aaa0c397bad50a39e0fa36bf6739e1f1968115c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc36b54dc5cfe21316477f9e519194909fe3978c238d1f5f4c283ef4f90f7c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27e762ebbb816ee1fb731cfc81df32846bec48933e5540daa53509a379196d7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09f4ad48459bb38de836dc6eb974c2c2bfe5581e6cf682d81f2a64d55f20738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5b4e759d1c56188fb777926de0d17498c25d3234d2635ce5a8e7b000bfaf7f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e23f712d3b15bd50bb12b01f209bad2bcc316977a1c45994711932447bc4262",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfe83a7faa009718f0ca5d9cafa5d61e4aa6cb4e439fdf2a9d3209d8057dc323",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba23ecf289572c7a1f3907b8bfab88630d00ca25d427156ed5a1ffa010ff5203",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4270cd73a7289c58ea736423756b244237b545d5523ba34b129877cf6443e06f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:840438421f3c7e28e49fa1327480ff7eb7780bcdbf605caf35ec0115bf4d7d9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72b2fbe65f24fa2dc41109cb0bd47b0962824847ac802a3c0160d832ee1e75f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28d630dae78579725857e2242ce2ce01e6748a20c538554a36b628157a7ea1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c442df8e338070106f86ed4762397a89c5485c72d6796f97535ec3b7f3c816",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8053eaf425c8bf14a476049eab59e586dd2d6fef458bf8eeb27ad661fdaf3d0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea37bbc4022aa6e266e0ec601d97620574c12c8b898b3ffb8ae8baffe553745f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:960633a9035f8fe02d49ba6713f240363383d5dc3b3f862d28e9b211fd34fea3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:247002230874dd0c449145d4e8f92d3d5d879a41ba2e50a67c5b73f4cff6e405",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31f31f6f1bc19d4137d15e8a434cc6aeea959f875ec94c2cb3f50346071570c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae1fef40fd8a0c5bf8c4aa74625119132b9564fabe2d84ae7856b39805b014d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9cf89d7e274a5ddf55fc4b97974c7aa33f50379c8ed50f6cb458b7286c89af7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad14549b59bcc2c3c2ed6152c0a3a2d4aebac3ae06ab5dc451659060f380624a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd584aa1a20378403d9253726ac23d78585f95155da02473aef9904460564912",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae32085526ec5234ac837ad5d39ce75d0dd106be3f0a8be975da5103b0b351f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d716aa1b01fb350f5c7e7534b9b6c4eca03aa359e12492787debee6ac7e5d72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a95497e1a387d05a6be065f4ae95f251f420c65901b5adbbd98765b361dd39d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f03d62bf2ab0c2606a64a4326934765ae6d25afabe7cc7b77e44445c49fa4ac2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f52405026bce203a5a1dd62b533f9e6c61a68bba6271d2f7de3948dcb1a47fd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:364011baa5e293baae2e60992fd1241f6c822d7c7e48c259d3e6abb0530036af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d13d18388dda2d493b0883d2162e0a6a832cd652b8186552425eb92fba608e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e58c18b53a81e8ffbe7b2998a8ac97f6b8fcbeec73929c1f4838d61d43a6be15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f62a59f67418dedf7b7de1d267a685e4e4d0040851dd1da706dfd5cdcd37c38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c9e1a8abff915edbb2f793d8998338e7667d9690dd7ee8f332752a0950f844",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0cc982fbdbd002b3028706e3fbfff6c030b751e3fd4e98122db123346f13441",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24674d92e5dbd7116d11b50ce3af5fa90122fa73c57b0be94784c3e732def97a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1dc9df91a970ceb98bc7b68b5f71234f0191e3e4bc4dd7f084b65cb4e12465e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3a162d4a1623457f74522f944f27c037e3ece7094e4497b1e09339851e726fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40bdee106c7d9df3c4b2a39289b247635450d763fb84cd5e63e2493f9519b58d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:278bfd824633a3c49357342679e9dd5864a33bcda5d25986bf3e6030bed4987e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e67e6a70e493c52515626820cef9d3df6457f111004483fe6a8657255f4ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e14f25f5cdbbb523cfc3f7381b8c053a26f05f61666fb1f86fecda50d3764a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d4fa9fa98c029560b4cad221eae6825f87c8191ce54b3a374ebb9edd0b0ffa3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1698a5eace8302ba8cd5b09c23b4c8d2ca4c9647a83ef92e03caed5ff066fa0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5efb96c9ce79c98fae0297f5fc2d6740a5f2c167d64020d18876d9e842e8d32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcdb39155a419f86e3070329e0c9ef19f1c6b605bad1e7af9309fcaf8d718195",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfbe63bdf373f8a141954f84aff98d3f044ba936c80e201c4755efcc6b1a9d82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2aac86cd8a7197d3ce75797501dfd5ff3bd77b3c92f9c975e63efabd5e941d1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52a60aced835f862b077e74808f17124aad5bdfe79f42dba7d7983577c6614b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c813e74f44061f164236a0bc1d5e3e2aab1ece94ad2b190213b90c407c95cd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0bd6b3f97c370399de8aad7e37d1195d3be5f3aa66c3ab4c83eeb42e4cde23ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a85fbcff4bbac0e5f92bccfdde601d8cfe7a43677b7a328b9b265304de380654",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c053d341934e4853cca55b47c49e30df6be74535fe29b48db00a0fef355958d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adf559f274af1e1a4facb1cc93e3840e83ba429513df55bdb79baa6508423e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4b47992384c822ee021452275896dfebc302ccf9f054d5d6975a364214d4f9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76fb459232b71b8a991531c1b58ec93f4099281451e258964f53f1864a1c530",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f72a06635024c2bf9f43768aa3296f4f00d8dac3862e8f880bec360e56e2bb87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ac04873c24d8d89c1b60e5cec35544756507fb1be2c2556b92af8bdfcc2a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee54c169df955389d600c8990969e809407dabf087a05111da9ccbf16cfec4d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9577665c819179202b3439b7be4c69052df5ed79c9812be5ebb51fcbdfc8330f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:688c033cd1c7b39b918c215af5480de238c16be94b72086ed4efc34dd6201b80",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ba1fb96a5e6b78dde962d5b9fe97726a393c977e9a9106e896dceeefffc6472",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77798df08cf783df929249944ed44ebe8ecf1e2eaf7a12e0aea5657b78612e13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:932abcd232d522bb508daa2c9e6f4a3ea79039ad80a6478e6384d517c1d6698c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e748380f1796e2a7be2137cecd8a1662fcdfdbc858d27b218c931350e296240",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01a2ac7dc3829b47eb0d188909175b806a1e93eb1aefad2737f8fe07e42972e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fd8bb0bc2edd80b13c0d3ac38cf26b1ad94736fbf1b4b37ee6433772d6f18e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69ca0883e3929168bc8eb555463ae051fc38afedae0fa98d566bc22388304a91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52fb4dc0ad2f889ace412f7b05b2a5827a3eda8bfb9179fbe7cb393dd0d88dd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:002eb0cd50f7f38dad54f2fb4cb1fc445c7ae0d320d11201f43f582c12e17a8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c203ba66a8da80ad3f21305dd932073c1ede06cfa2d1b267ccb28089596094bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e857999c674a0a6154074042c3864c6e8e7411ee6da3e4cb41c7760177b8b22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d43e7cd6fe9faa738384509be775d4867c11f3ee199e7c06daef69e86b517c57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7324e7200eb3c740bd9a836cb99f1fe6c6842a716c865309c61897e866f3e111",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31493b05b4a053487e4418a7f663b50b801e4f3d557c6245ebb8c32e3cd12db9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b853538a9e367a6a0da999f2ba2e7ae83af6790a3b04b5e47495fede61773367",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be94dbe638c7e0a02fbc9bc73355dff9bea812d87b72eb45c1e7b75ef731b42a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d71c5fc0e75b48b330cfc391920b8b2dd32c5c844202ba134172a31630a29460",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b772806fa1412ba843d87d2a84ed9c087880f3c9e7ded3f6035718f83888efbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:744cf61b729b0516567b9e622244f21d7dc6d44c35bbc507e5ae1b49f791e7df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c966372c322648dcf3e0b84dd0a7bdb92031270de243640739cb5c735cb6cef1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61e84444fcf3f76d3268b356e5b29f251a966d57ce043c8c5e0c1491179b7023",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8622f18e1c13db40256d25c5c01b191712ea703407343ea52289ffe07a486833",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d62eec866919cfc099ea008e165effa38edd53c0489deb121d39839cc30a3e92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a27d291b03476f2e041cee4b0c91eebedf31a4d13cc2ed1030eaca5f77f93ddd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57b0cbd11daab17a9b9486f89545407de965d26029938e991f1aefdaf0e48614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d53b6b5f20e16b95bdf743f3962f45911577e1a483c756971405f5ef0506772f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf997d2d6fa655ec7e03fc58769e29770409254861d75c3732fcd9a264cc2820",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bbb0584a1be90d64cdcd12a5712b9153ead35cf68b1431b1bf8159bfe77b5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e5281196fd18f90f4204d2104354936cd8f6fa88c209638f690134e61572b5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8057ff6e5fa3339726c83173fdd11898b5f7545e72d81503f8c6660c4404885",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5972f3f4f85193b67865db97e5e6e706d431d272f207a434d6b2102e153b5baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ab9c4b08aa61930f6c156d2c87584df182460396c7e03231b47778820f91d7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac17caddde45a5f9f2d5f894476cd82e799c8f52c6def22d2e8f2e0033050453",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03d7cdfdb9e52782ea8487823da1d8a33fc217875f28bda20e26f4392be2c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a58f6a4a83359244206dc707b6bf891468604ddc169ba4e29b628b96d3004f74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b17b885344823eb7d581edd0b09082f193c728f3c806138ddc4bdcd9bb059b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4df07c734a7b4135d6b5dd73f72cbc188763a09457f3bf24f893fc178fd89d9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cdba0d602a32cb4b90461bd7dbdfacf0bc30f63ee5dd8f460d5bee3dc4cb586",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b776d46067bf44c37801e19b243572feb26aae0fee721e061207a80873da1f46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d3c81dc359adc676afc9044743aeaf8fbc924e019b093084035413716e78f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69ff7199c3b6dd205c09022bbc598851e21a9dd192ab5b63a7f25fbe706933bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0545bc486067591d26070790405beb3330dbd5cee3deecb2a5b654bb1965d64f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2abbcca2ad0d7d7505775c9d5fc8dd34a89f87a27a3e2c770cb91632000021d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7805e9ea70864f34883cdee1cede47fa95f8a1150f37575574190e076aa322e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:198166311dabedc62d80a332da8d32b63fa2e1ae9329c6f2cad0c96e83050072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01ae93cdb80ef99a9dcf56ab6e1929d78606bd345fe7189a3a7d00921847c36f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cba7fbe4f72489a2fb27429ecfdf8b0177ac8cc4fa30aa7baaa8ce1a0dc4f5ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e733d49496689131148b00a233229e484b5b622f9cb8c230230a05117763065e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d45acd2ae98e922732fc9c4966c3bb8d570f4185122d766a83199955b96cad7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:352231cb2c4b6c7de0797b83020df840390d83654c642fcd40c586701c2c81d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e69146d4bbb40be987bcef433b916503acc68c8c40fab2fdb2ed6b32be39aed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ef4c02f8aa95c12ccf7c7708c8a6e9031efbbf76cf3c1d533ae80dd5444abf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:670528275ca6b3371e35c5c79618da004ffaf999fbf8b29f14c3fa21f701ab5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e627ce0440ccdb69f21d5928df87182b42655ece611c7bd9073b1f80a76b38b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e91182e4edc4ef94e52da5532527549f692184213ca0257dfb8cb1f2c3ed163",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e88be19e5a5ae7f2b310f52470c454979a5c6627325e2e528a38360bb5e4655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:903761fe0e670a53194e1e5e976bb1edd914258103d01583f1c89fa4d36c9730",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a50276d2a8bd7f2b16cbdf6592ea365c19fa9f9bd33b5cfa1ab4bbd5ca89c69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01bf6ae14456eda9a669b2b754b496e9ee1a79d18d03276b9baec216757df054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa30a837be5cce2abf071c4afead1af95faf7d87c05e390404aa0de3b10b8046",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9549982392bd6cd0c8fbcaab7a672bc94aac048f3f20a5c98fea083866748c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fc2b6910a5c954f8ef9c89e6ccb09df3a66ce5a323075775f65366ef649db95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a980a3db08191299cb1ae9640a924fce3631d34a7a931ba34b0a44daf2b53c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec583a673d3ba649d69246fc67455f01c2431bc8e80b14b724117ce709b317ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09bd56123cc38e0b6eca84a97848f3985caa421e0879345b89c42e726a19b49b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:91daae949ff91b3d96865ee10b99376b9db82bf62d4ee77123572345dbf586dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f6d6c53e06ada97d73329dc360393e493dae399f8f669efc1f0099e17192d898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb156348e3350bec888a272bd31a5fb113585432ec3c3276fdb05c6561169eb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded733a845f66010ff47249a502d406038cff2a6ddd17886e3e4c11290ae9b1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:250cc6648ef7fbb6c209f83805e7cf2a16ff8fb98725c6945df9f085998cbb05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ede52be80704a7476d14516577b8d62192f938a2451d8f5e5e779d1fc75f1dec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b344dbb131f5546c6c4f23332368e05c759c0a301be63fa95185724e34d16fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6abf8009d5cbf395ec36ba465aab3d5ba641bfbab940a949a4c98577844735ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee5d5c88c5de5ecd3c2105a159c1313b15cf3437593c6d071bef1d622a8d8d3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4dc7042fb07030a20b8349fe31120d08156be5257e4ed272666c061cbc40fc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddd95d0cc09f558e8f3defa1ac0396d56b02964530404e99813200c0afd4633f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf036d6391b68c2c61456c5adac015dfc959f11c3000529268607f16c3d9568",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25e7ed20f6efd972d534e32b295aced111b8f47f3b788b43832d69b3655b89eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47c1c0854206fb50fa5a933f621642b2b304da3bc8a5b0b462ff751457073645",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c471712a2998682347e1680ef1d5a652b48c12502f19e8d39354c4083af91d8a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ebad7b53812d4332a27e9a5cb0d42e2e063ef475deb0d270db3c186313ca233d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f7e37418823a9bfd3257ee05233109aee8b47e0fff84e274da8d39ffb381576",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5db608d8fa06570129e0278ce0af77300e4677fb201668b64131d97dffe2da36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e33050f1d6ff44a889213a947f6bc9f905336d4d89723ee6a50a51fd8ac10d9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:229d197810a5e64665283e0f2e1b4268f4dc7514fff803e99c1b862201d6d827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b2d309ebe0f57e515b402130cd1b63e412798deacd0118c10cbb2320bfd6eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2633fba63aecad94afd7eab596f5d4971c483148168114a58e633bcfc386663",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd10dbfb5b6bb286cac3d50e6dc187e1b2ae48df6798fea19a59387d53a34308",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:895cce126d2da91e85900c7a83d85a9978b2e29f2e9a6d611185f77f90d886c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f58c30365cc31d0b5f8013a8561417d58d5c7682f4a075cbb2ecb9c6b8f9bb25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9025dee2752b6bd4138e19f856a05a0f1a68347db49e1fbb47a2b61ffaf937d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f12d5e9f0294047cbb3a07018df31df5a6eeac754fe8e6b4a21749a5c6f8acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5a39fb33423ad80829a270cc8e340d0f0bb2b27e1b5c84235eb76c56d3462df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b9fc73f981a4f89886a1ab4629be179b738b7dbb1f2c29c30cf169f24666ddb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7e7d3793988a51ea308b7e9bf9882fa35d1b44a27da67e64c4b5a6eed34f792",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a73b3d5a5f472d8347a2f858a0061e3f338323dd962d5293b2d0982db9f20bee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c241cc7b92bbd88e05ce015efd2c3777c49590d4e2a914aed79942ea9226ab05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3fc4908c11bf3f85bbf51a14a79d4bead80ae7035cae607f7580ba7d7dad58a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ed93771948eba20a48a5c824079710be94d927aeaf7c2d0db1a5a402b2eb923",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e169c14f3c544cd0355633040eaee3ebeddde31bf022ab2d4441db084c5779b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4769356b15d8811aa64813bcf6ee63547d60c97162f0cea7a22970f3467f937",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d4f57d5d26265b3090e6ede9efb9f2bc3996e9032f6693e60fe02cb5d9a6a58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:330e209e3700c12717c686796717e947796c71d914bb32719ab7213e556b642c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "legacy": "i386-pc",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.19.3-300.fc37.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "ext4"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:002eb0cd50f7f38dad54f2fb4cb1fc445c7ae0d320d11201f43f582c12e17a8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libreport-filesystem-2.17.2-1.fc37.noarch.rpm"
+          },
+          "sha256:0129362310d1fc9a4faa7300888eb6a476d1568f3ec5b4f144cb42fb4a6183e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-libs-0.187-6.fc37.x86_64.rpm"
+          },
+          "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm"
+          },
+          "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:01a2ac7dc3829b47eb0d188909175b806a1e93eb1aefad2737f8fe07e42972e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:01ae93cdb80ef99a9dcf56ab6e1929d78606bd345fe7189a3a7d00921847c36f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssl-pkcs11-0.4.12-1.fc37.x86_64.rpm"
+          },
+          "sha256:01bf6ae14456eda9a669b2b754b496e9ee1a79d18d03276b9baec216757df054": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-3.11.0~rc1-2.fc37.x86_64.rpm"
+          },
+          "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:03d7cdfdb9e52782ea8487823da1d8a33fc217875f28bda20e26f4392be2c705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:0545bc486067591d26070790405beb3330dbd5cee3deecb2a5b654bb1965d64f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/oniguruma-6.9.8-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:05c35c69329756f69abf8520f3be0a831f59018c69f4b3b987e1ebf1122162e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dracut-config-rescue-057-2.fc37.x86_64.rpm"
+          },
+          "sha256:05c442df8e338070106f86ed4762397a89c5485c72d6796f97535ec3b7f3c816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm"
+          },
+          "sha256:05c9e1a8abff915edbb2f793d8998338e7667d9690dd7ee8f332752a0950f844": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-loop-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:084350137f900095704a4dad7855c20cfa12fe540caca8b7db7fdc4c20218860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dracut-057-2.fc37.x86_64.rpm"
+          },
+          "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm"
+          },
+          "sha256:09bd56123cc38e0b6eca84a97848f3985caa421e0879345b89c42e726a19b49b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:0ab9c4b08aa61930f6c156d2c87584df182460396c7e03231b47778820f91d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:0b344dbb131f5546c6c4f23332368e05c759c0a301be63fa95185724e34d16fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-unbound-1.16.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:0bd6b3f97c370399de8aad7e37d1195d3be5f3aa66c3ab4c83eeb42e4cde23ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgudev-237-3.fc37.x86_64.rpm"
+          },
+          "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:0e69146d4bbb40be987bcef433b916503acc68c8c40fab2fdb2ed6b32be39aed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:11ef902abb560166f418e4f4bba230c7c5a3d0bf2f917fb771229fe923a767ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-repos-modular-37-0.6.noarch.rpm"
+          },
+          "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm"
+          },
+          "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:15dae5e79467e6f5155297b1cba8d9df68f92c29ddd55570caafdd115a602534": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:198166311dabedc62d80a332da8d32b63fa2e1ae9329c6f2cad0c96e83050072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssh-server-8.8p1-6.fc37.x86_64.rpm"
+          },
+          "sha256:19b7e1385a12e9196622d1549ebee9a2254656300a530a9abb824737950571ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:1baa8a7b21c0b7afbf606c4fe14ef95f68adf446f80caf4093756d187b05d134": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bash-5.1.16-3.fc37.x86_64.rpm"
+          },
+          "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm"
+          },
+          "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm"
+          },
+          "sha256:1d4f57d5d26265b3090e6ede9efb9f2bc3996e9032f6693e60fe02cb5d9a6a58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zlib-1.2.12-4.fc37.x86_64.rpm"
+          },
+          "sha256:1da1c93fd682aa10d39362e393971ef6a0b5a9fd62f3b24d75b14ef1004843c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bluez-5.65-1.fc37.x86_64.rpm"
+          },
+          "sha256:1e14f25f5cdbbb523cfc3f7381b8c053a26f05f61666fb1f86fecda50d3764a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:1e857999c674a0a6154074042c3864c6e8e7411ee6da3e4cb41c7760177b8b22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libssh-0.9.6-5.fc37.x86_64.rpm"
+          },
+          "sha256:1ef037a08f8b410305c305d9b77497d7fc557b66dd08927d31ba4beffc3faa1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:1ef4c02f8aa95c12ccf7c7708c8a6e9031efbbf76cf3c1d533ae80dd5444abf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pinentry-1.2.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-identity-basic-37-0.12.noarch.rpm"
+          },
+          "sha256:229d197810a5e64665283e0f2e1b4268f4dc7514fff803e99c1b862201d6d827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:22aad91a73901b4723ca1b6e97fbdc3a919139be73c758e6ff0f04767d2cc1f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-runtime-0.21-18.fc37.0.20220203.x86_64.rpm"
+          },
+          "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sed-4.8-11.fc37.x86_64.rpm"
+          },
+          "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:24674d92e5dbd7116d11b50ce3af5fa90122fa73c57b0be94784c3e732def97a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-part-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:247002230874dd0c449145d4e8f92d3d5d879a41ba2e50a67c5b73f4cff6e405": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ipset-7.15-4.fc37.x86_64.rpm"
+          },
+          "sha256:250cc6648ef7fbb6c209f83805e7cf2a16ff8fb98725c6945df9f085998cbb05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-nftables-1.0.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:25e7ed20f6efd972d534e32b295aced111b8f47f3b788b43832d69b3655b89eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-common-37-0.12.noarch.rpm"
+          },
+          "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-common-1.14.0-5.fc37.noarch.rpm"
+          },
+          "sha256:278bfd824633a3c49357342679e9dd5864a33bcda5d25986bf3e6030bed4987e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:27e762ebbb816ee1fb731cfc81df32846bec48933e5540daa53509a379196d7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-minimal-langpack-2.36-1.fc37.x86_64.rpm"
+          },
+          "sha256:28d630dae78579725857e2242ce2ce01e6748a20c538554a36b628157a7ea1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/inih-56-2.fc37.x86_64.rpm"
+          },
+          "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm"
+          },
+          "sha256:2aac86cd8a7197d3ce75797501dfd5ff3bd77b3c92f9c975e63efabd5e941d1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:2d4fa9fa98c029560b4cad221eae6825f87c8191ce54b3a374ebb9edd0b0ffa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcurl-7.84.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:2e5281196fd18f90f4204d2104354936cd8f6fa88c209638f690134e61572b5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nano-6.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:2e91182e4edc4ef94e52da5532527549f692184213ca0257dfb8cb1f2c3ed163": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/plymouth-scripts-22.02.122-2.fc37.x86_64.rpm"
+          },
+          "sha256:2ee54c169df955389d600c8990969e809407dabf087a05111da9ccbf16cfec4d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmaxminddb-1.6.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:2f12d5e9f0294047cbb3a07018df31df5a6eeac754fe8e6b4a21749a5c6f8acb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:31493b05b4a053487e4418a7f663b50b801e4f3d557c6245ebb8c32e3cd12db9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_nss_idmap-2.7.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm"
+          },
+          "sha256:31f31f6f1bc19d4137d15e8a434cc6aeea959f875ec94c2cb3f50346071570c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ipset-libs-7.15-4.fc37.x86_64.rpm"
+          },
+          "sha256:3253a8869d584382e519cbe6576f39bf6a81bbf55aabd1f6befc23f5a3ba74bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glib2-2.73.2-8.fc37.x86_64.rpm"
+          },
+          "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm"
+          },
+          "sha256:32e67e6a70e493c52515626820cef9d3df6457f111004483fe6a8657255f4ba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:330e209e3700c12717c686796717e947796c71d914bb32719ab7213e556b642c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:352231cb2c4b6c7de0797b83020df840390d83654c642fcd40c586701c2c81d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcsc-lite-1.9.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:364011baa5e293baae2e60992fd1241f6c822d7c7e48c259d3e6abb0530036af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:3845db664d89151f8a07f465f734705eaeb76c242c58866f91045db46f63b650": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:393cc43a853a2f5f391d133acb032b0a50d5070aca8bd3ec132d949b6af157bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:3b9fc73f981a4f89886a1ab4629be179b738b7dbb1f2c29c30cf169f24666ddb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/unbound-libs-1.16.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/polkit-121-4.fc37.x86_64.rpm"
+          },
+          "sha256:3e23f712d3b15bd50bb12b01f209bad2bcc316977a1c45994711932447bc4262": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-pc-2.06-52.fc37.x86_64.rpm"
+          },
+          "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gzip-1.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:3fc4908c11bf3f85bbf51a14a79d4bead80ae7035cae607f7580ba7d7dad58a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm"
+          },
+          "sha256:40bdee106c7d9df3c4b2a39289b247635450d763fb84cd5e63e2493f9519b58d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:4270cd73a7289c58ea736423756b244237b545d5523ba34b129877cf6443e06f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-tools-minimal-2.06-52.fc37.x86_64.rpm"
+          },
+          "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:47c1c0854206fb50fa5a933f621642b2b304da3bc8a5b0b462ff751457073645": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/shadow-utils-4.11.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm"
+          },
+          "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grubby-8.40-66.fc37.x86_64.rpm"
+          },
+          "sha256:4a50276d2a8bd7f2b16cbdf6592ea365c19fa9f9bd33b5cfa1ab4bbd5ca89c69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm"
+          },
+          "sha256:4a95497e1a387d05a6be065f4ae95f251f420c65901b5adbbd98765b361dd39d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kernel-modules-5.19.3-300.fc37.x86_64.rpm"
+          },
+          "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm"
+          },
+          "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-repos-37-0.6.noarch.rpm"
+          },
+          "sha256:4cdba0d602a32cb4b90461bd7dbdfacf0bc30f63ee5dd8f460d5bee3dc4cb586": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:4d716aa1b01fb350f5c7e7534b9b6c4eca03aa359e12492787debee6ac7e5d72": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kernel-core-5.19.3-300.fc37.x86_64.rpm"
+          },
+          "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:4df07c734a7b4135d6b5dd73f72cbc188763a09457f3bf24f893fc178fd89d9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm"
+          },
+          "sha256:4e88be19e5a5ae7f2b310f52470c454979a5c6627325e2e528a38360bb5e4655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/popt-1.19~rc1-3.fc37.x86_64.rpm"
+          },
+          "sha256:4ed93771948eba20a48a5c824079710be94d927aeaf7c2d0db1a5a402b2eb923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xfsprogs-5.18.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:4fc2b6910a5c954f8ef9c89e6ccb09df3a66ce5a323075775f65366ef649db95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:51b17b885344823eb7d581edd0b09082f193c728f3c806138ddc4bdcd9bb059b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-util-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:52a60aced835f862b077e74808f17124aad5bdfe79f42dba7d7983577c6614b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgcc-12.2.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:52fb4dc0ad2f889ace412f7b05b2a5827a3eda8bfb9179fbe7cb393dd0d88dd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/librepo-1.14.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm"
+          },
+          "sha256:558476ce7be43951868fef0c6216a99ff0a5ecfbb69e68785172b3a9a627b28b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cpio-2.13-13.fc37.x86_64.rpm"
+          },
+          "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:57b0cbd11daab17a9b9486f89545407de965d26029938e991f1aefdaf0e48614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm"
+          },
+          "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:5972f3f4f85193b67865db97e5e6e706d431d272f207a434d6b2102e153b5baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nspr-4.34.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm"
+          },
+          "sha256:5a980a3db08191299cb1ae9640a924fce3631d34a7a931ba34b0a44daf2b53c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-unversioned-command-3.11.0~rc1-2.fc37.noarch.rpm"
+          },
+          "sha256:5cf036d6391b68c2c61456c5adac015dfc959f11c3000529268607f16c3d9568": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:5d13d18388dda2d493b0883d2162e0a6a832cd652b8186552425eb92fba608e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:5db608d8fa06570129e0278ce0af77300e4677fb201668b64131d97dffe2da36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sssd-kcm-2.7.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:5e748380f1796e2a7be2137cecd8a1662fcdfdbc858d27b218c931350e296240": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnftnl-1.2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:5f26f097818a1eeb5bd4b9a97dafd97dd8793f9bf704ff9467129701e03479ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:5f62a59f67418dedf7b7de1d267a685e4e4d0040851dd1da706dfd5cdcd37c38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-fs-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:5fd8bb0bc2edd80b13c0d3ac38cf26b1ad94736fbf1b4b37ee6433772d6f18e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:61e84444fcf3f76d3268b356e5b29f251a966d57ce043c8c5e0c1491179b7023": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libuser-0.63-12.fc37.x86_64.rpm"
+          },
+          "sha256:62df028d47d6465b65db421089805f8da363980b3e2425d21de7561a69b967ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/audit-libs-3.0.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm"
+          },
+          "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm"
+          },
+          "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:670528275ca6b3371e35c5c79618da004ffaf999fbf8b29f14c3fa21f701ab5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/plymouth-22.02.122-2.fc37.x86_64.rpm"
+          },
+          "sha256:688c033cd1c7b39b918c215af5480de238c16be94b72086ed4efc34dd6201b80": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmnl-1.0.4-16.fc37.x86_64.rpm"
+          },
+          "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:6922ba2992ea7c110f49eda9b1fa7da61165d35b23d03d42db07a770c57fd096": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-2.36-1.fc37.x86_64.rpm"
+          },
+          "sha256:69ca0883e3929168bc8eb555463ae051fc38afedae0fa98d566bc22388304a91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm"
+          },
+          "sha256:69ff7199c3b6dd205c09022bbc598851e21a9dd192ab5b63a7f25fbe706933bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nvidia-gpu-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:6abf8009d5cbf395ec36ba465aab3d5ba641bfbab940a949a4c98577844735ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/npth-1.6-9.fc37.x86_64.rpm"
+          },
+          "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm"
+          },
+          "sha256:6f7e37418823a9bfd3257ee05233109aee8b47e0fff84e274da8d39ffb381576": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sssd-common-2.7.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:72b2fbe65f24fa2dc41109cb0bd47b0962824847ac802a3c0160d832ee1e75f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:7324e7200eb3c740bd9a836cb99f1fe6c6842a716c865309c61897e866f3e111": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_idmap-2.7.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:73cacc81fbf8f6a632b05ca5880f51e245fbdaa92ca590a5dc153196714f44bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dhcp-client-4.4.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:744cf61b729b0516567b9e622244f21d7dc6d44c35bbc507e5ae1b49f791e7df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nftables-1.0.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm"
+          },
+          "sha256:77798df08cf783df929249944ed44ebe8ecf1e2eaf7a12e0aea5657b78612e13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnghttp2-1.48.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:7983ac68f01f7ff72010401d03584c226d3c55fdddaa4c900a562494e470cad9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:7b2d309ebe0f57e515b402130cd1b63e412798deacd0118c10cbb2320bfd6eaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-251.4-53.fc37.x86_64.rpm"
+          },
+          "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:7c813e74f44061f164236a0bc1d5e3e2aab1ece94ad2b190213b90c407c95cd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgomp-12.2.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:7e169c14f3c544cd0355633040eaee3ebeddde31bf022ab2d4441db084c5779b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/y/yum-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm"
+          },
+          "sha256:7e8a30665f945fa47886a9f147b43f6db0db0f0f104f20e8b1301035b9de0b2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-libs-1.14.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:8053eaf425c8bf14a476049eab59e586dd2d6fef458bf8eeb27ad661fdaf3d0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/intel-gpu-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/selinux-policy-37.8-1.fc37.noarch.rpm"
+          },
+          "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pigz-2.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:840438421f3c7e28e49fa1327480ff7eb7780bcdbf605caf35ec0115bf4d7d9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/h/hostname-3.23-7.fc37.x86_64.rpm"
+          },
+          "sha256:8622f18e1c13db40256d25c5c01b191712ea703407343ea52289ffe07a486833": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxmlb-0.3.9-2.fc37.x86_64.rpm"
+          },
+          "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm"
+          },
+          "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-common-2.06-52.fc37.noarch.rpm"
+          },
+          "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm"
+          },
+          "sha256:895cce126d2da91e85900c7a83d85a9978b2e29f2e9a6d611185f77f90d886c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-pam-251.4-53.fc37.x86_64.rpm"
+          },
+          "sha256:89ac04873c24d8d89c1b60e5cec35544756507fb1be2c2556b92af8bdfcc2a7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:8ba1fb96a5e6b78dde962d5b9fe97726a393c977e9a9106e896dceeefffc6472": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libndp-1.8-4.fc37.x86_64.rpm"
+          },
+          "sha256:8c864716f0efc6e66f2819dea425a34913d4d1a7e56d7a890d254202caca4f49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-0.21-18.fc37.0.20220203.x86_64.rpm"
+          },
+          "sha256:8d45acd2ae98e922732fc9c4966c3bb8d570f4185122d766a83199955b96cad7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:8dc6f57f2942758833a5e08295e8b83dcd285b35700d28e79f5e34ed02b3e97d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-1.14.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:8fb56b6d4ca6cc84bfb896275aaa0c397bad50a39e0fa36bf6739e1f1968115c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-common-2.36-1.fc37.x86_64.rpm"
+          },
+          "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nettle-3.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:9025dee2752b6bd4138e19f856a05a0f1a68347db49e1fbb47a2b61ffaf937d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-udev-251.4-53.fc37.x86_64.rpm"
+          },
+          "sha256:903761fe0e670a53194e1e5e976bb1edd914258103d01583f1c89fa4d36c9730": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/protobuf-c-1.4.0-6.fc37.x86_64.rpm"
+          },
+          "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:911355f71b817f8fba1c98169646759d85f2d20a6d139f54cd46b4664b294529": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gdisk-1.0.9-3.fc37.x86_64.rpm"
+          },
+          "sha256:91daae949ff91b3d96865ee10b99376b9db82bf62d4ee77123572345dbf586dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-hawkey-0.68.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:932abcd232d522bb508daa2c9e6f4a3ea79039ad80a6478e6384d517c1d6698c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm"
+          },
+          "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:9549982392bd6cd0c8fbcaab7a672bc94aac048f3f20a5c98fea083866748c47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:9577665c819179202b3439b7be4c69052df5ed79c9812be5ebb51fcbdfc8330f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:960633a9035f8fe02d49ba6713f240363383d5dc3b3f862d28e9b211fd34fea3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iproute-5.18.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm"
+          },
+          "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:9cf89d7e274a5ddf55fc4b97974c7aa33f50379c8ed50f6cb458b7286c89af7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iputils-20211215-3.fc37.x86_64.rpm"
+          },
+          "sha256:9ec2fe94d7573b61068710179c7588dec264198fd55a04247bb1cf9a1f925cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm"
+          },
+          "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:a09f4ad48459bb38de836dc6eb974c2c2bfe5581e6cf682d81f2a64d55f20738": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gobject-introspection-1.73.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:a1c518fabdd55099686918e292d1cbf29adca46d1a83baace30066ceaf93b86c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:a27d291b03476f2e041cee4b0c91eebedf31a4d13cc2ed1030eaca5f77f93ddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/linux-firmware-whence-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:a2fafeb3f4035726e27a0039356164e1d732d0e870e2c4314869ebd80b71236b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-libs-0.21-18.fc37.0.20220203.x86_64.rpm"
+          },
+          "sha256:a58f6a4a83359244206dc707b6bf891468604ddc169ba4e29b628b96d3004f74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-sysinit-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:a5d3c81dc359adc676afc9044743aeaf8fbc924e019b093084035413716e78f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:a73b3d5a5f472d8347a2f858a0061e3f338323dd962d5293b2d0982db9f20bee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/v/vim-data-9.0.213-1.fc37.noarch.rpm"
+          },
+          "sha256:a76fb459232b71b8a991531c1b58ec93f4099281451e258964f53f1864a1c530": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libjcat-0.1.10-2.fc37.x86_64.rpm"
+          },
+          "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:a85fbcff4bbac0e5f92bccfdde601d8cfe7a43677b7a328b9b265304de380654": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgusb-0.3.10-3.fc37.x86_64.rpm"
+          },
+          "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm"
+          },
+          "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-2.48-5.fc37.x86_64.rpm"
+          },
+          "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/t/tzdata-2022c-1.fc37.noarch.rpm"
+          },
+          "sha256:ac17caddde45a5f9f2d5f894476cd82e799c8f52c6def22d2e8f2e0033050453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-softokn-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ac84aded77545e1725104e25cef9ef4c6389567f551042fe57a05dcd19b40636": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/audit-3.0.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:ad14549b59bcc2c3c2ed6152c0a3a2d4aebac3ae06ab5dc451659060f380624a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/jq-1.6-14.fc37.x86_64.rpm"
+          },
+          "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:adf559f274af1e1a4facb1cc93e3840e83ba429513df55bdb79baa6508423e42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:ae1fef40fd8a0c5bf8c4aa74625119132b9564fabe2d84ae7856b39805b014d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:ae32085526ec5234ac837ad5d39ce75d0dd106be3f0a8be975da5103b0b351f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kernel-5.19.3-300.fc37.x86_64.rpm"
+          },
+          "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:b4b47992384c822ee021452275896dfebc302ccf9f054d5d6975a364214d4f9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libjaylink-0.3.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kmod-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:b5b4e759d1c56188fb777926de0d17498c25d3234d2635ce5a8e7b000bfaf7f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm"
+          },
+          "sha256:b5cd8989ab70e06e0246ed8668d9553155ae48355059a200ca016cf7c1251930": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/curl-7.84.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:b772806fa1412ba843d87d2a84ed9c087880f3c9e7ded3f6035718f83888efbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:b776d46067bf44c37801e19b243572feb26aae0fee721e061207a80873da1f46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:b7805e9ea70864f34883cdee1cede47fa95f8a1150f37575574190e076aa322e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssh-clients-8.8p1-6.fc37.x86_64.rpm"
+          },
+          "sha256:b7e7d3793988a51ea308b7e9bf9882fa35d1b44a27da67e64c4b5a6eed34f792": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:b853538a9e367a6a0da999f2ba2e7ae83af6790a3b04b5e47495fede61773367": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_sudo-2.7.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:b99c481853fd3a81ac704283154d0323b621d4c799cd15db8021d5ee4f48bf2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dracut-config-generic-057-2.fc37.x86_64.rpm"
+          },
+          "sha256:ba23ecf289572c7a1f3907b8bfab88630d00ca25d427156ed5a1ffa010ff5203": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-tools-2.06-52.fc37.x86_64.rpm"
+          },
+          "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:be94dbe638c7e0a02fbc9bc73355dff9bea812d87b72eb45c1e7b75ef731b42a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libstdc++-12.2.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm"
+          },
+          "sha256:bfc36b54dc5cfe21316477f9e519194909fe3978c238d1f5f4c283ef4f90f7c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-gconv-extra-2.36-1.fc37.x86_64.rpm"
+          },
+          "sha256:c053d341934e4853cca55b47c49e30df6be74535fe29b48db00a0fef355958d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libicu-71.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:c1698a5eace8302ba8cd5b09c23b4c8d2ca4c9647a83ef92e03caed5ff066fa0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:c1dc9df91a970ceb98bc7b68b5f71234f0191e3e4bc4dd7f084b65cb4e12465e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-swap-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:c203ba66a8da80ad3f21305dd932073c1ede06cfa2d1b267ccb28089596094bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm"
+          },
+          "sha256:c241cc7b92bbd88e05ce015efd2c3777c49590d4e2a914aed79942ea9226ab05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/v/vim-minimal-9.0.213-1.fc37.x86_64.rpm"
+          },
+          "sha256:c2abbcca2ad0d7d7505775c9d5fc8dd34a89f87a27a3e2c770cb91632000021d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssh-8.8p1-6.fc37.x86_64.rpm"
+          },
+          "sha256:c3a162d4a1623457f74522f944f27c037e3ece7094e4497b1e09339851e726fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-utils-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:c471712a2998682347e1680ef1d5a652b48c12502f19e8d39354c4083af91d8a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:c5efb96c9ce79c98fae0297f5fc2d6740a5f2c167d64020d18876d9e842e8d32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libdnf-0.68.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:c70e5ab3e25d6f78c9bc66d0f6b3a7f33457a63c2a17cd15efeb5ca6a0023c62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:c8057ff6e5fa3339726c83173fdd11898b5f7545e72d81503f8c6660c4404885": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/file-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:c966372c322648dcf3e0b84dd0a7bdb92031270de243640739cb5c735cb6cef1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:cba7fbe4f72489a2fb27429ecfdf8b0177ac8cc4fa30aa7baaa8ce1a0dc4f5ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/parted-3.5-6.fc37.x86_64.rpm"
+          },
+          "sha256:cd10dbfb5b6bb286cac3d50e6dc187e1b2ae48df6798fea19a59387d53a34308": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-networkd-251.4-53.fc37.x86_64.rpm"
+          },
+          "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm"
+          },
+          "sha256:cf997d2d6fa655ec7e03fc58769e29770409254861d75c3732fcd9a264cc2820": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:cfe83a7faa009718f0ca5d9cafa5d61e4aa6cb4e439fdf2a9d3209d8057dc323": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-pc-modules-2.06-52.fc37.noarch.rpm"
+          },
+          "sha256:d2633fba63aecad94afd7eab596f5d4971c483148168114a58e633bcfc386663": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-libs-251.4-53.fc37.x86_64.rpm"
+          },
+          "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-37-0.12.noarch.rpm"
+          },
+          "sha256:d3a06680422d09103dc2f602376da3708751695bb23ad947adce07275236e263": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.x86_64.rpm"
+          },
+          "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:d43e7cd6fe9faa738384509be775d4867c11f3ee199e7c06daef69e86b517c57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_certmap-2.7.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:d4769356b15d8811aa64813bcf6ee63547d60c97162f0cea7a22970f3467f937": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zchunk-libs-1.2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:d4bbb0584a1be90d64cdcd12a5712b9153ead35cf68b1431b1bf8159bfe77b5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mozjs102-102.2.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:d53b6b5f20e16b95bdf743f3962f45911577e1a483c756971405f5ef0506772f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/man-db-2.10.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:d62eec866919cfc099ea008e165effa38edd53c0489deb121d39839cc30a3e92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/linux-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:d71c5fc0e75b48b330cfc391920b8b2dd32c5c844202ba134172a31630a29460": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm"
+          },
+          "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm"
+          },
+          "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm"
+          },
+          "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grep-3.7-4.fc37.x86_64.rpm"
+          },
+          "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/json-c-0.16-2.fc37.x86_64.rpm"
+          },
+          "sha256:db2088f9a2f250d9e1c01c85dc9cb3fef32788d92ac2be2beb6c6f6bda85ce5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/NetworkManager-libnm-1.39.90-1.fc37.x86_64.rpm"
+          },
+          "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:dcdb39155a419f86e3070329e0c9ef19f1c6b605bad1e7af9309fcaf8d718195": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm"
+          },
+          "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm"
+          },
+          "sha256:ddd95d0cc09f558e8f3defa1ac0396d56b02964530404e99813200c0afd4633f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:ded733a845f66010ff47249a502d406038cff2a6ddd17886e3e4c11290ae9b1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-libs-3.11.0~rc1-2.fc37.x86_64.rpm"
+          },
+          "sha256:dfbe63bdf373f8a141954f84aff98d3f044ba936c80e201c4755efcc6b1a9d82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:e0cc982fbdbd002b3028706e3fbfff6c030b751e3fd4e98122db123346f13441": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-mdraid-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-gpg-keys-37-0.6.noarch.rpm"
+          },
+          "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/polkit-libs-121-4.fc37.x86_64.rpm"
+          },
+          "sha256:e33050f1d6ff44a889213a947f6bc9f905336d4d89723ee6a50a51fd8ac10d9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:e39ff78d65d980546c9b1d0e33d19854888cc70bf000e3a160b1fd327bf25c77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-envsubst-0.21-18.fc37.0.20220203.x86_64.rpm"
+          },
+          "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm"
+          },
+          "sha256:e56dc2a37766276593c4f40c9d588defc5ba66ab29ae90ee03480c8bcfba459b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:e58c18b53a81e8ffbe7b2998a8ac97f6b8fcbeec73929c1f4838d61d43a6be15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-crypto-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:e5a39fb33423ad80829a270cc8e340d0f0bb2b27e1b5c84235eb76c56d3462df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/unbound-anchor-1.16.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm"
+          },
+          "sha256:e627ce0440ccdb69f21d5928df87182b42655ece611c7bd9073b1f80a76b38b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/plymouth-core-libs-22.02.122-2.fc37.x86_64.rpm"
+          },
+          "sha256:e6ab731e69c9782e4b5b733145949214f01999692c724781e35512606bcffe56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/NetworkManager-1.39.90-1.fc37.x86_64.rpm"
+          },
+          "sha256:e733d49496689131148b00a233229e484b5b622f9cb8c230230a05117763065e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/passwd-0.80-13.fc37.x86_64.rpm"
+          },
+          "sha256:e73a0ffebc89d0f00df64fb1556f632eddea245eaa5254c8d76cc9bf85117cd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm"
+          },
+          "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:ea37bbc4022aa6e266e0ec601d97620574c12c8b898b3ffb8ae8baffe553745f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm"
+          },
+          "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm"
+          },
+          "sha256:eb156348e3350bec888a272bd31a5fb113585432ec3c3276fdb05c6561169eb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-libdnf-0.68.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ebad7b53812d4332a27e9a5cb0d42e2e063ef475deb0d270db3c186313ca233d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sssd-client-2.7.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:ec583a673d3ba649d69246fc67455f01c2431bc8e80b14b724117ce709b317ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/readline-8.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:eda13519d50710e3566c367510bcc69178609af0b30cfe9074082ee10de2fee1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:ede52be80704a7476d14516577b8d62192f938a2451d8f5e5e779d1fc75f1dec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:ee5d5c88c5de5ecd3c2105a159c1313b15cf3437593c6d071bef1d622a8d8d3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:f03d62bf2ab0c2606a64a4326934765ae6d25afabe7cc7b77e44445c49fa4ac2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/less-590-5.fc37.x86_64.rpm"
+          },
+          "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/w/which-2.21-35.fc37.x86_64.rpm"
+          },
+          "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm"
+          },
+          "sha256:f31a8421c338393c824e461b49ae05a3f8c9350fed2347aa8de8df00dcb94631": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-libelf-0.187-6.fc37.x86_64.rpm"
+          },
+          "sha256:f3d72ee9f04141387d75d3e8ec9fe3a720ad40eaa815ffcb9e18f5e98e2353d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:f46592a35c4569e5d32364baa37081e1454761043a873e3ee20067ce5409a85a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm"
+          },
+          "sha256:f4dc7042fb07030a20b8349fe31120d08156be5257e4ed272666c061cbc40fc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:f52405026bce203a5a1dd62b533f9e6c61a68bba6271d2f7de3948dcb1a47fd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm"
+          },
+          "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:f58c30365cc31d0b5f8013a8561417d58d5c7682f4a075cbb2ecb9c6b8f9bb25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-resolved-251.4-53.fc37.x86_64.rpm"
+          },
+          "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:f6d6c53e06ada97d73329dc360393e493dae399f8f669efc1f0099e17192d898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:f70b262c317b0a012fbe1fc1239f7972da097c45e15075c8165b26069a7f7267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:f72a06635024c2bf9f43768aa3296f4f00d8dac3862e8f880bec360e56e2bb87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libksba-1.6.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:f863051b731a75ea7443c096b1a0e236fa4b285b08b3dd7175d68c228eea1dbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/selinux-policy-targeted-37.8-1.fc37.noarch.rpm"
+          },
+          "sha256:fa30a837be5cce2abf071c4afead1af95faf7d87c05e390404aa0de3b10b8046": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dbus-1.2.18-5.fc37.x86_64.rpm"
+          },
+          "sha256:fd584aa1a20378403d9253726ac23d78585f95155da02473aef9904460564912": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kbd-2.5.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:fec9c3bbc378c458dea2ec3e8da500d6f3278d723cc94d8a27a1d0259ea3c89e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/amd-gpu-firmware-20220815-138.fc37.noarch.rpm"
+          },
+          "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/audit-libs-3.0.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:62df028d47d6465b65db421089805f8da363980b3e2425d21de7561a69b967ff",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bash-5.1.16-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1baa8a7b21c0b7afbf606c4fe14ef95f68adf446f80caf4093756d187b05d134",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:a1c518fabdd55099686918e292d1cbf29adca46d1a83baace30066ceaf93b86c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/curl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b5cd8989ab70e06e0246ed8668d9553155ae48355059a200ca016cf7c1251930",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm",
+        "checksum": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-1.14.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8dc6f57f2942758833a5e08295e8b83dcd285b35700d28e79f5e34ed02b3e97d",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-common-1.14.0-5.fc37.noarch.rpm",
+        "checksum": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dracut-057-2.fc37.x86_64.rpm",
+        "checksum": "sha256:084350137f900095704a4dad7855c20cfa12fe540caca8b7db7fdc4c20218860",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:d3a06680422d09103dc2f602376da3708751695bb23ad947adce07275236e263",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-libelf-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:f31a8421c338393c824e461b49ae05a3f8c9350fed2347aa8de8df00dcb94631",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-libs-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:0129362310d1fc9a4faa7300888eb6a476d1568f3ec5b4f144cb42fb4a6183e8",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-gpg-keys-37-0.6.noarch.rpm",
+        "checksum": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-37-0.12.noarch.rpm",
+        "checksum": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-common-37-0.12.noarch.rpm",
+        "checksum": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-identity-basic-37-0.12.noarch.rpm",
+        "checksum": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-repos-37-0.6.noarch.rpm",
+        "checksum": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:8c864716f0efc6e66f2819dea425a34913d4d1a7e56d7a890d254202caca4f49",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-envsubst-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:e39ff78d65d980546c9b1d0e33d19854888cc70bf000e3a160b1fd327bf25c77",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-libs-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:a2fafeb3f4035726e27a0039356164e1d732d0e870e2c4314869ebd80b71236b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-runtime-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:22aad91a73901b4723ca1b6e97fbdc3a919139be73c758e6ff0f04767d2cc1f5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:6922ba2992ea7c110f49eda9b1fa7da61165d35b23d03d42db07a770c57fd096",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-common-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:8fb56b6d4ca6cc84bfb896275aaa0c397bad50a39e0fa36bf6739e1f1968115c",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-gconv-extra-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bfc36b54dc5cfe21316477f9e519194909fe3978c238d1f5f4c283ef4f90f7c1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-minimal-langpack-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:27e762ebbb816ee1fb731cfc81df32846bec48933e5540daa53509a379196d7d",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-common-2.06-52.fc37.noarch.rpm",
+        "checksum": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-pc-2.06-52.fc37.x86_64.rpm",
+        "checksum": "sha256:3e23f712d3b15bd50bb12b01f209bad2bcc316977a1c45994711932447bc4262",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-pc-modules-2.06-52.fc37.noarch.rpm",
+        "checksum": "sha256:cfe83a7faa009718f0ca5d9cafa5d61e4aa6cb4e439fdf2a9d3209d8057dc323",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-tools-2.06-52.fc37.x86_64.rpm",
+        "checksum": "sha256:ba23ecf289572c7a1f3907b8bfab88630d00ca25d427156ed5a1ffa010ff5203",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-tools-minimal-2.06-52.fc37.x86_64.rpm",
+        "checksum": "sha256:4270cd73a7289c58ea736423756b244237b545d5523ba34b129877cf6443e06f",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grubby-8.40-66.fc37.x86_64.rpm",
+        "checksum": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kbd-2.5.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:fd584aa1a20378403d9253726ac23d78585f95155da02473aef9904460564912",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcurl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2d4fa9fa98c029560b4cad221eae6825f87c8191ce54b3a374ebb9edd0b0ffa3",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgcc-12.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:52a60aced835f862b077e74808f17124aad5bdfe79f42dba7d7983577c6614b1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgomp-12.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7c813e74f44061f164236a0bc1d5e3e2aab1ece94ad2b190213b90c407c95cd2",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnghttp2-1.48.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:77798df08cf783df929249944ed44ebe8ecf1e2eaf7a12e0aea5657b78612e13",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libssh-0.9.6-5.fc37.x86_64.rpm",
+        "checksum": "sha256:1e857999c674a0a6154074042c3864c6e8e7411ee6da3e4cb41c7760177b8b22",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libstdc++-12.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:be94dbe638c7e0a02fbc9bc73355dff9bea812d87b72eb45c1e7b75ef731b42a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm",
+        "checksum": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssl-pkcs11-0.4.12-1.fc37.x86_64.rpm",
+        "checksum": "sha256:01ae93cdb80ef99a9dcf56ab6e1929d78606bd345fe7189a3a7d00921847c36f",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/popt-1.19~rc1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4e88be19e5a5ae7f2b310f52470c454979a5c6627325e2e528a38360bb5e4655",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm",
+        "checksum": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-unversioned-command-3.11.0~rc1-2.fc37.noarch.rpm",
+        "checksum": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-3.11.0~rc1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:01bf6ae14456eda9a669b2b754b496e9ee1a79d18d03276b9baec216757df054",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-libs-3.11.0~rc1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ded733a845f66010ff47249a502d406038cff2a6ddd17886e3e4c11290ae9b1c",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/readline-8.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:6abf8009d5cbf395ec36ba465aab3d5ba641bfbab940a949a4c98577844735ba",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:f4dc7042fb07030a20b8349fe31120d08156be5257e4ed272666c061cbc40fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:ddd95d0cc09f558e8f3defa1ac0396d56b02964530404e99813200c0afd4633f",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/selinux-policy-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/selinux-policy-targeted-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/shadow-utils-4.11.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:47c1c0854206fb50fa5a933f621642b2b304da3bc8a5b0b462ff751457073645",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:7b2d309ebe0f57e515b402130cd1b63e412798deacd0118c10cbb2320bfd6eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-libs-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:d2633fba63aecad94afd7eab596f5d4971c483148168114a58e633bcfc386663",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-networkd-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:cd10dbfb5b6bb286cac3d50e6dc187e1b2ae48df6798fea19a59387d53a34308",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-pam-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:895cce126d2da91e85900c7a83d85a9978b2e29f2e9a6d611185f77f90d886c5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-resolved-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:f58c30365cc31d0b5f8013a8561417d58d5c7682f4a075cbb2ecb9c6b8f9bb25",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-udev-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:9025dee2752b6bd4138e19f856a05a0f1a68347db49e1fbb47a2b61ffaf937d1",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022c",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/t/tzdata-2022c-1.fc37.noarch.rpm",
+        "checksum": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "35.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/w/which-2.21-35.fc37.x86_64.rpm",
+        "checksum": "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zlib-1.2.12-4.fc37.x86_64.rpm",
+        "checksum": "sha256:1d4f57d5d26265b3090e6ede9efb9f2bc3996e9032f6693e60fe02cb5d9a6a58",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e56dc2a37766276593c4f40c9d588defc5ba66ab29ae90ee03480c8bcfba459b",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.39.90",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/NetworkManager-1.39.90-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e6ab731e69c9782e4b5b733145949214f01999692c724781e35512606bcffe56",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.39.90",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/NetworkManager-libnm-1.39.90-1.fc37.x86_64.rpm",
+        "checksum": "sha256:db2088f9a2f250d9e1c01c85dc9cb3fef32788d92ac2be2beb6c6f6bda85ce5a",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a9ca97b6dc978f2a3895963780b0a99c794e5db5ce3f18e16951449fb11c74c4",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/amd-gpu-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:fec9c3bbc378c458dea2ec3e8da500d6f3278d723cc94d8a27a1d0259ea3c89e",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/audit-3.0.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ac84aded77545e1725104e25cef9ef4c6389567f551042fe57a05dcd19b40636",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/audit-libs-3.0.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:62df028d47d6465b65db421089805f8da363980b3e2425d21de7561a69b967ff",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:74ee0b4664d9300b0538372064e74e1609f5bf89a4cef76c7849d774af7295cf",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:68e0f60ad19cf5f0f211f0e14b96b42db87806d9536eb05386cf9bf168891c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:38d1877d647bb5f4047d22982a51899c95bdfea1d7b2debbff37c66f0fc0ed44",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bash-5.1.16-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1baa8a7b21c0b7afbf606c4fe14ef95f68adf446f80caf4093756d187b05d134",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bluez-5.65-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1da1c93fd682aa10d39362e393971ef6a0b5a9fd62f3b24d75b14ef1004843c8",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:192808b88d6473b4bdb33ffe8aa37f2b01ca3e2b76d9b221db8a9eee1ab5d201",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:6e74a8ed5b472cf811f9bf429a999ed3f362e2c88566a461517a12c058abd401",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:558476ce7be43951868fef0c6216a99ff0a5ecfbb69e68785172b3a9a627b28b",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:97e2a8bdc663e7441d79696b35e1f28410f5fc993e5a0707049f328df83007ed",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:cd4d0c1b5490e1cee5e461b89eb1b1e7bb40c40de981cfd73ac060103a5c42a0",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:31af27f44c4a8d06068389731d3a5adc0fd45b1c8ce4d28163f938e68fa58cbf",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:55fa8740ada6c7ff268b7675350e7df41bf5652f3a110058c4c6d06c7ab986a2",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:a1c518fabdd55099686918e292d1cbf29adca46d1a83baace30066ceaf93b86c",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:15dae5e79467e6f5155297b1cba8d9df68f92c29ddd55570caafdd115a602534",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/crypto-policies-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:486a11feeaad706c68b05de60a906cc57059454cbce436aeba45f88b84578c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc37.noarch.rpm",
+        "checksum": "sha256:108dcc63b7aa387c1fbf2d3153b98447645c313132fea16e855b4549864f96cf",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9a9c9f908326ce672180964c0dee6a387fefce9f4e49dacbca87f4aa8bf1e31f",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/curl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b5cd8989ab70e06e0246ed8668d9553155ae48355059a200ca016cf7c1251930",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/c/cyrus-sasl-lib-2.1.28-8.fc37.x86_64.rpm",
+        "checksum": "sha256:4e0e8656faf1f4f5227e4e40cdb4e662a1d78b19e74b90ba2f39f3cdf73e0083",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-1.14.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8dc6f57f2942758833a5e08295e8b83dcd285b35700d28e79f5e34ed02b3e97d",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e5bbfce30b88c0b4f06c4ad0c80645cfec9c23248d7c734d76607d8bc500c43f",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-common-1.14.0-5.fc37.noarch.rpm",
+        "checksum": "sha256:26eee19e4c5be888dd7e171187ad5f641e1022bad613e84f66ccfd5e12ed79d4",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dbus-libs-1.14.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7e8a30665f945fa47886a9f147b43f6db0db0f0f104f20e8b1301035b9de0b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm",
+        "checksum": "sha256:9ec2fe94d7573b61068710179c7588dec264198fd55a04247bb1cf9a1f925cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c57831b8629e2e31b3c55d4f0064cd25a515d3eb1ac61fc6897ce07421a2e91b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:7c0f72217eacc9b5caf553c17cb2428de242094dc7e0e1dbd0d21869d909c7d2",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dhcp-client-4.4.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:73cacc81fbf8f6a632b05ca5880f51e245fbdaa92ca590a5dc153196714f44bf",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm",
+        "checksum": "sha256:f46592a35c4569e5d32364baa37081e1454761043a873e3ee20067ce5409a85a",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c1374e3372d0d246ecb0e04b36743e23c68ab307c7603c5a267fce654bf05cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:19b7e1385a12e9196622d1549ebee9a2254656300a530a9abb824737950571ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:3845db664d89151f8a07f465f734705eaeb76c242c58866f91045db46f63b650",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:c70e5ab3e25d6f78c9bc66d0f6b3a7f33457a63c2a17cd15efeb5ca6a0023c62",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:1ef037a08f8b410305c305d9b77497d7fc557b66dd08927d31ba4beffc3faa1a",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:de1990841523374112fb1962b414c6d34c0a008a0c2f2b36e733d3fa7f93aa31",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dracut-057-2.fc37.x86_64.rpm",
+        "checksum": "sha256:084350137f900095704a4dad7855c20cfa12fe540caca8b7db7fdc4c20218860",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dracut-config-generic-057-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b99c481853fd3a81ac704283154d0323b621d4c799cd15db8021d5ee4f48bf2a",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/d/dracut-config-rescue-057-2.fc37.x86_64.rpm",
+        "checksum": "sha256:05c35c69329756f69abf8520f3be0a831f59018c69f4b3b987e1ebf1122162e2",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b99e95ae8a2594ffdde2bcd10e4b3676c4b2ac9517d1f33f929e24be2ad03a0",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:631c5cdd65015cf905cf9c7b9c0213384a524eeb0b1f15da971aae8cc38ed27e",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm",
+        "checksum": "sha256:f1333de1f729a9f570251d37764c5c20faf596e9cff41643832d33f74bae24a3",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:d3a06680422d09103dc2f602376da3708751695bb23ad947adce07275236e263",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:894568773a38d50d81cd610c4cbb081bd4a54b5674251944a3cfe09ce2557a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-libelf-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:f31a8421c338393c824e461b49ae05a3f8c9350fed2347aa8de8df00dcb94631",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/elfutils-libs-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:0129362310d1fc9a4faa7300888eb6a476d1568f3ec5b4f144cb42fb4a6183e8",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6b9b252702c66da50fde953741fe5470d53cb955dddf6a50d890002927517f0b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-gpg-keys-37-0.6.noarch.rpm",
+        "checksum": "sha256:e10c8b75f5a6fc292cee955aeb625640979990eaac2e0c942ec821cd10eaae40",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-37-0.12.noarch.rpm",
+        "checksum": "sha256:d2e0e5bd8385fc8affbe8d41028426f6579d76198d285d928c47b689e6f0cc9f",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-common-37-0.12.noarch.rpm",
+        "checksum": "sha256:260ebaa38d49dfd758237d0a48ad73deae605d86653f2393f4fe7641e5cd7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.12",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-release-identity-basic-37-0.12.noarch.rpm",
+        "checksum": "sha256:21daf66051adb6b0723b699f7459a2bc52479cec5887b0f60d4ef82add689dba",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-repos-37-0.6.noarch.rpm",
+        "checksum": "sha256:4c1f1d1f9af5f00b5de01b696a4300157edeeec11b88f83a130d6fc57257d795",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "37",
+        "release": "0.6",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fedora-repos-modular-37-0.6.noarch.rpm",
+        "checksum": "sha256:11ef902abb560166f418e4f4bba230c7c5a3d0bf2f917fb771229fe923a767ae",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c84d46c1df7de7f3574733ca5cacca81619fcc296bf566b218dc116929bbbc4a",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d5923edd7fd2e5f5cd8aeb08b291b160ea06d9bc8221ffd146111ff6a9982950",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1c28f722e7f3e48dba7ebf4f763ebebc6688b9e0fd58b55ba4fcd884c8180ef4",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd555f1a70138b3e81ede1cd375cb620e7a3de05680c9ebaa764f1261d0ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:f70b262c317b0a012fbe1fc1239f7972da097c45e15075c8165b26069a7f7267",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:393cc43a853a2f5f391d133acb032b0a50d5070aca8bd3ec132d949b6af157bb",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:f3d72ee9f04141387d75d3e8ec9fe3a720ad40eaa815ffcb9e18f5e98e2353d6",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:e084290b302fdae060c81e90504c960a49061e0058033903b45fb27b384aa283",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e73a0ffebc89d0f00df64fb1556f632eddea245eaa5254c8d76cc9bf85117cd3",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f863051b731a75ea7443c096b1a0e236fa4b285b08b3dd7175d68c228eea1dbe",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7983ac68f01f7ff72010401d03584c226d3c55fdddaa4c900a562494e470cad9",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:eda13519d50710e3566c367510bcc69178609af0b30cfe9074082ee10de2fee1",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:5f26f097818a1eeb5bd4b9a97dafd97dd8793f9bf704ff9467129701e03479ce",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6caea2f79e9fadf96e6cd55eac3f8625137b12f6a2ca75fb5e36b453dfe54edd",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ad1d5667152334c4ff13b6fb8a57575ebe18e086df5184a57b40a86c05cbb0bb",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:32ab362365afcf96144ba3e65c461cf6f8d495651d0c99fb4eeb970fc2b838e5",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gdisk-1.0.9-3.fc37.x86_64.rpm",
+        "checksum": "sha256:911355f71b817f8fba1c98169646759d85f2d20a6d139f54cd46b4664b294529",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:f52edeae190ea55635b96cb8a5fb81ecd9a2ca900fa65c4403e4890c2d70da83",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:aef4052ca482ce6d1e8400191a2791a635415868e7aa36d3efbea546f710df11",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:8c864716f0efc6e66f2819dea425a34913d4d1a7e56d7a890d254202caca4f49",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-envsubst",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-envsubst-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:e39ff78d65d980546c9b1d0e33d19854888cc70bf000e3a160b1fd327bf25c77",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-libs-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:a2fafeb3f4035726e27a0039356164e1d732d0e870e2c4314869ebd80b71236b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "18.fc37.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gettext-runtime-0.21-18.fc37.0.20220203.x86_64.rpm",
+        "checksum": "sha256:22aad91a73901b4723ca1b6e97fbdc3a919139be73c758e6ff0f04767d2cc1f5",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.73.2",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glib2-2.73.2-8.fc37.x86_64.rpm",
+        "checksum": "sha256:3253a8869d584382e519cbe6576f39bf6a81bbf55aabd1f6befc23f5a3ba74bc",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:6922ba2992ea7c110f49eda9b1fa7da61165d35b23d03d42db07a770c57fd096",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-common-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:8fb56b6d4ca6cc84bfb896275aaa0c397bad50a39e0fa36bf6739e1f1968115c",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-gconv-extra-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bfc36b54dc5cfe21316477f9e519194909fe3978c238d1f5f4c283ef4f90f7c1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/glibc-minimal-langpack-2.36-1.fc37.x86_64.rpm",
+        "checksum": "sha256:27e762ebbb816ee1fb731cfc81df32846bec48933e5540daa53509a379196d7d",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:42c8a66f1efcdffaf611e70395e16311f6c56ef795ee2a43c2a48c55eef77734",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c688de5844e5bbe41b94e7f84612d96c59e4d1348f7c8f596baaa5227e871ed7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5081d23a1ae79d9ce3abb22648a358c1d07d55e03c1aa2ffa9f920a9871344aa",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm",
+        "checksum": "sha256:31c439058714931736b9a7e4bc5b2c70d47ed188721c40cb8b8839bb3c5ee732",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.73.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gobject-introspection-1.73.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a09f4ad48459bb38de836dc6eb974c2c2bfe5581e6cf682d81f2a64d55f20738",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:03209772270d0f1fcac1b006d2d4b4bff967a001e7c9fdc6ed97950fede5e3cf",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:d997786e71f2c7b4a9ed1323b8684ec1802e49a866fb0c1b69101531440cb464",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm",
+        "checksum": "sha256:b5b4e759d1c56188fb777926de0d17498c25d3234d2635ce5a8e7b000bfaf7f3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-common-2.06-52.fc37.noarch.rpm",
+        "checksum": "sha256:88e29f4636c8d8284952b897be34488bba2385adb4e6262a335d69b5c31bcdbb",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-pc-2.06-52.fc37.x86_64.rpm",
+        "checksum": "sha256:3e23f712d3b15bd50bb12b01f209bad2bcc316977a1c45994711932447bc4262",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-pc-modules-2.06-52.fc37.noarch.rpm",
+        "checksum": "sha256:cfe83a7faa009718f0ca5d9cafa5d61e4aa6cb4e439fdf2a9d3209d8057dc323",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-tools-2.06-52.fc37.x86_64.rpm",
+        "checksum": "sha256:ba23ecf289572c7a1f3907b8bfab88630d00ca25d427156ed5a1ffa010ff5203",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grub2-tools-minimal-2.06-52.fc37.x86_64.rpm",
+        "checksum": "sha256:4270cd73a7289c58ea736423756b244237b545d5523ba34b129877cf6443e06f",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "66.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/grubby-8.40-66.fc37.x86_64.rpm",
+        "checksum": "sha256:48caf50f3662cd13164bf47f5ba9b58e7faeb7dca1c0461707f265bd8f965fb4",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3ef9e1b938dd19c5268004e370d90f8a8ae0dbc664715457a371ce900ee7736c",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/h/hostname-3.23-7.fc37.x86_64.rpm",
+        "checksum": "sha256:840438421f3c7e28e49fa1327480ff7eb7780bcdbf605caf35ec0115bf4d7d9e",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:72b2fbe65f24fa2dc41109cb0bd47b0962824847ac802a3c0160d832ee1e75f6",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/inih-56-2.fc37.x86_64.rpm",
+        "checksum": "sha256:28d630dae78579725857e2242ce2ce01e6748a20c538554a36b628157a7ea1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm",
+        "checksum": "sha256:05c442df8e338070106f86ed4762397a89c5485c72d6796f97535ec3b7f3c816",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/intel-gpu-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:8053eaf425c8bf14a476049eab59e586dd2d6fef458bf8eeb27ad661fdaf3d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ea37bbc4022aa6e266e0ec601d97620574c12c8b898b3ffb8ae8baffe553745f",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iproute-5.18.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:960633a9035f8fe02d49ba6713f240363383d5dc3b3f862d28e9b211fd34fea3",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ipset-7.15-4.fc37.x86_64.rpm",
+        "checksum": "sha256:247002230874dd0c449145d4e8f92d3d5d879a41ba2e50a67c5b73f4cff6e405",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/ipset-libs-7.15-4.fc37.x86_64.rpm",
+        "checksum": "sha256:31f31f6f1bc19d4137d15e8a434cc6aeea959f875ec94c2cb3f50346071570c6",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:57a1d67b5a9c1151e3f3c9401ff7f4704f91307f0d95d5ea7b276e9095748e20",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ae1fef40fd8a0c5bf8c4aa74625119132b9564fabe2d84ae7856b39805b014d5",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/i/iputils-20211215-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9cf89d7e274a5ddf55fc4b97974c7aa33f50379c8ed50f6cb458b7286c89af7e",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c63e2ad394b69e31da35ddb4578c8b0c45b7d1bbf6015c92434627ad4b243263",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/jq-1.6-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ad14549b59bcc2c3c2ed6152c0a3a2d4aebac3ae06ab5dc451659060f380624a",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dae406fca4514b396783fc79f20f20501eaf357389ccbb0b0c6207bdaadbf236",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm",
+        "checksum": "sha256:598ddb966e5ac4f664f2cbe9d0087b62c1a4067a1f1af24f290d7f681956e29c",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kbd-2.5.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:fd584aa1a20378403d9253726ac23d78585f95155da02473aef9904460564912",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:ce82ccdd05037e3f95b6dd71f1b0a8db88d8c9599131b9ae76215823486f0371",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.19.3",
+        "release": "300.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kernel-5.19.3-300.fc37.x86_64.rpm",
+        "checksum": "sha256:ae32085526ec5234ac837ad5d39ce75d0dd106be3f0a8be975da5103b0b351f8",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.19.3",
+        "release": "300.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kernel-core-5.19.3-300.fc37.x86_64.rpm",
+        "checksum": "sha256:4d716aa1b01fb350f5c7e7534b9b6c4eca03aa359e12492787debee6ac7e5d72",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.19.3",
+        "release": "300.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kernel-modules-5.19.3-300.fc37.x86_64.rpm",
+        "checksum": "sha256:4a95497e1a387d05a6be065f4ae95f251f420c65901b5adbbd98765b361dd39d",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3fd19c3020e55d80b8a24edb68506d2adbb07b2db29eecbde91facae1cca59d",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b57193efad83c9cdb3acf6ad843e1ef17b8c00382a8395713b1480905e23f786",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:73a1a0f041819c1d50501a699945f0121a3b6e1f54df40cd0bf8f94b1b261ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/kpartx-0.9.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9ccf3b0e27bcba1698f7e14b1f52743ef4d59833b41cf24dd5b1aa490c389b22",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:159f17086ec145c629cedca9a038bc0c8fa38b4a8f7f0f0e9bedba0f3e76af28",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/less-590-5.fc37.x86_64.rpm",
+        "checksum": "sha256:f03d62bf2ab0c2606a64a4326934765ae6d25afabe7cc7b77e44445c49fa4ac2",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15224cb92199b8011fe47dc12e0bbcdbee0c93e0f29553b3b07ae41768b48ce3",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8e41b0d094a6635221cc015437ce4131c9ce502a4d4d2a5c1b51ac36ad0ccd21",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bf280bf9e59891bfcb4a987d5df22d6a6d9f60589dd00b790b5a3047a727a40b",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:337900b23fc2550547c243e11b7a65284c53c844a3882e0b67e2fbb93f8bf1db",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm",
+        "checksum": "sha256:f52405026bce203a5a1dd62b533f9e6c61a68bba6271d2f7de3948dcb1a47fd9",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:3a423be562953538eaa0d1e78ef35890396cdf1ad89561c619aa72d3a59bfb82",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:da6c0a039fb7e2ce0b324c758757c6482c2683f2ff7bd7f9b06cd625d0fae17a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:364011baa5e293baae2e60992fd1241f6c822d7c7e48c259d3e6abb0530036af",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b0388d1a529bf6b54ca648e91529b1e7790e6aaa42e0ac2b7be6640e4f24a21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5d13d18388dda2d493b0883d2162e0a6a832cd652b8186552425eb92fba608e4",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-crypto-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e58c18b53a81e8ffbe7b2998a8ac97f6b8fcbeec73929c1f4838d61d43a6be15",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-fs-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5f62a59f67418dedf7b7de1d267a685e4e4d0040851dd1da706dfd5cdcd37c38",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-loop-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:05c9e1a8abff915edbb2f793d8998338e7667d9690dd7ee8f332752a0950f844",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-mdraid-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e0cc982fbdbd002b3028706e3fbfff6c030b751e3fd4e98122db123346f13441",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-part-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:24674d92e5dbd7116d11b50ce3af5fa90122fa73c57b0be94784c3e732def97a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-swap-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c1dc9df91a970ceb98bc7b68b5f71234f0191e3e4bc4dd7f084b65cb4e12465e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libblockdev-utils-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c3a162d4a1623457f74522f944f27c037e3ece7094e4497b1e09339851e726fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3722422d69b3fcfc2d1b0e263051aa94c3fed6b89a709b1f1b4ff6627e114c0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2a8b12086461425c602dd65443a6430b11a73580378f43e207f34346162f3050",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:40bdee106c7d9df3c4b2a39289b247635450d763fb84cd5e63e2493f9519b58d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:aa22373907b6ff9fa3d2f7d9e33a9bdefc9ac50486f2dac5251ac4e206a8a61d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bcca8a17ae16f9f1c8664f9f54e8f2178f028821f6802ebf33cdcd2d4289bf7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:278bfd824633a3c49357342679e9dd5864a33bcda5d25986bf3e6030bed4987e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a63b5ae933d77e03609dc4a019f2e053a210db0ea2d9d152e52029b55e3560eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:32e67e6a70e493c52515626820cef9d3df6457f111004483fe6a8657255f4ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e98643b3299e5a5b9b1e85a0763b567035f1d83164b3b9a4629fd23467667464",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:1e14f25f5cdbbb523cfc3f7381b8c053a26f05f61666fb1f86fecda50d3764a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libcurl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2d4fa9fa98c029560b4cad221eae6825f87c8191ce54b3a374ebb9edd0b0ffa3",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:e89a4a620d5531f30b895694134a982fa37615b3f61c59a21ede6e64a096c5cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:c1698a5eace8302ba8cd5b09c23b4c8d2ca4c9647a83ef92e03caed5ff066fa0",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libdnf-0.68.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c5efb96c9ce79c98fae0297f5fc2d6740a5f2c167d64020d18876d9e842e8d32",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0cc1addee779f09aade289e3be4e9bd103a274a6bdf11f8331878686f432653",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm",
+        "checksum": "sha256:d81e04636fdf51ce19c3647652e37fa7775dad171ac563ac97fae4636ce6c6e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eac9405b6177c4778d772b61ef03a5cd571e2ce6ea337929a1e8a10e80422ba7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7a4bd1f4975a52fc201c9bc978f155dcb97212cb970210525d903b03644a713d",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:dc5f7ca1ce86cd9380525b383624bdc1afa52d98db624cfdece7b08086f829d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5ecccdaa221a28d88b8c9e8102d2478d26bef7932f20c2f7960bcb842893b449",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm",
+        "checksum": "sha256:dcdb39155a419f86e3070329e0c9ef19f1c6b605bad1e7af9309fcaf8d718195",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:dfbe63bdf373f8a141954f84aff98d3f044ba936c80e201c4755efcc6b1a9d82",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2aac86cd8a7197d3ce75797501dfd5ff3bd77b3c92f9c975e63efabd5e941d1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgcc-12.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:52a60aced835f862b077e74808f17124aad5bdfe79f42dba7d7983577c6614b1",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca802ad5d10b2728ba10bf98bb16796585d69ec775f5452b3a43718e07c4667a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgomp-12.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:7c813e74f44061f164236a0bc1d5e3e2aab1ece94ad2b190213b90c407c95cd2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d7cb7fd8b0694ff882c9ce27b14e93d91f25469547d5f76e55d113aae6c3b5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgudev-237-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0bd6b3f97c370399de8aad7e37d1195d3be5f3aa66c3ab4c83eeb42e4cde23ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libgusb-0.3.10-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a85fbcff4bbac0e5f92bccfdde601d8cfe7a43677b7a328b9b265304de380654",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:58fc922b01b99cf99809121ca2d3134853a5cc06ec5b8b5f6a0de7eec5c12202",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "71.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libicu-71.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c053d341934e4853cca55b47c49e30df6be74535fe29b48db00a0fef355958d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e022d35d3834e81cdb7c9582086acce4dff74a026ea600f6a5cb86388d231423",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:adf559f274af1e1a4facb1cc93e3840e83ba429513df55bdb79baa6508423e42",
+        "check_gpg": true
+      },
+      {
+        "name": "libjaylink",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libjaylink-0.3.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b4b47992384c822ee021452275896dfebc302ccf9f054d5d6975a364214d4f9a",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libjcat-0.1.10-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a76fb459232b71b8a991531c1b58ec93f4099281451e258964f53f1864a1c530",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libkcapi-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2b36d5db018c0060b6f620abaf526201a438a2ed26ee97bc89a79b438c41b765",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:76b454f47efd92d1bc4560ea5193bfbf6c1954e854c10e505afc52fd3f05bc69",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libksba-1.6.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f72a06635024c2bf9f43768aa3296f4f00d8dac3862e8f880bec360e56e2bb87",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:89ac04873c24d8d89c1b60e5cec35544756507fb1be2c2556b92af8bdfcc2a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmaxminddb-1.6.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2ee54c169df955389d600c8990969e809407dabf087a05111da9ccbf16cfec4d",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:9577665c819179202b3439b7be4c69052df5ed79c9812be5ebb51fcbdfc8330f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmnl-1.0.4-16.fc37.x86_64.rpm",
+        "checksum": "sha256:688c033cd1c7b39b918c215af5480de238c16be94b72086ed4efc34dd6201b80",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:7bd0358110b6b80f3e4facb097746b19c8d82b3fa079a6dddb80582aae42cad9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50c304faa94d7959e5cbc0642b3c77539ad000042e6617ea5da4789c8105496f",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libndp-1.8-4.fc37.x86_64.rpm",
+        "checksum": "sha256:8ba1fb96a5e6b78dde962d5b9fe97726a393c977e9a9106e896dceeefffc6472",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7e5767c70bc9f6429b6e9a66ce2cb75e90eea0d9a48392e1e9eb54480fcabd8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:44e396c693edeea0a6db316428af4bd7b2c0df41ce562e2f951b871b70a10bc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnftnl-1.2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5ea5031e6eb8d915f4c2910527c3cac1c7cb969fded5057f21be5873a22bad3c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnghttp2-1.48.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:77798df08cf783df929249944ed44ebe8ecf1e2eaf7a12e0aea5657b78612e13",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4543c991e6f536468d9d47527a201b58b9bc049364a6bdfe15a2f910a02e68f6",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:a1e9428515b0df1c2a423ad3c35bcdf93333172fe346169bb3018a882e27be5f",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:932abcd232d522bb508daa2c9e6f4a3ea79039ad80a6478e6384d517c1d6698c",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:213ea8f5cd8ed07a61d13e3e32b66f9f9d3e992b121414ae6fd9d3af3cf49e5d",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5e748380f1796e2a7be2137cecd8a1662fcdfdbc858d27b218c931350e296240",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:90801f2f5ce98f2ba06f659b4676cb55d39f8e597a8f2da3e59dc943abe8f5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:ddc6d5cb5a094abc04b93e4018dd178aa1c527c80f2059c21963d3621a428989",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:01a2ac7dc3829b47eb0d188909175b806a1e93eb1aefad2737f8fe07e42972e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:5fd8bb0bc2edd80b13c0d3ac38cf26b1ad94736fbf1b4b37ee6433772d6f18e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm",
+        "checksum": "sha256:69ca0883e3929168bc8eb555463ae051fc38afedae0fa98d566bc22388304a91",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/librepo-1.14.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:52fb4dc0ad2f889ace412f7b05b2a5827a3eda8bfb9179fbe7cb393dd0d88dd3",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libreport-filesystem-2.17.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:002eb0cd50f7f38dad54f2fb4cb1fc445c7ae0d320d11201f43f582c12e17a8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:017877a97c8222fc7eca7fab77600a3a1fcdec92f9dd39d8df6e64726909fcbe",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0de55e331087a0c931dbff4ff4973dfd54b190b2ba112e6c22ea8f13dd0329d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2a5b4e2e1dd388c3c13d79af971fb8efd522f5c2ba8d257875f02c16b4858214",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7c7c409363b5a1a459b8ceb987866fc54e1feee5d4d2919d31295c8526b7d96f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:66305d7a3ca92165f1c17e14cc29ea70280fa1c1fd3bf223b5b1d4f7d1ce0dd8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:97e918bc5b11c8abfec9343e1b0bd88087b792e85c604427d5cdc32733f70b3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f038b70d155dae3df4824776c5a135f02c423c688b9486d4f84eb6a16a90494",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:93246c002aefec27bb398aa3397ae555bcc3035b10aebb4937c4bea9268bacf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm",
+        "checksum": "sha256:c203ba66a8da80ad3f21305dd932073c1ede06cfa2d1b267ccb28089596094bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e45a35d7f68a2657719b18ad53c9efd5a2ca86deab37a886ddc1d1515593ce33",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b34584a26bf7ee036c2201ce5d92219d775c76237c99573dfe36a10c74e73eec",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libssh-0.9.6-5.fc37.x86_64.rpm",
+        "checksum": "sha256:1e857999c674a0a6154074042c3864c6e8e7411ee6da3e4cb41c7760177b8b22",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:99add80d2b086bb679359766d0fe9c8821327dc8826ca2faf8393f725b2a9d4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_certmap-2.7.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d43e7cd6fe9faa738384509be775d4867c11f3ee199e7c06daef69e86b517c57",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_idmap-2.7.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7324e7200eb3c740bd9a836cb99f1fe6c6842a716c865309c61897e866f3e111",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_nss_idmap-2.7.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:31493b05b4a053487e4418a7f663b50b801e4f3d557c6245ebb8c32e3cd12db9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libsss_sudo-2.7.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b853538a9e367a6a0da999f2ba2e7ae83af6790a3b04b5e47495fede61773367",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.2.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libstdc++-12.2.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:be94dbe638c7e0a02fbc9bc73355dff9bea812d87b72eb45c1e7b75ef731b42a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d71c5fc0e75b48b330cfc391920b8b2dd32c5c844202ba134172a31630a29460",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9546058ef3561af0a5e24d50469fc2317afb6aa760363c9348bd2374a31cb5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b772806fa1412ba843d87d2a84ed9c087880f3c9e7ded3f6035718f83888efbf",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:744cf61b729b0516567b9e622244f21d7dc6d44c35bbc507e5ae1b49f791e7df",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:76dcdfd95452e176f64d6008d114e9415cd8384c5c0d3300fe644c137b6917fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c966372c322648dcf3e0b84dd0a7bdb92031270de243640739cb5c735cb6cef1",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:acb031577655bba5a41c1fb0ec954bb84e207f9e2d08b2cdb3d4e2b7806b0670",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm",
+        "checksum": "sha256:012a7fbcbffc0c6d9a7101fb29eef81cd7ba18d3bb427b3aa0c9ae3a27ba2b2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libuser-0.63-12.fc37.x86_64.rpm",
+        "checksum": "sha256:61e84444fcf3f76d3268b356e5b29f251a966d57ce043c8c5e0c1491179b7023",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8fc30b0742e939954d6aebd45364dcd1dbb8b9c85e75c799301c3507e22ea56a",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b054577d98aa9615fe459abec31be46b19ad72e0da620d8d251b4449a6db020d",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ca47b52e1ecd8a2ac6eda368d985390816fbb447f43135ec0ba105165997817f",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxcrypt-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1ce5fc1b93217cd4b9db8b47bcd548ac401047ac73f48d1bfd66f0ffb91fd21a",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxcrypt-compat-4.4.28-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d7d0f5ded000fe57622ed2e551dbfad3b86b6bfdcd7d33a5e3c0862b9fcf6dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec9520e18b72651f309f78f4decc2b6571d04be898cf173bbfd6dc7b8d7611d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:539f9b54e9f497f0d40374f3d863a62c6fcc4e54a7336ac54445344612fc151c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libxmlb-0.3.9-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8622f18e1c13db40256d25c5c01b191712ea703407343ea52289ffe07a486833",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm",
+        "checksum": "sha256:54ebc02523f7b85a9b790aec6be0b6ef01e377216bd76fc0ada4354fa0f0d8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c105f54738fba9793dad9b6ab2e88b4ae05cc47b9ea062cd7215b69d11ce0e1c",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/linux-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:d62eec866919cfc099ea008e165effa38edd53c0489deb121d39839cc30a3e92",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/linux-firmware-whence-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:a27d291b03476f2e041cee4b0c91eebedf31a4d13cc2ed1030eaca5f77f93ddd",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm",
+        "checksum": "sha256:57b0cbd11daab17a9b9486f89545407de965d26029938e991f1aefdaf0e48614",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ffbcf2d3558dec17023a930d8e278756ffec150d943b66239085043e06fbce59",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:93476a87e1531898ab2a95a701d918ce589c4da252aac2c615ba650138664feb",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/man-db-2.10.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d53b6b5f20e16b95bdf743f3962f45911577e1a483c756971405f5ef0506772f",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cf997d2d6fa655ec7e03fc58769e29770409254861d75c3732fcd9a264cc2820",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ecdef96acbb30ce62236fad1a55f6a87c0cf9f39ce73fa3c2b4c1ce021f7080f",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm",
+        "checksum": "sha256:08c7782ae9fe49cbec8db74d566061656689bf48cc2977bd0dd8daf3d645133c",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs102",
+        "epoch": 0,
+        "version": "102.2.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mozjs102-102.2.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:d4bbb0584a1be90d64cdcd12a5712b9153ead35cf68b1431b1bf8159bfe77b5d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:45764a6773175638883e02215074f084de209d172d1d07be289e89aa5f4131d3",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3be8cf104424fb5e148846a1df4a9c193527f55ee866bff0963e788450483566",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nano-6.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:2e5281196fd18f90f4204d2104354936cd8f6fa88c209638f690134e61572b5f",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:18b46fafae10d86249df30a025faf411cb1369ddd2d2ade738f9cc4b45ab6f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:c8057ff6e5fa3339726c83173fdd11898b5f7545e72d81503f8c6660c4404885",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:f5cfeff82e7aa24cd00b430c1db17ce63e72acab8508505db7207b70a7d9e0d6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:47a3ce5b9228ccb688da7458828fef2138f6e4215e73941922dda962aecd14f8",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nettle-3.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8fe2d98578b0c4454536faacbaafd66d1754b8439bb6332d7576a741f4c72208",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nftables-1.0.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:763343a0a0c30885b064b920ceaee7b4846298d07c8975ca5e2a0ce72e0982a2",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/npth-1.6-9.fc37.x86_64.rpm",
+        "checksum": "sha256:6bf0c6a9c2a00e9e06988299543a9bb1aec4445014b11216db6d6c2e2253bda9",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nspr-4.34.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5972f3f4f85193b67865db97e5e6e706d431d272f207a434d6b2102e153b5baa",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:0ab9c4b08aa61930f6c156d2c87584df182460396c7e03231b47778820f91d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-softokn-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ac17caddde45a5f9f2d5f894476cd82e799c8f52c6def22d2e8f2e0033050453",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:03d7cdfdb9e52782ea8487823da1d8a33fc217875f28bda20e26f4392be2c705",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-sysinit-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:a58f6a4a83359244206dc707b6bf891468604ddc169ba4e29b628b96d3004f74",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nss-util-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:51b17b885344823eb7d581edd0b09082f193c728f3c806138ddc4bdcd9bb059b",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4df07c734a7b4135d6b5dd73f72cbc188763a09457f3bf24f893fc178fd89d9f",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4cdba0d602a32cb4b90461bd7dbdfacf0bc30f63ee5dd8f460d5bee3dc4cb586",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:b776d46067bf44c37801e19b243572feb26aae0fee721e061207a80873da1f46",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a5d3c81dc359adc676afc9044743aeaf8fbc924e019b093084035413716e78f7",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "138.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/n/nvidia-gpu-firmware-20220815-138.fc37.noarch.rpm",
+        "checksum": "sha256:69ff7199c3b6dd205c09022bbc598851e21a9dd192ab5b63a7f25fbe706933bb",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/oniguruma-6.9.8-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:0545bc486067591d26070790405beb3330dbd5cee3deecb2a5b654bb1965d64f",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openldap-2.6.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c42642046bf068a2d0cc32f38cdc56d0c92af48eb131fc8dce55a997142f2e88",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssh-8.8p1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:c2abbcca2ad0d7d7505775c9d5fc8dd34a89f87a27a3e2c770cb91632000021d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssh-clients-8.8p1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:b7805e9ea70864f34883cdee1cede47fa95f8a1150f37575574190e076aa322e",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssh-server-8.8p1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:198166311dabedc62d80a332da8d32b63fa2e1ae9329c6f2cad0c96e83050072",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1e7bff42a7164385e2ca87fe11bfc8ff6e50d56f8da32b5ebd1e5f0a4508b66b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/openssl-pkcs11-0.4.12-1.fc37.x86_64.rpm",
+        "checksum": "sha256:01ae93cdb80ef99a9dcf56ab6e1929d78606bd345fe7189a3a7d00921847c36f",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:4b3df07f460096de0c8d97eec8acf77e4ffd560ed8165f4d7479458f202c52ba",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4dad6ac54eb7708cbfc8522d372f2a196cf711e97e279cbddba8cc8b92970dd7",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0fd85eb1ce27615fea745721b18648b4a4585ad4b11a482c1b77fc1785cd5194",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:a66ee1c9f9155c97e77cbd18658ce5129638f7d6e208c01c172c4dd1dfdbbe6d",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:ee34422adc6451da744bd16a8cd66c9912a822c4e55227c23ff56960c32980f5",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/parted-3.5-6.fc37.x86_64.rpm",
+        "checksum": "sha256:cba7fbe4f72489a2fb27429ecfdf8b0177ac8cc4fa30aa7baaa8ce1a0dc4f5ea",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/passwd-0.80-13.fc37.x86_64.rpm",
+        "checksum": "sha256:e733d49496689131148b00a233229e484b5b622f9cb8c230230a05117763065e",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8d45acd2ae98e922732fc9c4966c3bb8d570f4185122d766a83199955b96cad7",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:86a648e3b88f581b15ca2eda6b441be7c5c3810a9eae25ca940c767029e4e923",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:422de947ec1a7aafcd212a51e64257b64d5b0a02808104a33e7c3cd9ef629148",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:585f339942a0bf4b0eab638ddf825544793485cbcb9f1eaee079b9956d90aafa",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcsc-lite-1.9.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:352231cb2c4b6c7de0797b83020df840390d83654c642fcd40c586701c2c81d7",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0b01cb100fa03ec4ac41532662cda8aa9f47ff4abe5f33b2cbf682c311fba841",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:0e69146d4bbb40be987bcef433b916503acc68c8c40fab2fdb2ed6b32be39aed",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:82a090d13ea86d6320fb7e77bde29862fa10cb31538167b7b03e4821a3ee81f7",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/pinentry-1.2.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:1ef4c02f8aa95c12ccf7c7708c8a6e9031efbbf76cf3c1d533ae80dd5444abf5",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/plymouth-22.02.122-2.fc37.x86_64.rpm",
+        "checksum": "sha256:670528275ca6b3371e35c5c79618da004ffaf999fbf8b29f14c3fa21f701ab5f",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/plymouth-core-libs-22.02.122-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e627ce0440ccdb69f21d5928df87182b42655ece611c7bd9073b1f80a76b38b9",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/plymouth-scripts-22.02.122-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2e91182e4edc4ef94e52da5532527549f692184213ca0257dfb8cb1f2c3ed163",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20b825188654b5b5d17340ce6a78cbd3504e74729f8cfb83150b6798db4a586f",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/polkit-121-4.fc37.x86_64.rpm",
+        "checksum": "sha256:3df7fd45694c994a41077966f80f48d28a5466c21e161c92d05629cc64efe0e6",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/polkit-libs-121-4.fc37.x86_64.rpm",
+        "checksum": "sha256:e16b0c15a0820ca0795ac8e5cd196c4c8bef3dfebd70eef28a5152a2c69a9386",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:fd67360c39e9d4bd6eb9c6179ec2fa68382715129a8a43972e9fe63ee870f420",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/popt-1.19~rc1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4e88be19e5a5ae7f2b310f52470c454979a5c6627325e2e528a38360bb5e4655",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm",
+        "checksum": "sha256:64112ed94189c99bddc05003aa3bdea8a5486e8cf056678512586864b41985ad",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/protobuf-c-1.4.0-6.fc37.x86_64.rpm",
+        "checksum": "sha256:903761fe0e670a53194e1e5e976bb1edd914258103d01583f1c89fa4d36c9730",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:4a50276d2a8bd7f2b16cbdf6592ea365c19fa9f9bd33b5cfa1ab4bbd5ca89c69",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:66f0cb20aae801f5810d2bdd27f0d6b9a70935a231e04269611113f96989132e",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:ea5e38e2e40928ff949244455bb3ea60de724183cf623ace37c5ad05fe3ed9de",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:5a9c2a69949d1bd9293d3fd34719e4d01c8e65d80957d8534ebc23b1deb756c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python-unversioned-command-3.11.0~rc1-2.fc37.noarch.rpm",
+        "checksum": "sha256:5bb2c6765e4994942a054a6f1e9b61ea56d3b15c88bc31a977bdc707391806f5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-3.11.0~rc1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:01bf6ae14456eda9a669b2b754b496e9ee1a79d18d03276b9baec216757df054",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:6e1b3ebb0f9945593365eaf0bc01d052d2e221e930d5731d1bd8276289194ba1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dbus-1.2.18-5.fc37.x86_64.rpm",
+        "checksum": "sha256:fa30a837be5cce2abf071c4afead1af95faf7d87c05e390404aa0de3b10b8046",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:6427a8b877a51be140e06665b3680a911816c9eb581aa54ecf29c77f51b6e898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:9549982392bd6cd0c8fbcaab7a672bc94aac048f3f20a5c98fea083866748c47",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:4fc2b6910a5c954f8ef9c89e6ccb09df3a66ce5a323075775f65366ef649db95",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:5a980a3db08191299cb1ae9640a924fce3631d34a7a931ba34b0a44daf2b53c2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ec583a673d3ba649d69246fc67455f01c2431bc8e80b14b724117ce709b317ee",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:e9bbf1cbf6b2df49cf17585f3913a9064f7b0c3c56b116a92e9f242a3676efde",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:09bd56123cc38e0b6eca84a97848f3985caa421e0879345b89c42e726a19b49b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-hawkey-0.68.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:91daae949ff91b3d96865ee10b99376b9db82bf62d4ee77123572345dbf586dc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f6d6c53e06ada97d73329dc360393e493dae399f8f669efc1f0099e17192d898",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.68.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-libdnf-0.68.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:eb156348e3350bec888a272bd31a5fb113585432ec3c3276fdb05c6561169eb1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-libs-3.11.0~rc1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ded733a845f66010ff47249a502d406038cff2a6ddd17886e3e4c11290ae9b1c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-nftables-1.0.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:250cc6648ef7fbb6c209f83805e7cf2a16ff8fb98725c6945df9f085998cbb05",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:ede52be80704a7476d14516577b8d62192f938a2451d8f5e5e779d1fc75f1dec",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:3f33292317a057dd50fd05ad00e5495a866a3df35d8acd83efdb592fb90c603e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/p/python3-unbound-1.16.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0b344dbb131f5546c6c4f23332368e05c759c0a301be63fa95185724e34d16fb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a7e50bb3ca0e684840d9513cb2bb0024dcc7bcfb1f3f52e27b3fd8f5f656a85d",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/readline-8.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:ed6c8cd71a52822a69c6dd28d2a112a0f772983a20e037884c7821d9eddef6ba",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:0c0e32d108fcf6ac2f4c61aecc03163168337179b861786abd206ae58535a0e2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:6abf8009d5cbf395ec36ba465aab3d5ba641bfbab940a949a4c98577844735ba",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:ee5d5c88c5de5ecd3c2105a159c1313b15cf3437593c6d071bef1d622a8d8d3e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:f4dc7042fb07030a20b8349fe31120d08156be5257e4ed272666c061cbc40fc2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:ddd95d0cc09f558e8f3defa1ac0396d56b02964530404e99813200c0afd4633f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:5cf036d6391b68c2c61456c5adac015dfc959f11c3000529268607f16c3d9568",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:25e7ed20f6efd972d534e32b295aced111b8f47f3b788b43832d69b3655b89eb",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:231e782077862f4abecf025aa254a9c391a950490ae856261dcfd229863ac80f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/selinux-policy-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:807573b368d4ba94b4b9086432037fe2255555d4226e4cd678fd91b10d791040",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.8",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/selinux-policy-targeted-37.8-1.fc37.noarch.rpm",
+        "checksum": "sha256:f93a1048226f39b19eae24de082810806431ad5b526701ea1df6e9d182c74a57",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:15d72b2a44f403b3a7ee9138820a8ce7584f954aeafbb43b1251621bca26f785",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/shadow-utils-4.11.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:47c1c0854206fb50fa5a933f621642b2b304da3bc8a5b0b462ff751457073645",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c471712a2998682347e1680ef1d5a652b48c12502f19e8d39354c4083af91d8a",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b8958e57d4f99bea5bd52c17f26ff5973dabe941aaa279cfca576c3b7c055c4b",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sssd-client-2.7.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:ebad7b53812d4332a27e9a5cb0d42e2e063ef475deb0d270db3c186313ca233d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sssd-common-2.7.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6f7e37418823a9bfd3257ee05233109aee8b47e0fff84e274da8d39ffb381576",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sssd-kcm-2.7.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:5db608d8fa06570129e0278ce0af77300e4677fb201668b64131d97dffe2da36",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:e33050f1d6ff44a889213a947f6bc9f905336d4d89723ee6a50a51fd8ac10d9f",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:229d197810a5e64665283e0f2e1b4268f4dc7514fff803e99c1b862201d6d827",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:7b2d309ebe0f57e515b402130cd1b63e412798deacd0118c10cbb2320bfd6eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-libs-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:d2633fba63aecad94afd7eab596f5d4971c483148168114a58e633bcfc386663",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-networkd-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:cd10dbfb5b6bb286cac3d50e6dc187e1b2ae48df6798fea19a59387d53a34308",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-pam-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:895cce126d2da91e85900c7a83d85a9978b2e29f2e9a6d611185f77f90d886c5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-resolved-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:f58c30365cc31d0b5f8013a8561417d58d5c7682f4a075cbb2ecb9c6b8f9bb25",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/s/systemd-udev-251.4-53.fc37.x86_64.rpm",
+        "checksum": "sha256:9025dee2752b6bd4138e19f856a05a0f1a68347db49e1fbb47a2b61ffaf937d1",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d4d4230f282f18fcd120bdbff40382d8c04d322675612d9fd85e1461c62b66c7",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022c",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/t/tzdata-2022c-1.fc37.noarch.rpm",
+        "checksum": "sha256:aa311b92ad24b71e3180b7dcb8d7a149d342c3ca17cc211db6854a89cfa3d821",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2f12d5e9f0294047cbb3a07018df31df5a6eeac754fe8e6b4a21749a5c6f8acb",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/unbound-anchor-1.16.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e5a39fb33423ad80829a270cc8e340d0f0bb2b27e1b5c84235eb76c56d3462df",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/unbound-libs-1.16.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:3b9fc73f981a4f89886a1ab4629be179b738b7dbb1f2c29c30cf169f24666ddb",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b7e7d3793988a51ea308b7e9bf9882fa35d1b44a27da67e64c4b5a6eed34f792",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:23f052850cd509743fae6089181a124ee65c2783d6d15f61ffbae1272f5f67ef",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:f87ad8fc18f4da254966cc6f99b533dc8125e1ec0eaefd5f89a6b6398cb13a34",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/v/vim-data-9.0.213-1.fc37.noarch.rpm",
+        "checksum": "sha256:a73b3d5a5f472d8347a2f858a0061e3f338323dd962d5293b2d0982db9f20bee",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/v/vim-minimal-9.0.213-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c241cc7b92bbd88e05ce015efd2c3777c49590d4e2a914aed79942ea9226ab05",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm",
+        "checksum": "sha256:3fc4908c11bf3f85bbf51a14a79d4bead80ae7035cae607f7580ba7d7dad58a2",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "35.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/w/which-2.21-35.fc37.x86_64.rpm",
+        "checksum": "sha256:f1302b8a938e3c8235510f02d1500b36b03ca8990b5380280ba0a383416c75f0",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:d3f0b501380df634585b5ab534244c01a654627f448cd3d8d1a6460a65bae6b7",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xfsprogs-5.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4ed93771948eba20a48a5c824079710be94d927aeaf7c2d0db1a5a402b2eb923",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:a0b0f8af8b2c62c459d5869b0144c29c0d106e1b28e59b798cea05590a67695b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:4d5c9d11876f3a1688d31fa669986eaaa4c0717435ca99e78fb86bf5ddc193cf",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:9f9541ae85dcbefd66fd88c014ccf176b8a6b32788443981490d3a76381c2cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/y/yum-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:7e169c14f3c544cd0355633040eaee3ebeddde31bf022ab2d4441db084c5779b",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zchunk-libs-1.2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d4769356b15d8811aa64813bcf6ee63547d60c97162f0cea7a22970f3467f937",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zlib-1.2.12-4.fc37.x86_64.rpm",
+        "checksum": "sha256:1d4f57d5d26265b3090e6ede9efb9f2bc3996e9032f6693e60fe02cb5d9a6a58",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:330e209e3700c12717c686796717e947796c71d914bb32719ab7213e556b642c",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f37/f37-x86_64-fedora-development-20220831/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:2c492273497329d9a1ea2293d0f668edf953e18830f7d49797f7ff8412ea76da",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests.plain/fedora_38-aarch64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_38-aarch64-minimal_rpm-boot.json
@@ -1,0 +1,11374 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "aarch64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-modular-20220817/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:8e59aca2373dfb636f7a5cea8f4d085d1fdc18577dd6aedd6ac19b6b937bcc9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e8db2cef395cb3ca7940fcb712a27e50a279da1aaed63e019b96d003e525840",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ef317581715089895fc30425b3eb3f351138894fbe86f4594c8512ba7be19fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25378e75b524c602a0af5c12da1b68b4699a61bc165b487040a2357cfdc96683",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:615d42a7ea6822fa0564ecff628d5f0cb725e7578bc5fa3b27968faa3cd9c108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da2e61e1c7998f724d50a60279f03af089d470c009b77adb4a8e93b95d199bbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0dc904e2d0c90613dcf2c9db3b7f9dde1cd682030b14cbde677beb328a93d8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa9c0ac890e8264d5b44479c8fea74ae79bdeb6a72c474733c7d06100a893144",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a52bd1031b97bf1642e0b56f460b6a88b426755b9e1fe218af359b215585175c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ceee888ce84b6d50e713fddf8e4f876f779a6f662f27d781bc8942a73d798750",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e9178f02120efcfaf723da06ee73725213a3e67831fea796e21275899b0fa54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b72109015ff0f8d68698d2663bab1c417576f237733ec53a32e0e6835c6b2a6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81ea9684679162bb4cb55a5742714b72491f8b4ddfd68d713564f0ad87f08d47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20e2b9a751fcd737d09916932cbc7be84e106507393ef386da0057152aff5a2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5fd6952e04ab59dfb897d8407ec2724c98f364e8ac7212677531725da941fcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51668bc8aa5ef6c3552fa6e5e7d7aa9acf02a0297badacb707adf0f5ca432f32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12d299008217b4bf3eac42c86b1948c6bdd514cabc600e955e525df3c95b401c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7af3d490cecbb309a48a7b982cd59a82e2716121436e2b56c769ddd8130ee7dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2afe7a7b8da38f2d0eb619efeb293dda7014682625a7604735d497d99f9203d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9870ed936bff3d80332751f33239d29ae5e02af4ddab8b0f4eef6d1a2749dea6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:281e37fa1e91648a82ba5a41bc03757457c532f22d6cdb183c1f216e66b82d94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6119bfd75ce7cca0ccf7cb439ba6f23587eb563058c0c4ffabcfbd550767210",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a1d698bb9f754af6fa35a4145f147851dfe7feadc3b058e0e6821876060f188",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:124d0e3f779e3bf7cb2fc8635aa1ed73a7d1540dd1bc22420542c26e6fb3e46d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf993ab622bbb03d6b0561ebf654e777254425aff03de0b87e9a18a7a252428",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d42d31e6e5433ac1e9aca4fe6573dd57ce66a6dbec09bb75addac05da9c4c3e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ff28ea3ed7b69ab47e64b3625eea861b3f3c4903682ce94aee46d8fbb8e58a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61ace5783032cdbc1db06545a0adbb52122996697f10512c24c8b5a6d36c9900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f257703df5320763eb8a4d20b2ee9f4ce209840ac986237274190f7a1dcc88d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28b17f73ce6ca866b7e8af7a4cc354e7f2443f1f7d2fc99386834b84a5938c89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42dddccd8a02d172d8894796d94b329a3ac38d69545a085e3942975a59ed9c4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a7c69315a2b7b355de4551d4ad9790a7ae0ca86dced94d35670030b55371ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:170ad90a5f690e3998db2350023f9212aa688d71bf7769fab4a77eecc164332e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60d3707ed83661b28a1f859cea78367c77aa40e4cd77a6e8011e756ca35ac807",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5f5ee0665ad3d629ad53471359e5a428623666af22781de4c37aa5f646410af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa45ab2259216391b465c4b9ccdb89fb7908e90fd34ee7c6973d862ef518f637",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75e807735799d981a5cf395879065b0cb5147e70923dc9314d3ba7eedd219893",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0718fa539da95a64b3d2449af8104217f55e9379b905bc5fb87c3c3274130186",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7fa45aec5bae3e6c08fad86e13a7f4185ebf53912687c707a9d88e7b815b1da1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9071b0957ceedf8bbeb2acb80ab91cc43302525dfb14184d540f1c133d6fa298",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ca758a939959e0bddf5a3590c888df07db7c1fab55beceece1a3548bd1f17f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31e4f1c33720828bf97cf768939856eb49531e6ca0805720e9946fa354f03537",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0235e965a1a21a4e548625abcb562f4a4181e9d29830ac208d2decee3067c644",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:272a4e9b637d1732477e24c751c5e2561996ae3d82ea10cdac822d996ab68143",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe81316360f7512b27c3740e22d0c42b3bdd383e21e8d53b34239360b9538717",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc5fe78e55afe5528e6c133d08ea96465ae2dc223499adbc1d3d314eb822ee26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6ccf60e3629f33ff9dd2b3b6215e0b8e3b81a3219cefcc11cde083ecc4664f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd7dc65be232b9b7b011932367eca95f07fdf271ccd88c1fafb65d152d547a12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d31be2cd877d2f6a22ed9efa52d27f287d8a33036cb7833c545f00188e6a477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:909fb5490bb5df6c877668ac18bbf73cda213d7dbb3a1d2a8d1013bef4f8ed22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:349e77eb1fca043555141f1aeb018c47079c147358df4d6a58d00402bee9791b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f35908c2704a9219002a316958665b6d56092d2fe59d8fcdf20fa3817bb482c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1caadea1fe1f44be99448485efdd8c02ef616da6a8d0a050bf308a68ec23ea68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c832ac1f2b95744b48fe50795ffd8ba136b93b14653b5ffc428e1642c62b91a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c63610924ad5aea7867167a2d8ffe3ad61ded28b13319c7d91c7ca0473d95e99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:689ef2b8d48e5a906d79d5aebe16c3a46843155b236361af5faab189e82a4d6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d2fb53f362a449a838989041b614aa32367816e338edf9d3dc1a58532bb68f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4ce968491bbe0f2db29e9af17f6972c7fed4fb014e56bea40a9585e40dcf082",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:baf1ae39b1ca951a1c3edf73d62f21bc409dd211f447000c1d21584d58847575",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:235e8bef01064ad26fcd52f83fb63207d32fa0e8f4ffe32ac19a7e4e5df002a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7809f426ffbbf705762eb4c3a63c5e60fe80d865e8f324e0512af8b426fc8c69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0741570a6aea320cf433c9576f1af8b6020984cb190fc8b94e9de364b9a16c03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2800324594d595ea1d585e149a3641a876d03f328910bca6b8d5146a06f7bbdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b80e7b8f67c26eebe534e5d40920a430ae9ea099a5227de5c89cfd09735b19a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b936514f5a3a15efc8c8eb84e7ee24c062efa954d8c9c25df951f4007c08336b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3542f5da08d71f2caa8742eb2d632e83f8b31d5fa5a93d771ddc9209be9ae895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e4b581c98a7ca80bf83eaa3859d33bcadc8970ef661a4672f8cc0495af72175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09aa2d7801d61e63530a28bee09de287c99ba11171d6756d8675d31dc754dcc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df409a92f0a1edbf3902e63a7cb692bbb05a91bee87565b108495ae6c5f47b19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:a21e3d9871e35bffbb194952de4bac40bfd2cc4481225c5da610db824d83e3d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f7d94a07fe0bba6fa9b0ec306faa022d6206fab30cf29fa2f5ba3c3909473b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c433230048161b2a019e71d4987d2882ee74badcf980cbe6e1a78e6b865b2149",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e59aca2373dfb636f7a5cea8f4d085d1fdc18577dd6aedd6ac19b6b937bcc9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c568f1d12548ff1f2a379c6d6892982a47b2d303f886f98b2924f8ac354e5cbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e954ed4778a06f63f421dc47b5370b6c6b8cc03c0376a63a1f01daa040a5bc8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e8db2cef395cb3ca7940fcb712a27e50a279da1aaed63e019b96d003e525840",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ef317581715089895fc30425b3eb3f351138894fbe86f4594c8512ba7be19fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e78cf0c9744c640f0eee419d5c5b4ff057693be4b8cc99bae3367571b4c5bb6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86e5cb2ff99e096a1d7a31bdd0a0038ba0aa6831ccd8804f5a04b262e2772dda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73793bf267725e2ebbf2fa5d32aff363a614d1cbc98624258ac8df564d158e4b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25378e75b524c602a0af5c12da1b68b4699a61bc165b487040a2357cfdc96683",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:615d42a7ea6822fa0564ecff628d5f0cb725e7578bc5fa3b27968faa3cd9c108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da2e61e1c7998f724d50a60279f03af089d470c009b77adb4a8e93b95d199bbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0dc904e2d0c90613dcf2c9db3b7f9dde1cd682030b14cbde677beb328a93d8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:240fd2e4f0ab37d475a1e981921729bcaeda85a38c0d3e44079b1006769a77a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa9c0ac890e8264d5b44479c8fea74ae79bdeb6a72c474733c7d06100a893144",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a52bd1031b97bf1642e0b56f460b6a88b426755b9e1fe218af359b215585175c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ceee888ce84b6d50e713fddf8e4f876f779a6f662f27d781bc8942a73d798750",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42eb0c3836c6e593a371009808dbd1013de30cd0e636f6c668eb79475b6c42ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:608b7df709cddea3a9733e93502f1f1c052d3cd6044f2b00af6116b4cedd10bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e9178f02120efcfaf723da06ee73725213a3e67831fea796e21275899b0fa54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b72109015ff0f8d68698d2663bab1c417576f237733ec53a32e0e6835c6b2a6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3fc4b0553bef0015b8e73b00ea5c247e5eeb069583bdda3be4b9c97c3731efeb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:351b9f8911296b57b7f69f8b6f04bde3715648ed827aa6f5fa6b6ea44168341a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d2bf7377a0181175b289acae55b3afad0dfb850ad9f65695818ec80481abccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a630412a9094d1294745986fd77c6e99762a667e8265c9859feb67651996785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b353a0995c13684076f30b900fa47ce16652145302f9670ebd3f7ca1397e46c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:828ccdf867dea1145e90a327a3556465d1076c5d749b1976c32f1cfb3f3468ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81ea9684679162bb4cb55a5742714b72491f8b4ddfd68d713564f0ad87f08d47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df6903cc9da281664fe8d9648f7e0cde1fe6b09006928daa31143bcb5c65efc1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:249f9d67685549d38500d41607dcc2af37101d967d23e3b47decbe60566ec250",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20e2b9a751fcd737d09916932cbc7be84e106507393ef386da0057152aff5a2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5fd6952e04ab59dfb897d8407ec2724c98f364e8ac7212677531725da941fcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51668bc8aa5ef6c3552fa6e5e7d7aa9acf02a0297badacb707adf0f5ca432f32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85a7acceec5dbd64452b50af82887038c103768790a8a9c666caa048263432f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15b79ceb2f5777ee511f9bcb722c4affc72a5e994fc3dcb250fd4e49c25814b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7176e5bd8f6a7137a54684507a3eec12999fbf23607d87a0f59f165794a80da3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0121cf8885d2a35b98223ebb05ad2daf7ea2ed2856227297d556c93564defe7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b4d3978ec7272aedd39b654ca1e360d1d433da76cafc74e5cc0a4271b4f63dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa1e45f9951b173954988890143df5263921f2ad9f66b7942e3c4174ff79922",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6bcc3e1b3b6515466f3f771069003d1a7c28be3adaeecf7afa6318ad0f679fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:476f42824d9813f4a3dfa9677101e2bada11079b9690ff481d04d8229d6f506d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d33d5a86d00d5c21b25612d5b56ad41941171947ac6cc586f588fe57adcba2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39d78c38fab0fdeda95d6831fbadf03ce3a8dd6dac641d03592f2b9fd498547b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:030e6baed3f298c645ebbc4fe12c87ef0060c9b210c46bf738545f9c265746ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12d299008217b4bf3eac42c86b1948c6bdd514cabc600e955e525df3c95b401c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7af3d490cecbb309a48a7b982cd59a82e2716121436e2b56c769ddd8130ee7dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2afe7a7b8da38f2d0eb619efeb293dda7014682625a7604735d497d99f9203d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4ff1c4e2ca4fef57964f233b56ed592551170af0019c55f92f0a82806737254",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9870ed936bff3d80332751f33239d29ae5e02af4ddab8b0f4eef6d1a2749dea6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:281e37fa1e91648a82ba5a41bc03757457c532f22d6cdb183c1f216e66b82d94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6119bfd75ce7cca0ccf7cb439ba6f23587eb563058c0c4ffabcfbd550767210",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a1d698bb9f754af6fa35a4145f147851dfe7feadc3b058e0e6821876060f188",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0c4b4986edc058f49dabeb5ce6f9759546e23b165c7ee20fd0e161161a25255",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c46f78fd60d3cfb0decf559edcc1d67f52cfcc4db6b8da58c2a8112f72aba73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:469f29bcd47822c46be00e6c7ed76000dc58ee3be1008b26d80e1e7a529083e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:050de9d7c87944233a18b8c0bc96c2ad55ca3f4fe87b786143421c5cbce64d90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:124d0e3f779e3bf7cb2fc8635aa1ed73a7d1540dd1bc22420542c26e6fb3e46d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d5f46eddc547cddf4a2d33b952322d7cca7d32cb44891490f9de31c75b12652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:659fdc4df649e574f48e2e60bb2e728ca910a7007358fcc196c1a3e1f162ae47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acf993ab622bbb03d6b0561ebf654e777254425aff03de0b87e9a18a7a252428",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d42d31e6e5433ac1e9aca4fe6573dd57ce66a6dbec09bb75addac05da9c4c3e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ff28ea3ed7b69ab47e64b3625eea861b3f3c4903682ce94aee46d8fbb8e58a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a77017d08f6b0be4bcf52fbb6b471465a7cf6c6361195167b07e81feaacdb10b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27c7f18e0360f10badc8bd3156fcf255dcfd0500ac86c7793a5edfef02a3647c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7520ccf6e89c32dabf2d57bfaeef54a560bd751c521a045baeb93572489f062b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c297a9d8223d4cd595d89d3e789b86e2558b902c9ba636af3f49587a17541dcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16a7a3f9d73ff11170a6f0fa686d03ef9a491089e8a3ddd492c93a865ed75aa3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c208a19538792b5664edf16eb9e1fa4e41a362a07879ef452f103eed5e3d9447",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76e56ea613d2ed02b02b6d707e4a09e53d99b6e3ea5151a069bf9f71fc126f25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20a0b23ad7f8f14327251b64491802cf457aba161d45e364240797fd608186c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0ba009ae3f8c15520952b6c3a4f56390411f66bec7800209e482913e71cb196",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8429326af23a76cb51e2944b846a141b9d3d121a3cc455b4a83e319bd2a1d6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aec24794b31ece49a4cc72a2e038cbf4f58cbe5606a28bf40d231b53e0832542",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d48d0bcb1de7ca243014616e40871ae85fd905923636d46917467f947deef1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e59f2bf60be15a82c13bf6532a12b19ea2951c6b81f0f07dd110bd9747175c84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36cbb69f70b77ab95176533a4b35ee1cc44755804d958038524222d50edb9238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61ace5783032cdbc1db06545a0adbb52122996697f10512c24c8b5a6d36c9900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f876f764c6b29dc77e092e7e2f924b9a4a6d9f2cb3896ffe0fbc2cd575ddbe4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:410020e00906f7983cc262d2dee2717eaacc45e1a58b58ac1abbc1280444170a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11c357d57555231335ecb6e287804e1969d8b2c0c00d7e509de5347e3144864f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f257703df5320763eb8a4d20b2ee9f4ce209840ac986237274190f7a1dcc88d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4623dd1d17576dc75dc5e017429ddad453ae03b424c27b1f119628fa8f7b2c05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44ee380afc6f438f608704b108853ff0d501b700c4a8196fa16a824ac31e777d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cf395ef797a9aac4df6b7a02ce18a0032c76092bc9c4afa1471540c263e79ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28b17f73ce6ca866b7e8af7a4cc354e7f2443f1f7d2fc99386834b84a5938c89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c230ca1e298337fccf4038a6380d7c8a4662758bce4bbe55b7c2a5e02fb439a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbc018ba524a54968bf5706eb7fff65eecc0a32620e5ec8c92dd2e60c4501b92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d53df41d99d85cab778ade553f245e5c8f22633e8e55ce0a55bad1c4b68a2e38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e5b41cd84ac4bc60b1797e0eabb501a699eee13ea782b8e403671c2ec985622",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f17c50a820abc4257dfcbcca511f551502cb7262d926db6ddbdee27969c8f728",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d362d886ed77c4dcd6920b598a6af73a3a82223ad8f4ee4ab6c8095c21525cfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be2f40da21ea9ac1b430fc98c3a06b6e1e140d61b77d5d5f1e056f9f41a066e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d39aa564715fbc725187e35df5d857ae947827c3ab71660024b7f5d93ed92c4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f11d4ef320502bcd0fe26ccbe1850a8969bf04cd28f04efe5b9e913054841fa8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:331103386328c4cf8d8620885a847703b5844b568ed842383d4ec454ab8e1846",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:add4f6ec969242fe36a7c88306688551123f93fcc74864671956683aa1d86339",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4ca03301fe8f6074211c3be890a2ff44d14c8d067c469f92b111d7d841da3fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42dddccd8a02d172d8894796d94b329a3ac38d69545a085e3942975a59ed9c4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72859b9721f0c6e7d2a2fdb5c2e928eec80becbf1761dd723c8ee912dd5e4de9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78edead1498bac0e459ac199ff65a513510af4a32786c41b7d365e6022c510c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25710922f3156fe1f06171feee1256c577416f291e389826f6d661b010124752",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a7c69315a2b7b355de4551d4ad9790a7ae0ca86dced94d35670030b55371ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:170ad90a5f690e3998db2350023f9212aa688d71bf7769fab4a77eecc164332e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6339453924f503b9d3cb4dde921f7b705528e2cb7f562243444121e7dbf19b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d42939c39dc1e978f4fa9530f3253d521cace197a18dc566454b0143c48bb0d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a317432b034404123e89b883bef600c1771247fe09f463fc1b39313bfc2e80bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60d3707ed83661b28a1f859cea78367c77aa40e4cd77a6e8011e756ca35ac807",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5f5ee0665ad3d629ad53471359e5a428623666af22781de4c37aa5f646410af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:912776644a49202be3407010dedc31cb4d31fc2411b97629a5ad8e537a093892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5bdb1c4df2bf524e5800bb8f530181e31842bff8976a14d7c77360352a646f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:917d4c028b5c6e8f79e4d0f21fea12c178d27710da0aca052d7dd0481b502898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7afa5da1ec37dad4230b57f2df4d6c07f404b31248fcd171d330d2f8b7ad148c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa45ab2259216391b465c4b9ccdb89fb7908e90fd34ee7c6973d862ef518f637",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3db76609448c443df02b8277429507b64f3ac814616778b80a7c5a2a0409cf96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6989d53b95e3903b59516440bf56ee1002f01ef0e8318d9b0f4d00782836a8b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c71c0014b26dd1a4d897f53cafbb671b76ef1bd5901a6c27178e2754e29d4256",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c156e8db644666cd02c17335383f1e33513f71ad05aa279fb47d7746b8ea595",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74f2aec75861452ac25eaf371cba7dbc3cbbec4600555131d34b9b35a8ea0132",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9b91a1c6f4e194acd077ece95b995b3c0987734d75dfc3a0f2abdcdeedf1be1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b1e845a8c68c4af045a34bd920650e6a21f9852652baf756200bf3c649d2397",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75e807735799d981a5cf395879065b0cb5147e70923dc9314d3ba7eedd219893",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9de5d871550544523eb64203df597c0eb2e3b4d4471d0f118eaeadae72055fc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:051a659d539bcbbeb00f6c4f76a927fcf2939cc351302ccec6960d4d92305ea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d044d167ba9209a4dfe0314501e0f0cc1a589b45a40a65775bf7e433e71cbae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:378bd2a9d051665b960728fd8a562c5b776ede0f8cc4821b5ceb92b470153503",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0718fa539da95a64b3d2449af8104217f55e9379b905bc5fb87c3c3274130186",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ade9a1cbf3063e2284c79fb80282dbb176de4578e9de53f96e45bef1a50a6c19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b694b01bb2873bcc3585bb65ace24e92948af31e1f1f2a8211dabbea1424188",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1db6355fdeda942720b166dec938b0e7a081cb87de80e72f23d30f5896f3bc97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:875e1ad123d2c83aea326805a53f4140296c2a6afad6c45882e1cae2c8d7ca8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc3310c7d92abc3e42e89af3afd7b9b050000878db63cf08167d331bf4cc3b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60cdfaff2b8bd8de04414164dcdbb106e2fdb6846f2b6cb2540bf51eb9a80510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dcc4bd4d5fb72f38b7c23f32047cb820ec2dc2242f08ec69619e62582b909f73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d08064f5cf2de564b49ea4391cf45ede95f6761b11bc31ca218e8dfd264a476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29c61e3a7856ed3e31ae8d42777b571ae7f08644bf27acb1f0a1c1856c308b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7fa45aec5bae3e6c08fad86e13a7f4185ebf53912687c707a9d88e7b815b1da1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9071b0957ceedf8bbeb2acb80ab91cc43302525dfb14184d540f1c133d6fa298",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4356080dd69f765842adb5b43e6dc036529d404afc93c2b03c516d2b9f5c6199",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a1ecca6298a044afa3e3ce0b15f871fc31e32f8dc80c43f5c9a088b70c771ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fb2ab129465aa9b8b2112eb27c9c156dc3eb7e2660ef63cc3e8a1c150467a74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8be1e8abe310fc2f8d9a8e5c52398e17fdb9975a416e208608661298492e05b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ca758a939959e0bddf5a3590c888df07db7c1fab55beceece1a3548bd1f17f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbdaa37cc9bf25cabe9cb48e86720efe609bbc2d6244c115d601d932bac0edd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd85247a2b661c62ae903219fa25cff5f583fc2c6b193e02d201dae26f1ce84d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c6c0d8654f12e0f6b2fbb06d8ef55081e97f530a48562d4c844127d1fcf6b7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ebf0ae35c1fc16342a8778cc9212b5254c9ee5162cf439dfe66eedfda5c39a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef78de9d48882e3e55be59b9ac421e6eda50b38bd79e0f5808d72bc7625a6216",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:249dd0b9c3b3714e92a53596d0c800a1baacd8b005235ffa5fd4b0422004876a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31e4f1c33720828bf97cf768939856eb49531e6ca0805720e9946fa354f03537",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0235e965a1a21a4e548625abcb562f4a4181e9d29830ac208d2decee3067c644",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77cff9e52636e1db952b872e7b2f02393772caf0285ca5d7ed81da5db173fdec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:648e27449350f50b6fbed7bce4ecdb586976446ddafcfa100cd235e74d3a2c38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:607d9c1a9c9f80a1bd21b1d3dfe9dad0b564c6a90d3359bd2d7e6594fc24f430",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dccb33ffe4778bee0967443755e55e7ae96fdda9e827bc61ea6287d11bda1a19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:272a4e9b637d1732477e24c751c5e2561996ae3d82ea10cdac822d996ab68143",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:710f24b54f1b3430cfd5070583c82a193ece7e6a99a8888b68f4c8906193de13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03ff91894dcba5710060a913dee3387294d5d918b4d92dab96205afd50459ae0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe81316360f7512b27c3740e22d0c42b3bdd383e21e8d53b34239360b9538717",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c55024a1b2106ffdf399590f6ed7ea33f5ae534b601d7eb726a02ac02b687bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2fb53692b291acfb5641ac4128fbf5f34703f04dede9c51994fc247d13739c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cef75ed0e5383138263d81e2cf31d65c1bfb2416f3fa33d91dd56f772a1aa8fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76bba9ac90c720b8513764aefd45dd4426bd670f45855a95faba47a66317faed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5ea004644ca56e10a6be724759a43c86e26d36968f141cd33bf56c00ded4a9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4705cbebe0f2b86173f7501909e174f47f2af99df540832d15c4ff8e3cb0c506",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9e9fc9a4fdb8861f7ceedf4e9a2652c9a2f23c37c09526b23277d5a0d384495",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cdb3e216a7792f00636cd5b2d28f45061cf957e6001909143da86d53f2b68413",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68cd6c6f8302389cb00e2b00a159fdeac24f644fe9daf6378091f000f1a7fa41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7f1ed9e93ac0034d350f0129af8bd2bd068eb69a9783f4f3e33b29d2a64c6f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff128f537a012f30dfec9fec00d38f9f50268198a124783e2c2c1dbc54a79873",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89013dbf6d1eda9b50402fbe4691d2d911d7f9a1cf69657cd88e9a3232fa0ab5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03e753dd69715f7b1b4bb994eb3d9a0c9b26fa611603492f6b5554999f8e2114",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73e74e9775bebc30a03b4407bb2b20061c09ee6b354ccac53dfed96205fc092a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eff8922a8b9fcc415fd0b2b058a35b3a3adbf782d947355156b2bf4f97fe1f8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6feb03f1014a2af15478e2d4087f550d1b69a32452d21aaf85745f6cf0c463a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc5fe78e55afe5528e6c133d08ea96465ae2dc223499adbc1d3d314eb822ee26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0052b724fc75638091e64feae206e56472f190038d1ddfe9788b207cd71fd360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdf455b6e7d7f099b3730996445cfb32f9743f519b32e3514f7dae468a86996c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8df95fe668cd67887b961dab177b97947039d7002ce74f7ae8bf0a9b6d5113cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6ccf60e3629f33ff9dd2b3b6215e0b8e3b81a3219cefcc11cde083ecc4664f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:818131ccd1235feeeb708903406eba00731ab0028b2272004b06235c75a121b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9e3aa8ab64ac34d90ce78c5911d91d7574de4c42bacd5ae9563b6d945147bf9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd7dc65be232b9b7b011932367eca95f07fdf271ccd88c1fafb65d152d547a12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9a9a6191cadf2ce8c4dd682c3e532c48b8ee7caf2465fed0190086c22b9492c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06911316ac07b9abd6ce0bed5ac424ce4e3e9e8e47ee8230118fc5dd2f4b48a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c27a813e7139bd63a370062a37235d90a6885258629358db2247f9346235aa91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89532cc989331b5ff07dc381067d087843137423fd2bef1bf2223f5f6b8f0d88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0df4a8e191bbab062c549daaabbe6ba4809ccdd9b87b61b4844c8c4d66b790a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:87e52531506685cb0f20dc15358bd187e5d38281c3b552bebf6e6d1e42ad92d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d31be2cd877d2f6a22ed9efa52d27f287d8a33036cb7833c545f00188e6a477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:909fb5490bb5df6c877668ac18bbf73cda213d7dbb3a1d2a8d1013bef4f8ed22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e95d6e0acd379be9b199113235c64c921223faa213b4e5f91f215f056adc1e69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6a0316b7b4713c22e093abc05a5bf01541c77ed24578fe1f57fe437a4208a25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:349e77eb1fca043555141f1aeb018c47079c147358df4d6a58d00402bee9791b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3c713d2b9d613fb286082decaf8ae0d44222855874a746238482a4c268c0bf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2bb600208d5a9cfb7f7df7e54bed27a8d3041b5657eddc74474edcb4e3ede12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc3b99028b610bd236645eca33d75b98fa9f07eb82239cf6031385ceb825080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e62bca2c90ace2b9e000d02bc3538cfc3dd5bb25b0c9740f47b4fbf1e6b6a00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e746f59d62344dcca7f14582affd2b2543e3204d3ecf6525513381057c7c2fbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44eb78b7f830a5cddf847c541080f8d2f54aed8ffbbf9e9e0a82f148893dbe5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c944c353ce1d26e0cafbe1a171d2bd8002d9588e6d217c811e8862ff12aad4dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d82fc296d351848a187b975166e77ff1740ab94dfa50e0ad40bbb368470653dc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a42215e87f56483854177094f00a56dec2355e2cc0346091c0d131696114bd81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88dd22e6b6c0b82f58b8bfcb96a718b61175ed6b5a174b71d87c19e0f260af3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f35908c2704a9219002a316958665b6d56092d2fe59d8fcdf20fa3817bb482c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce92079aa9854b25e8b0179e884c7fac36787f1227f087caddcce1cbc3f42568",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0b1505c9797a351ba292b3ecd9d525e94bbe96cac0f5cb5a3d024aacd7aee2c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:563be3c9ca5d1cfa3fdbab3ee89c769934d71987d61770a8723176d8fde3da24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1caadea1fe1f44be99448485efdd8c02ef616da6a8d0a050bf308a68ec23ea68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c832ac1f2b95744b48fe50795ffd8ba136b93b14653b5ffc428e1642c62b91a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0eb4b37fe8a8bc9c452c58ebe200fbf49f6d436210014c29c9c1f9dd57ef8df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c63610924ad5aea7867167a2d8ffe3ad61ded28b13319c7d91c7ca0473d95e99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:689ef2b8d48e5a906d79d5aebe16c3a46843155b236361af5faab189e82a4d6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e348e94e73ce1be18394a47c2a6805fd50908c087f362586dcc3ee3a1e58d654",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e6bf9e329baa9ea5b348a16a2fb38fdc05ccafc393fd99fdf773f735a9c5573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d2fb53f362a449a838989041b614aa32367816e338edf9d3dc1a58532bb68f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c0d4a908b2cf6051da6d5ce3171f65cf193acc1b10968a376424f11ad7dc60d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4ce968491bbe0f2db29e9af17f6972c7fed4fb014e56bea40a9585e40dcf082",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7f71897aad9420b8c9e67073d7ed86eb969c20d8621379a7bd24aa1915f0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82c1bb049f19de6ebae1f17bad545e8093fa91d586eff77a57adb306f2d187e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:137d4c21c59430bd54523fe68df630ecbe2f5d226e587cba32161808dd248183",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:735bcb34d97de94e5515acf7b70bf6680e5f7a7235fe653bae666e9e664d41cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:679728f60d6d1a342c06aebe3830dad314a5e46ef4295ae8a0494c04f34fca08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:baf1ae39b1ca951a1c3edf73d62f21bc409dd211f447000c1d21584d58847575",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:235e8bef01064ad26fcd52f83fb63207d32fa0e8f4ffe32ac19a7e4e5df002a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7809f426ffbbf705762eb4c3a63c5e60fe80d865e8f324e0512af8b426fc8c69",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0741570a6aea320cf433c9576f1af8b6020984cb190fc8b94e9de364b9a16c03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2800324594d595ea1d585e149a3641a876d03f328910bca6b8d5146a06f7bbdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b80e7b8f67c26eebe534e5d40920a430ae9ea099a5227de5c89cfd09735b19a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e33a4dbe7d2fd2760c6912b6a5b8efc055d6ad93c9936689a940f3204aee55b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2cefaf35e48685298b803f2c9e9ad8733d3e22b378e50d359f1535c0310be46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa756c8a894b19f1296c821caf7e9aab5316f822612d8a32758b906b3c0ce364",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f0f886c8994e9def478076bbc14120da42450dd342b085a99b9ef8084af9aab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b936514f5a3a15efc8c8eb84e7ee24c062efa954d8c9c25df951f4007c08336b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3542f5da08d71f2caa8742eb2d632e83f8b31d5fa5a93d771ddc9209be9ae895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0687cbfe5b9e9a63521b4a2f1e913ecffb35bff038211fc8bfc4dc277c193d0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:234a225028a09eed2d7747a72e447b5734318c4406b9459f5b689a6bf93c5d09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72e04c6d932e87f097a4bc344d67c2fdb383f5f5a7a532a236321f6a4dcfbb66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f99af7003a71fc0afacf96968a740ea2892b2fc8c6b45ed8321fe7fe0260c4b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e4b581c98a7ca80bf83eaa3859d33bcadc8970ef661a4672f8cc0495af72175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a09aa2d7801d61e63530a28bee09de287c99ba11171d6756d8675d31dc754dcc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57f465bbca8c4ee064a73e3fa044b4fac3a158e1d754611a63db7feb7ffeec2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e6022327fc69de2c0c3b4f95a35ddc12104e5c41d9adf74f4c1d50a4bfc8f78",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df409a92f0a1edbf3902e63a7cb692bbb05a91bee87565b108495ae6c5f47b19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37596c9b03d1beac82964c6cf5b1e5abe75c4a6975d82973ab2d4dda90a2faef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-6.0.0-0.rc1.13.fc38.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:0052b724fc75638091e64feae206e56472f190038d1ddfe9788b207cd71fd360": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssh-9.0p1-1.fc38.aarch64.rpm"
+          },
+          "sha256:0121cf8885d2a35b98223ebb05ad2daf7ea2ed2856227297d556c93564defe7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/duktape-2.6.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:0235e965a1a21a4e548625abcb562f4a4181e9d29830ac208d2decee3067c644": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:030e6baed3f298c645ebbc4fe12c87ef0060c9b210c46bf738545f9c265746ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gdisk-1.0.9-3.fc37.aarch64.rpm"
+          },
+          "sha256:03e753dd69715f7b1b4bb994eb3d9a0c9b26fa611603492f6b5554999f8e2114": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:03ff91894dcba5710060a913dee3387294d5d918b4d92dab96205afd50459ae0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm"
+          },
+          "sha256:050de9d7c87944233a18b8c0bc96c2ad55ca3f4fe87b786143421c5cbce64d90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gobject-introspection-1.73.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:051a659d539bcbbeb00f6c4f76a927fcf2939cc351302ccec6960d4d92305ea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm"
+          },
+          "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:0687cbfe5b9e9a63521b4a2f1e913ecffb35bff038211fc8bfc4dc277c193d0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/v/vim-data-9.0.213-1.fc38.noarch.rpm"
+          },
+          "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc38.noarch.rpm"
+          },
+          "sha256:06911316ac07b9abd6ce0bed5ac424ce4e3e9e8e47ee8230118fc5dd2f4b48a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:0718fa539da95a64b3d2449af8104217f55e9379b905bc5fb87c3c3274130186": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnghttp2-1.48.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:0741570a6aea320cf433c9576f1af8b6020984cb190fc8b94e9de364b9a16c03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-pam-251.4-51.fc37.aarch64.rpm"
+          },
+          "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:0b1505c9797a351ba292b3ecd9d525e94bbe96cac0f5cb5a3d024aacd7aee2c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:0b694b01bb2873bcc3585bb65ace24e92948af31e1f1f2a8211dabbea1424188": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:0c230ca1e298337fccf4038a6380d7c8a4662758bce4bbe55b7c2a5e02fb439a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm"
+          },
+          "sha256:0d2fb53f362a449a838989041b614aa32367816e338edf9d3dc1a58532bb68f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/shadow-utils-4.11.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm"
+          },
+          "sha256:0df4a8e191bbab062c549daaabbe6ba4809ccdd9b87b61b4844c8c4d66b790a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/plymouth-core-libs-22.02.122-2.fc37.aarch64.rpm"
+          },
+          "sha256:0e8db2cef395cb3ca7940fcb712a27e50a279da1aaed63e019b96d003e525840": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/audit-libs-3.0.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:0ff28ea3ed7b69ab47e64b3625eea861b3f3c4903682ce94aee46d8fbb8e58a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grubby-8.40-64.fc37.aarch64.rpm"
+          },
+          "sha256:11c357d57555231335ecb6e287804e1969d8b2c0c00d7e509de5347e3144864f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kernel-modules-6.0.0-0.rc1.13.fc38.aarch64.rpm"
+          },
+          "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/selinux-policy-targeted-37.9-1.fc38.noarch.rpm"
+          },
+          "sha256:124d0e3f779e3bf7cb2fc8635aa1ed73a7d1540dd1bc22420542c26e6fb3e46d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grep-3.7-4.fc37.aarch64.rpm"
+          },
+          "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:12d299008217b4bf3eac42c86b1948c6bdd514cabc600e955e525df3c95b401c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-0.21-17.fc38.0.20220203.aarch64.rpm"
+          },
+          "sha256:137d4c21c59430bd54523fe68df630ecbe2f5d226e587cba32161808dd248183": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sssd-kcm-2.7.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:15b79ceb2f5777ee511f9bcb722c4affc72a5e994fc3dcb250fd4e49c25814b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-rawhide-modular-38-0.2.noarch.rpm"
+          },
+          "sha256:16a7a3f9d73ff11170a6f0fa686d03ef9a491089e8a3ddd492c93a865ed75aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/intel-gpu-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:170ad90a5f690e3998db2350023f9212aa688d71bf7769fab4a77eecc164332e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-common-2.06-48.fc38.noarch.rpm"
+          },
+          "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm"
+          },
+          "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:1b4d3978ec7272aedd39b654ca1e360d1d433da76cafc74e5cc0a4271b4f63dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm"
+          },
+          "sha256:1caadea1fe1f44be99448485efdd8c02ef616da6a8d0a050bf308a68ec23ea68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/readline-8.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:1db6355fdeda942720b166dec938b0e7a081cb87de80e72f23d30f5896f3bc97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:1e78cf0c9744c640f0eee419d5c5b4ff057693be4b8cc99bae3367571b4c5bb6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bluez-5.65-1.fc37.aarch64.rpm"
+          },
+          "sha256:1e9178f02120efcfaf723da06ee73725213a3e67831fea796e21275899b0fa54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:1ef317581715089895fc30425b3eb3f351138894fbe86f4594c8512ba7be19fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bash-5.1.16-3.fc37.aarch64.rpm"
+          },
+          "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:20a0b23ad7f8f14327251b64491802cf457aba161d45e364240797fd608186c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ipset-7.15-4.fc37.aarch64.rpm"
+          },
+          "sha256:20e2b9a751fcd737d09916932cbc7be84e106507393ef386da0057152aff5a2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.aarch64.rpm"
+          },
+          "sha256:234a225028a09eed2d7747a72e447b5734318c4406b9459f5b689a6bf93c5d09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/v/vim-minimal-9.0.213-1.fc38.aarch64.rpm"
+          },
+          "sha256:235e8bef01064ad26fcd52f83fb63207d32fa0e8f4ffe32ac19a7e4e5df002a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-libs-251.4-51.fc37.aarch64.rpm"
+          },
+          "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:240fd2e4f0ab37d475a1e981921729bcaeda85a38c0d3e44079b1006769a77a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:249dd0b9c3b3714e92a53596d0c800a1baacd8b005235ffa5fd4b0422004876a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libuser-0.63-12.fc37.aarch64.rpm"
+          },
+          "sha256:249f9d67685549d38500d41607dcc2af37101d967d23e3b47decbe60566ec250": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dracut-config-rescue-057-2.fc38.aarch64.rpm"
+          },
+          "sha256:25378e75b524c602a0af5c12da1b68b4699a61bc165b487040a2357cfdc96683": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:25710922f3156fe1f06171feee1256c577416f291e389826f6d661b010124752": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm"
+          },
+          "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:272a4e9b637d1732477e24c751c5e2561996ae3d82ea10cdac822d996ab68143": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:27c7f18e0360f10badc8bd3156fcf255dcfd0500ac86c7793a5edfef02a3647c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:2800324594d595ea1d585e149a3641a876d03f328910bca6b8d5146a06f7bbdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-resolved-251.4-51.fc37.aarch64.rpm"
+          },
+          "sha256:281e37fa1e91648a82ba5a41bc03757457c532f22d6cdb183c1f216e66b82d94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-common-2.36.9000-1.fc38.aarch64.rpm"
+          },
+          "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/polkit-121-4.fc38.aarch64.rpm"
+          },
+          "sha256:28b17f73ce6ca866b7e8af7a4cc354e7f2443f1f7d2fc99386834b84a5938c89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:29c61e3a7856ed3e31ae8d42777b571ae7f08644bf27acb1f0a1c1856c308b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libreport-filesystem-2.17.1-3.fc37.noarch.rpm"
+          },
+          "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:2afe7a7b8da38f2d0eb619efeb293dda7014682625a7604735d497d99f9203d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-runtime-0.21-17.fc38.0.20220203.aarch64.rpm"
+          },
+          "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gzip-1.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:2d2bf7377a0181175b289acae55b3afad0dfb850ad9f65695818ec80481abccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:2d33d5a86d00d5c21b25612d5b56ad41941171947ac6cc586f588fe57adcba2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm"
+          },
+          "sha256:31e4f1c33720828bf97cf768939856eb49531e6ca0805720e9946fa354f03537": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:331103386328c4cf8d8620885a847703b5844b568ed842383d4ec454ab8e1846": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:349e77eb1fca043555141f1aeb018c47079c147358df4d6a58d00402bee9791b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-3.11.0~rc1-1.fc38.aarch64.rpm"
+          },
+          "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:351b9f8911296b57b7f69f8b6f04bde3715648ed827aa6f5fa6b6ea44168341a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm"
+          },
+          "sha256:3542f5da08d71f2caa8742eb2d632e83f8b31d5fa5a93d771ddc9209be9ae895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-2.48-5.fc37.aarch64.rpm"
+          },
+          "sha256:36cbb69f70b77ab95176533a4b35ee1cc44755804d958038524222d50edb9238": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/jq-1.6-14.fc37.aarch64.rpm"
+          },
+          "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-common-1.14.0-3.fc37.noarch.rpm"
+          },
+          "sha256:37596c9b03d1beac82964c6cf5b1e5abe75c4a6975d82973ab2d4dda90a2faef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:378bd2a9d051665b960728fd8a562c5b776ede0f8cc4821b5ceb92b470153503": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnftnl-1.2.3-1.fc38.aarch64.rpm"
+          },
+          "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm"
+          },
+          "sha256:39d78c38fab0fdeda95d6831fbadf03ce3a8dd6dac641d03592f2b9fd498547b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3a630412a9094d1294745986fd77c6e99762a667e8265c9859feb67651996785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:3c156e8db644666cd02c17335383f1e33513f71ad05aa279fb47d7746b8ea595": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:3c55024a1b2106ffdf399590f6ed7ea33f5ae534b601d7eb726a02ac02b687bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nano-6.4-1.fc37.aarch64.rpm"
+          },
+          "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/file-5.42-4.fc37.aarch64.rpm"
+          },
+          "sha256:3db76609448c443df02b8277429507b64f3ac814616778b80a7c5a2a0409cf96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:3e6022327fc69de2c0c3b4f95a35ddc12104e5c41d9adf74f4c1d50a4bfc8f78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zchunk-libs-1.2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:3e62bca2c90ace2b9e000d02bc3538cfc3dd5bb25b0c9740f47b4fbf1e6b6a00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:3fc4b0553bef0015b8e73b00ea5c247e5eeb069583bdda3be4b9c97c3731efeb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dhcp-client-4.4.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pigz-2.7-2.fc37.aarch64.rpm"
+          },
+          "sha256:410020e00906f7983cc262d2dee2717eaacc45e1a58b58ac1abbc1280444170a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kernel-core-6.0.0-0.rc1.13.fc38.aarch64.rpm"
+          },
+          "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-common-38-0.2.noarch.rpm"
+          },
+          "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-gpg-keys-38-0.2.noarch.rpm"
+          },
+          "sha256:42dddccd8a02d172d8894796d94b329a3ac38d69545a085e3942975a59ed9c4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcurl-7.84.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:42eb0c3836c6e593a371009808dbd1013de30cd0e636f6c668eb79475b6c42ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-libs-1.14.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm"
+          },
+          "sha256:4356080dd69f765842adb5b43e6dc036529d404afc93c2b03c516d2b9f5c6199": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_certmap-2.7.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:44eb78b7f830a5cddf847c541080f8d2f54aed8ffbbf9e9e0a82f148893dbe5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:44ee380afc6f438f608704b108853ff0d501b700c4a8196fa16a824ac31e777d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm"
+          },
+          "sha256:4623dd1d17576dc75dc5e017429ddad453ae03b424c27b1f119628fa8f7b2c05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/less-590-5.fc37.aarch64.rpm"
+          },
+          "sha256:469f29bcd47822c46be00e6c7ed76000dc58ee3be1008b26d80e1e7a529083e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm"
+          },
+          "sha256:4705cbebe0f2b86173f7501909e174f47f2af99df540832d15c4ff8e3cb0c506": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:476f42824d9813f4a3dfa9677101e2bada11079b9690ff481d04d8229d6f506d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm"
+          },
+          "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:4aa1e45f9951b173954988890143df5263921f2ad9f66b7942e3c4174ff79922": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-1.8.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:4c6c0d8654f12e0f6b2fbb06d8ef55081e97f530a48562d4c844127d1fcf6b7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:51668bc8aa5ef6c3552fa6e5e7d7aa9acf02a0297badacb707adf0f5ca432f32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-libs-0.187-6.fc37.aarch64.rpm"
+          },
+          "sha256:563be3c9ca5d1cfa3fdbab3ee89c769934d71987d61770a8723176d8fde3da24": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-unbound-1.16.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm"
+          },
+          "sha256:5c46f78fd60d3cfb0decf559edcc1d67f52cfcc4db6b8da58c2a8112f72aba73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:5ca758a939959e0bddf5a3590c888df07db7c1fab55beceece1a3548bd1f17f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libstdc++-12.1.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:5e4b581c98a7ca80bf83eaa3859d33bcadc8970ef661a4672f8cc0495af72175": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:5f0f886c8994e9def478076bbc14120da42450dd342b085a99b9ef8084af9aab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:5f257703df5320763eb8a4d20b2ee9f4ce209840ac986237274190f7a1dcc88d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kpartx-0.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:5fb2ab129465aa9b8b2112eb27c9c156dc3eb7e2660ef63cc3e8a1c150467a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_nss_idmap-2.7.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:607d9c1a9c9f80a1bd21b1d3dfe9dad0b564c6a90d3359bd2d7e6594fc24f430": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/linux-firmware-whence-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:608b7df709cddea3a9733e93502f1f1c052d3cd6044f2b00af6116b4cedd10bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm"
+          },
+          "sha256:60cdfaff2b8bd8de04414164dcdbb106e2fdb6846f2b6cb2540bf51eb9a80510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:60d3707ed83661b28a1f859cea78367c77aa40e4cd77a6e8011e756ca35ac807": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgcc-12.1.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:615d42a7ea6822fa0564ecff628d5f0cb725e7578bc5fa3b27968faa3cd9c108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:61ace5783032cdbc1db06545a0adbb52122996697f10512c24c8b5a6d36c9900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kbd-2.5.1-2.fc37.aarch64.rpm"
+          },
+          "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:648e27449350f50b6fbed7bce4ecdb586976446ddafcfa100cd235e74d3a2c38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/linux-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm"
+          },
+          "sha256:659fdc4df649e574f48e2e60bb2e728ca910a7007358fcc196c1a3e1f162ae47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-efi-aa64-2.06-48.fc38.aarch64.rpm"
+          },
+          "sha256:679728f60d6d1a342c06aebe3830dad314a5e46ef4295ae8a0494c04f34fca08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm"
+          },
+          "sha256:689ef2b8d48e5a906d79d5aebe16c3a46843155b236361af5faab189e82a4d6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:68cd6c6f8302389cb00e2b00a159fdeac24f644fe9daf6378091f000f1a7fa41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-sysinit-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:6989d53b95e3903b59516440bf56ee1002f01ef0e8318d9b0f4d00782836a8b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libjcat-0.1.10-2.fc37.aarch64.rpm"
+          },
+          "sha256:6b1e845a8c68c4af045a34bd920650e6a21f9852652baf756200bf3c649d2397": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmnl-1.0.4-16.fc37.aarch64.rpm"
+          },
+          "sha256:6b80e7b8f67c26eebe534e5d40920a430ae9ea099a5227de5c89cfd09735b19a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-udev-251.4-51.fc37.aarch64.rpm"
+          },
+          "sha256:6d08064f5cf2de564b49ea4391cf45ede95f6761b11bc31ca218e8dfd264a476": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/librepo-1.14.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:6d5f46eddc547cddf4a2d33b952322d7cca7d32cb44891490f9de31c75b12652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm"
+          },
+          "sha256:6e5b41cd84ac4bc60b1797e0eabb501a699eee13ea782b8e403671c2ec985622": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-loop-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:6e954ed4778a06f63f421dc47b5370b6c6b8cc03c0376a63a1f01daa040a5bc8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/audit-3.0.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/t/tzdata-2022b-1.fc38.noarch.rpm"
+          },
+          "sha256:6feb03f1014a2af15478e2d4087f550d1b69a32452d21aaf85745f6cf0c463a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/oniguruma-6.9.8-1.fc37.1.aarch64.rpm"
+          },
+          "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/shim-aa64-15.6-2.aarch64.rpm"
+          },
+          "sha256:710f24b54f1b3430cfd5070583c82a193ece7e6a99a8888b68f4c8906193de13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/man-db-2.10.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:7176e5bd8f6a7137a54684507a3eec12999fbf23607d87a0f59f165794a80da3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm"
+          },
+          "sha256:72859b9721f0c6e7d2a2fdb5c2e928eec80becbf1761dd723c8ee912dd5e4de9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:72e04c6d932e87f097a4bc344d67c2fdb383f5f5a7a532a236321f6a4dcfbb66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm"
+          },
+          "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:735bcb34d97de94e5515acf7b70bf6680e5f7a7235fe653bae666e9e664d41cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm"
+          },
+          "sha256:73793bf267725e2ebbf2fa5d32aff363a614d1cbc98624258ac8df564d158e4b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:73e74e9775bebc30a03b4407bb2b20061c09ee6b354ccac53dfed96205fc092a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:74f2aec75861452ac25eaf371cba7dbc3cbbec4600555131d34b9b35a8ea0132": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmaxminddb-1.6.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:7520ccf6e89c32dabf2d57bfaeef54a560bd751c521a045baeb93572489f062b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/inih-56-2.fc37.aarch64.rpm"
+          },
+          "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm"
+          },
+          "sha256:75e807735799d981a5cf395879065b0cb5147e70923dc9314d3ba7eedd219893": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:76bba9ac90c720b8513764aefd45dd4426bd670f45855a95faba47a66317faed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/npth-1.6-9.fc37.aarch64.rpm"
+          },
+          "sha256:76e56ea613d2ed02b02b6d707e4a09e53d99b6e3ea5151a069bf9f71fc126f25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iproute-5.18.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:77cff9e52636e1db952b872e7b2f02393772caf0285ca5d7ed81da5db173fdec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxmlb-0.3.9-2.fc37.aarch64.rpm"
+          },
+          "sha256:7809f426ffbbf705762eb4c3a63c5e60fe80d865e8f324e0512af8b426fc8c69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-networkd-251.4-51.fc37.aarch64.rpm"
+          },
+          "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:78edead1498bac0e459ac199ff65a513510af4a32786c41b7d365e6022c510c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libdnf-0.67.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:7a1ecca6298a044afa3e3ce0b15f871fc31e32f8dc80c43f5c9a088b70c771ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_idmap-2.7.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:7af3d490cecbb309a48a7b982cd59a82e2716121436e2b56c769ddd8130ee7dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-libs-0.21-17.fc38.0.20220203.aarch64.rpm"
+          },
+          "sha256:7afa5da1ec37dad4230b57f2df4d6c07f404b31248fcd171d330d2f8b7ad148c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm"
+          },
+          "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm"
+          },
+          "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/polkit-libs-121-4.fc38.aarch64.rpm"
+          },
+          "sha256:7d31be2cd877d2f6a22ed9efa52d27f287d8a33036cb7833c545f00188e6a477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/popt-1.19~rc1-3.fc37.aarch64.rpm"
+          },
+          "sha256:7fa45aec5bae3e6c08fad86e13a7f4185ebf53912687c707a9d88e7b815b1da1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:818131ccd1235feeeb708903406eba00731ab0028b2272004b06235c75a121b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/parted-3.5-6.fc38.aarch64.rpm"
+          },
+          "sha256:81ea9684679162bb4cb55a5742714b72491f8b4ddfd68d713564f0ad87f08d47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dracut-057-2.fc38.aarch64.rpm"
+          },
+          "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:828ccdf867dea1145e90a327a3556465d1076c5d749b1976c32f1cfb3f3468ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:82c1bb049f19de6ebae1f17bad545e8093fa91d586eff77a57adb306f2d187e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sssd-common-2.7.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:85a7acceec5dbd64452b50af82887038c103768790a8a9c666caa048263432f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-modular-38-0.2.noarch.rpm"
+          },
+          "sha256:86e5cb2ff99e096a1d7a31bdd0a0038ba0aa6831ccd8804f5a04b262e2772dda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm"
+          },
+          "sha256:875e1ad123d2c83aea326805a53f4140296c2a6afad6c45882e1cae2c8d7ca8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:87e52531506685cb0f20dc15358bd187e5d38281c3b552bebf6e6d1e42ad92d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/plymouth-scripts-22.02.122-2.fc37.aarch64.rpm"
+          },
+          "sha256:88dd22e6b6c0b82f58b8bfcb96a718b61175ed6b5a174b71d87c19e0f260af3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-libdnf-0.67.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:89013dbf6d1eda9b50402fbe4691d2d911d7f9a1cf69657cd88e9a3232fa0ab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:89532cc989331b5ff07dc381067d087843137423fd2bef1bf2223f5f6b8f0d88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/plymouth-22.02.122-2.fc37.aarch64.rpm"
+          },
+          "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm"
+          },
+          "sha256:8a1d698bb9f754af6fa35a4145f147851dfe7feadc3b058e0e6821876060f188": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-minimal-langpack-2.36.9000-1.fc38.aarch64.rpm"
+          },
+          "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:8c0d4a908b2cf6051da6d5ce3171f65cf193acc1b10968a376424f11ad7dc60d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-38-0.2.noarch.rpm"
+          },
+          "sha256:8cf395ef797a9aac4df6b7a02ce18a0032c76092bc9c4afa1471540c263e79ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm"
+          },
+          "sha256:8df95fe668cd67887b961dab177b97947039d7002ce74f7ae8bf0a9b6d5113cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssh-server-9.0p1-1.fc38.aarch64.rpm"
+          },
+          "sha256:8e59aca2373dfb636f7a5cea8f4d085d1fdc18577dd6aedd6ac19b6b937bcc9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm"
+          },
+          "sha256:8f876f764c6b29dc77e092e7e2f924b9a4a6d9f2cb3896ffe0fbc2cd575ddbe4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kernel-6.0.0-0.rc1.13.fc38.aarch64.rpm"
+          },
+          "sha256:9071b0957ceedf8bbeb2acb80ab91cc43302525dfb14184d540f1c133d6fa298": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libssh-0.9.6-5.fc37.aarch64.rpm"
+          },
+          "sha256:909fb5490bb5df6c877668ac18bbf73cda213d7dbb3a1d2a8d1013bef4f8ed22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm"
+          },
+          "sha256:912776644a49202be3407010dedc31cb4d31fc2411b97629a5ad8e537a093892": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm"
+          },
+          "sha256:917d4c028b5c6e8f79e4d0f21fea12c178d27710da0aca052d7dd0481b502898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgusb-0.3.10-3.fc37.aarch64.rpm"
+          },
+          "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm"
+          },
+          "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/crypto-policies-20220815-1.gite4ed860.fc38.noarch.rpm"
+          },
+          "sha256:9870ed936bff3d80332751f33239d29ae5e02af4ddab8b0f4eef6d1a2749dea6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-2.36.9000-1.fc38.aarch64.rpm"
+          },
+          "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm"
+          },
+          "sha256:9a7c69315a2b7b355de4551d4ad9790a7ae0ca86dced94d35670030b55371ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:9d044d167ba9209a4dfe0314501e0f0cc1a589b45a40a65775bf7e433e71cbae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:9de5d871550544523eb64203df597c0eb2e3b4d4471d0f118eaeadae72055fc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libndp-1.8-4.fc37.aarch64.rpm"
+          },
+          "sha256:9e33a4dbe7d2fd2760c6912b6a5b8efc055d6ad93c9936689a940f3204aee55b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:9e6bf9e329baa9ea5b348a16a2fb38fdc05ccafc393fd99fdf773f735a9c5573": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:a09aa2d7801d61e63530a28bee09de287c99ba11171d6756d8675d31dc754dcc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm"
+          },
+          "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm"
+          },
+          "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nettle-3.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kmod-30-2.fc37.aarch64.rpm"
+          },
+          "sha256:a21e3d9871e35bffbb194952de4bac40bfd2cc4481225c5da610db824d83e3d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm"
+          },
+          "sha256:a317432b034404123e89b883bef600c1771247fe09f463fc1b39313bfc2e80bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm"
+          },
+          "sha256:a3c713d2b9d613fb286082decaf8ae0d44222855874a746238482a4c268c0bf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dbus-1.2.18-5.fc37.aarch64.rpm"
+          },
+          "sha256:a3ebf0ae35c1fc16342a8778cc9212b5254c9ee5162cf439dfe66eedfda5c39a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:a42215e87f56483854177094f00a56dec2355e2cc0346091c0d131696114bd81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:a52bd1031b97bf1642e0b56f460b6a88b426755b9e1fe218af359b215585175c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cyrus-sasl-lib-2.1.28-7.fc37.aarch64.rpm"
+          },
+          "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm"
+          },
+          "sha256:a77017d08f6b0be4bcf52fbb6b471465a7cf6c6361195167b07e81feaacdb10b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/h/hostname-3.23-7.fc37.aarch64.rpm"
+          },
+          "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm"
+          },
+          "sha256:aa45ab2259216391b465c4b9ccdb89fb7908e90fd34ee7c6973d862ef518f637": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm"
+          },
+          "sha256:aa756c8a894b19f1296c821caf7e9aab5316f822612d8a32758b906b3c0ce364": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/unbound-libs-1.16.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-rawhide-38-0.2.noarch.rpm"
+          },
+          "sha256:acf993ab622bbb03d6b0561ebf654e777254425aff03de0b87e9a18a7a252428": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-tools-2.06-48.fc38.aarch64.rpm"
+          },
+          "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm"
+          },
+          "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:add4f6ec969242fe36a7c88306688551123f93fcc74864671956683aa1d86339": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm"
+          },
+          "sha256:ade9a1cbf3063e2284c79fb80282dbb176de4578e9de53f96e45bef1a50a6c19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:aec24794b31ece49a4cc72a2e038cbf4f58cbe5606a28bf40d231b53e0832542": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:b0c4b4986edc058f49dabeb5ce6f9759546e23b165c7ee20fd0e161161a25255": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:b0eb4b37fe8a8bc9c452c58ebe200fbf49f6d436210014c29c9c1f9dd57ef8df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm"
+          },
+          "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sed-4.8-11.fc37.aarch64.rpm"
+          },
+          "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:b353a0995c13684076f30b900fa47ce16652145302f9670ebd3f7ca1397e46c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:b3f7d94a07fe0bba6fa9b0ec306faa022d6206fab30cf29fa2f5ba3c3909473b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/NetworkManager-1.39.11-1.fc37.aarch64.rpm"
+          },
+          "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm"
+          },
+          "sha256:b4ca03301fe8f6074211c3be890a2ff44d14c8d067c469f92b111d7d841da3fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm"
+          },
+          "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm"
+          },
+          "sha256:b57f465bbca8c4ee064a73e3fa044b4fac3a158e1d754611a63db7feb7ffeec2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/y/yum-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:b5ea004644ca56e10a6be724759a43c86e26d36968f141cd33bf56c00ded4a9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nspr-4.34.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:b6339453924f503b9d3cb4dde921f7b705528e2cb7f562243444121e7dbf19b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm"
+          },
+          "sha256:b72109015ff0f8d68698d2663bab1c417576f237733ec53a32e0e6835c6b2a6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm"
+          },
+          "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm"
+          },
+          "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/json-c-0.16-2.fc37.aarch64.rpm"
+          },
+          "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm"
+          },
+          "sha256:b936514f5a3a15efc8c8eb84e7ee24c062efa954d8c9c25df951f4007c08336b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm"
+          },
+          "sha256:b9a9a6191cadf2ce8c4dd682c3e532c48b8ee7caf2465fed0190086c22b9492c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcsc-lite-1.9.8-2.fc37.aarch64.rpm"
+          },
+          "sha256:b9e3aa8ab64ac34d90ce78c5911d91d7574de4c42bacd5ae9563b6d945147bf9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/passwd-0.80-13.fc37.aarch64.rpm"
+          },
+          "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:baf1ae39b1ca951a1c3edf73d62f21bc409dd211f447000c1d21584d58847575": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-251.4-51.fc37.aarch64.rpm"
+          },
+          "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:bbc018ba524a54968bf5706eb7fff65eecc0a32620e5ec8c92dd2e60c4501b92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-crypto-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm"
+          },
+          "sha256:bc3b99028b610bd236645eca33d75b98fa9f07eb82239cf6031385ceb825080f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:bc5fe78e55afe5528e6c133d08ea96465ae2dc223499adbc1d3d314eb822ee26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openldap-2.6.2-5.fc38.aarch64.rpm"
+          },
+          "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm"
+          },
+          "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm"
+          },
+          "sha256:bdf455b6e7d7f099b3730996445cfb32f9743f519b32e3514f7dae468a86996c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssh-clients-9.0p1-1.fc38.aarch64.rpm"
+          },
+          "sha256:be2f40da21ea9ac1b430fc98c3a06b6e1e140d61b77d5d5f1e056f9f41a066e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-swap-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:c0dc904e2d0c90613dcf2c9db3b7f9dde1cd682030b14cbde677beb328a93d8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:c208a19538792b5664edf16eb9e1fa4e41a362a07879ef452f103eed5e3d9447": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:c27a813e7139bd63a370062a37235d90a6885258629358db2247f9346235aa91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pinentry-1.2.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:c297a9d8223d4cd595d89d3e789b86e2558b902c9ba636af3f49587a17541dcd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm"
+          },
+          "sha256:c2bb600208d5a9cfb7f7df7e54bed27a8d3041b5657eddc74474edcb4e3ede12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm"
+          },
+          "sha256:c2fb53692b291acfb5641ac4128fbf5f34703f04dede9c51994fc247d13739c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:c433230048161b2a019e71d4987d2882ee74badcf980cbe6e1a78e6b865b2149": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/NetworkManager-libnm-1.39.11-1.fc37.aarch64.rpm"
+          },
+          "sha256:c4ce968491bbe0f2db29e9af17f6972c7fed4fb014e56bea40a9585e40dcf082": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm"
+          },
+          "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:c568f1d12548ff1f2a379c6d6892982a47b2d303f886f98b2924f8ac354e5cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/amd-gpu-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:c63610924ad5aea7867167a2d8ffe3ad61ded28b13319c7d91c7ca0473d95e99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:c6bcc3e1b3b6515466f3f771069003d1a7c28be3adaeecf7afa6318ad0f679fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm"
+          },
+          "sha256:c6ccf60e3629f33ff9dd2b3b6215e0b8e3b81a3219cefcc11cde083ecc4664f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm"
+          },
+          "sha256:c71c0014b26dd1a4d897f53cafbb671b76ef1bd5901a6c27178e2754e29d4256": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libksba-1.6.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:c832ac1f2b95744b48fe50795ffd8ba136b93b14653b5ffc428e1642c62b91a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:c8be1e8abe310fc2f8d9a8e5c52398e17fdb9975a416e208608661298492e05b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_sudo-2.7.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:c944c353ce1d26e0cafbe1a171d2bd8002d9588e6d217c811e8862ff12aad4dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm"
+          },
+          "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-38-0.2.noarch.rpm"
+          },
+          "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm"
+          },
+          "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:cd7dc65be232b9b7b011932367eca95f07fdf271ccd88c1fafb65d152d547a12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm"
+          },
+          "sha256:cd85247a2b661c62ae903219fa25cff5f583fc2c6b193e02d201dae26f1ce84d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:cdb3e216a7792f00636cd5b2d28f45061cf957e6001909143da86d53f2b68413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:ce92079aa9854b25e8b0179e884c7fac36787f1227f087caddcce1cbc3f42568": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-nftables-1.0.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:ceee888ce84b6d50e713fddf8e4f876f779a6f662f27d781bc8942a73d798750": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-1.14.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:cef75ed0e5383138263d81e2cf31d65c1bfb2416f3fa33d91dd56f772a1aa8fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nftables-1.0.5-1.fc38.aarch64.rpm"
+          },
+          "sha256:d0ba009ae3f8c15520952b6c3a4f56390411f66bec7800209e482913e71cb196": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ipset-libs-7.15-4.fc37.aarch64.rpm"
+          },
+          "sha256:d2cefaf35e48685298b803f2c9e9ad8733d3e22b378e50d359f1535c0310be46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/unbound-anchor-1.16.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:d362d886ed77c4dcd6920b598a6af73a3a82223ad8f4ee4ab6c8095c21525cfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-part-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:d39aa564715fbc725187e35df5d857ae947827c3ab71660024b7f5d93ed92c4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-utils-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm"
+          },
+          "sha256:d42939c39dc1e978f4fa9530f3253d521cace197a18dc566454b0143c48bb0d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm"
+          },
+          "sha256:d42d31e6e5433ac1e9aca4fe6573dd57ce66a6dbec09bb75addac05da9c4c3e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-tools-minimal-2.06-48.fc38.aarch64.rpm"
+          },
+          "sha256:d48d0bcb1de7ca243014616e40871ae85fd905923636d46917467f947deef1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iputils-20211215-3.fc37.aarch64.rpm"
+          },
+          "sha256:d4ff1c4e2ca4fef57964f233b56ed592551170af0019c55f92f0a82806737254": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glib2-2.73.2-8.fc38.aarch64.rpm"
+          },
+          "sha256:d53df41d99d85cab778ade553f245e5c8f22633e8e55ce0a55bad1c4b68a2e38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-fs-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:d5bdb1c4df2bf524e5800bb8f530181e31842bff8976a14d7c77360352a646f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgudev-237-3.fc37.aarch64.rpm"
+          },
+          "sha256:d5f5ee0665ad3d629ad53471359e5a428623666af22781de4c37aa5f646410af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgomp-12.1.1-4.fc38.aarch64.rpm"
+          },
+          "sha256:d6119bfd75ce7cca0ccf7cb439ba6f23587eb563058c0c4ffabcfbd550767210": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-gconv-extra-2.36.9000-1.fc38.aarch64.rpm"
+          },
+          "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:d6a0316b7b4713c22e093abc05a5bf01541c77ed24578fe1f57fe437a4208a25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm"
+          },
+          "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm"
+          },
+          "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-unversioned-command-3.11.0~rc1-1.fc38.noarch.rpm"
+          },
+          "sha256:d7f1ed9e93ac0034d350f0129af8bd2bd068eb69a9783f4f3e33b29d2a64c6f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-util-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:d82fc296d351848a187b975166e77ff1740ab94dfa50e0ad40bbb368470653dc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-hawkey-0.67.0-4.fc37.aarch64.rpm"
+          },
+          "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:da2e61e1c7998f724d50a60279f03af089d470c009b77adb4a8e93b95d199bbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cpio-2.13-13.fc37.aarch64.rpm"
+          },
+          "sha256:dbdaa37cc9bf25cabe9cb48e86720efe609bbc2d6244c115d601d932bac0edd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm"
+          },
+          "sha256:dcc4bd4d5fb72f38b7c23f32047cb820ec2dc2242f08ec69619e62582b909f73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm"
+          },
+          "sha256:dccb33ffe4778bee0967443755e55e7ae96fdda9e827bc61ea6287d11bda1a19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm"
+          },
+          "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/selinux-policy-37.9-1.fc38.noarch.rpm"
+          },
+          "sha256:df409a92f0a1edbf3902e63a7cb692bbb05a91bee87565b108495ae6c5f47b19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zlib-1.2.12-4.fc37.aarch64.rpm"
+          },
+          "sha256:df6903cc9da281664fe8d9648f7e0cde1fe6b09006928daa31143bcb5c65efc1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dracut-config-generic-057-2.fc38.aarch64.rpm"
+          },
+          "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm"
+          },
+          "sha256:e348e94e73ce1be18394a47c2a6805fd50908c087f362586dcc3ee3a1e58d654": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.aarch64.rpm"
+          },
+          "sha256:e59f2bf60be15a82c13bf6532a12b19ea2951c6b81f0f07dd110bd9747175c84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm"
+          },
+          "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm"
+          },
+          "sha256:e5fd6952e04ab59dfb897d8407ec2724c98f364e8ac7212677531725da941fcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-libelf-0.187-6.fc37.aarch64.rpm"
+          },
+          "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm"
+          },
+          "sha256:e746f59d62344dcca7f14582affd2b2543e3204d3ecf6525513381057c7c2fbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-identity-basic-38-0.2.noarch.rpm"
+          },
+          "sha256:e95d6e0acd379be9b199113235c64c921223faa213b4e5f91f215f056adc1e69": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/protobuf-c-1.4.0-6.fc37.aarch64.rpm"
+          },
+          "sha256:e9e9fc9a4fdb8861f7ceedf4e9a2652c9a2f23c37c09526b23277d5a0d384495": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-softokn-3.81.0-1.fc37.aarch64.rpm"
+          },
+          "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm"
+          },
+          "sha256:ef78de9d48882e3e55be59b9ac421e6eda50b38bd79e0f5808d72bc7625a6216": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm"
+          },
+          "sha256:eff8922a8b9fcc415fd0b2b058a35b3a3adbf782d947355156b2bf4f97fe1f8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nvidia-gpu-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:f11d4ef320502bcd0fe26ccbe1850a8969bf04cd28f04efe5b9e913054841fa8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm"
+          },
+          "sha256:f17c50a820abc4257dfcbcca511f551502cb7262d926db6ddbdee27969c8f728": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-mdraid-2.27-3.fc37.aarch64.rpm"
+          },
+          "sha256:f35908c2704a9219002a316958665b6d56092d2fe59d8fcdf20fa3817bb482c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-libs-3.11.0~rc1-1.fc38.aarch64.rpm"
+          },
+          "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm"
+          },
+          "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm"
+          },
+          "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:f7f71897aad9420b8c9e67073d7ed86eb969c20d8621379a7bd24aa1915f0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sssd-client-2.7.3-3.fc38.aarch64.rpm"
+          },
+          "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm"
+          },
+          "sha256:f8429326af23a76cb51e2944b846a141b9d3d121a3cc455b4a83e319bd2a1d6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm"
+          },
+          "sha256:f99af7003a71fc0afacf96968a740ea2892b2fc8c6b45ed8321fe7fe0260c4b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xfsprogs-5.19.0-1.fc38.aarch64.rpm"
+          },
+          "sha256:f9b91a1c6f4e194acd077ece95b995b3c0987734d75dfc3a0f2abdcdeedf1be1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm"
+          },
+          "sha256:fa9c0ac890e8264d5b44479c8fea74ae79bdeb6a72c474733c7d06100a893144": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/curl-7.84.0-2.fc37.aarch64.rpm"
+          },
+          "sha256:fc3310c7d92abc3e42e89af3afd7b9b050000878db63cf08167d331bf4cc3b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm"
+          },
+          "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm"
+          },
+          "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm"
+          },
+          "sha256:fe81316360f7512b27c3740e22d0c42b3bdd383e21e8d53b34239360b9538717": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm"
+          },
+          "sha256:ff128f537a012f30dfec9fec00d38f9f50268198a124783e2c2c1dbc54a79873": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm"
+          },
+          "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm",
+        "checksum": "sha256:8e59aca2373dfb636f7a5cea8f4d085d1fdc18577dd6aedd6ac19b6b937bcc9c",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/audit-libs-3.0.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0e8db2cef395cb3ca7940fcb712a27e50a279da1aaed63e019b96d003e525840",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bash-5.1.16-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1ef317581715089895fc30425b3eb3f351138894fbe86f4594c8512ba7be19fc",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:25378e75b524c602a0af5c12da1b68b4699a61bc165b487040a2357cfdc96683",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:615d42a7ea6822fa0564ecff628d5f0cb725e7578bc5fa3b27968faa3cd9c108",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:da2e61e1c7998f724d50a60279f03af089d470c009b77adb4a8e93b95d199bbc",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:c0dc904e2d0c90613dcf2c9db3b7f9dde1cd682030b14cbde677beb328a93d8e",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/crypto-policies-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/curl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:fa9c0ac890e8264d5b44479c8fea74ae79bdeb6a72c474733c7d06100a893144",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cyrus-sasl-lib-2.1.28-7.fc37.aarch64.rpm",
+        "checksum": "sha256:a52bd1031b97bf1642e0b56f460b6a88b426755b9e1fe218af359b215585175c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-1.14.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ceee888ce84b6d50e713fddf8e4f876f779a6f662f27d781bc8942a73d798750",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-common-1.14.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:1e9178f02120efcfaf723da06ee73725213a3e67831fea796e21275899b0fa54",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:b72109015ff0f8d68698d2663bab1c417576f237733ec53a32e0e6835c6b2a6d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dracut-057-2.fc38.aarch64.rpm",
+        "checksum": "sha256:81ea9684679162bb4cb55a5742714b72491f8b4ddfd68d713564f0ad87f08d47",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:20e2b9a751fcd737d09916932cbc7be84e106507393ef386da0057152aff5a2d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-libelf-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:e5fd6952e04ab59dfb897d8407ec2724c98f364e8ac7212677531725da941fcf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-libs-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:51668bc8aa5ef6c3552fa6e5e7d7aa9acf02a0297badacb707adf0f5ca432f32",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-gpg-keys-38-0.2.noarch.rpm",
+        "checksum": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-38-0.2.noarch.rpm",
+        "checksum": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-common-38-0.2.noarch.rpm",
+        "checksum": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-identity-basic-38-0.2.noarch.rpm",
+        "checksum": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-38-0.2.noarch.rpm",
+        "checksum": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-rawhide-38-0.2.noarch.rpm",
+        "checksum": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-0.21-17.fc38.0.20220203.aarch64.rpm",
+        "checksum": "sha256:12d299008217b4bf3eac42c86b1948c6bdd514cabc600e955e525df3c95b401c",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-libs-0.21-17.fc38.0.20220203.aarch64.rpm",
+        "checksum": "sha256:7af3d490cecbb309a48a7b982cd59a82e2716121436e2b56c769ddd8130ee7dd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-runtime-0.21-17.fc38.0.20220203.aarch64.rpm",
+        "checksum": "sha256:2afe7a7b8da38f2d0eb619efeb293dda7014682625a7604735d497d99f9203d1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:9870ed936bff3d80332751f33239d29ae5e02af4ddab8b0f4eef6d1a2749dea6",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-common-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:281e37fa1e91648a82ba5a41bc03757457c532f22d6cdb183c1f216e66b82d94",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-gconv-extra-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:d6119bfd75ce7cca0ccf7cb439ba6f23587eb563058c0c4ffabcfbd550767210",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-minimal-langpack-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8a1d698bb9f754af6fa35a4145f147851dfe7feadc3b058e0e6821876060f188",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:124d0e3f779e3bf7cb2fc8635aa1ed73a7d1540dd1bc22420542c26e6fb3e46d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-common-2.06-48.fc38.noarch.rpm",
+        "checksum": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-tools-2.06-48.fc38.aarch64.rpm",
+        "checksum": "sha256:acf993ab622bbb03d6b0561ebf654e777254425aff03de0b87e9a18a7a252428",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-tools-minimal-2.06-48.fc38.aarch64.rpm",
+        "checksum": "sha256:d42d31e6e5433ac1e9aca4fe6573dd57ce66a6dbec09bb75addac05da9c4c3e2",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "64.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grubby-8.40-64.fc37.aarch64.rpm",
+        "checksum": "sha256:0ff28ea3ed7b69ab47e64b3625eea861b3f3c4903682ce94aee46d8fbb8e58a8",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kbd-2.5.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:61ace5783032cdbc1db06545a0adbb52122996697f10512c24c8b5a6d36c9900",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kpartx-0.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:5f257703df5320763eb8a4d20b2ee9f4ce209840ac986237274190f7a1dcc88d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:28b17f73ce6ca866b7e8af7a4cc354e7f2443f1f7d2fc99386834b84a5938c89",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcurl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:42dddccd8a02d172d8894796d94b329a3ac38d69545a085e3942975a59ed9c4c",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9a7c69315a2b7b355de4551d4ad9790a7ae0ca86dced94d35670030b55371ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:170ad90a5f690e3998db2350023f9212aa688d71bf7769fab4a77eecc164332e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgcc-12.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:60d3707ed83661b28a1f859cea78367c77aa40e4cd77a6e8011e756ca35ac807",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgomp-12.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:d5f5ee0665ad3d629ad53471359e5a428623666af22781de4c37aa5f646410af",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:aa45ab2259216391b465c4b9ccdb89fb7908e90fd34ee7c6973d862ef518f637",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:75e807735799d981a5cf395879065b0cb5147e70923dc9314d3ba7eedd219893",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnghttp2-1.48.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0718fa539da95a64b3d2449af8104217f55e9379b905bc5fb87c3c3274130186",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7fa45aec5bae3e6c08fad86e13a7f4185ebf53912687c707a9d88e7b815b1da1",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libssh-0.9.6-5.fc37.aarch64.rpm",
+        "checksum": "sha256:9071b0957ceedf8bbeb2acb80ab91cc43302525dfb14184d540f1c133d6fa298",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libstdc++-12.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:5ca758a939959e0bddf5a3590c888df07db7c1fab55beceece1a3548bd1f17f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:31e4f1c33720828bf97cf768939856eb49531e6ca0805720e9946fa354f03537",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0235e965a1a21a4e548625abcb562f4a4181e9d29830ac208d2decee3067c644",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:272a4e9b637d1732477e24c751c5e2561996ae3d82ea10cdac822d996ab68143",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm",
+        "checksum": "sha256:fe81316360f7512b27c3740e22d0c42b3bdd383e21e8d53b34239360b9538717",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openldap-2.6.2-5.fc38.aarch64.rpm",
+        "checksum": "sha256:bc5fe78e55afe5528e6c133d08ea96465ae2dc223499adbc1d3d314eb822ee26",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c6ccf60e3629f33ff9dd2b3b6215e0b8e3b81a3219cefcc11cde083ecc4664f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:cd7dc65be232b9b7b011932367eca95f07fdf271ccd88c1fafb65d152d547a12",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/popt-1.19~rc1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7d31be2cd877d2f6a22ed9efa52d27f287d8a33036cb7833c545f00188e6a477",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm",
+        "checksum": "sha256:909fb5490bb5df6c877668ac18bbf73cda213d7dbb3a1d2a8d1013bef4f8ed22",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-unversioned-command-3.11.0~rc1-1.fc38.noarch.rpm",
+        "checksum": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-3.11.0~rc1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:349e77eb1fca043555141f1aeb018c47079c147358df4d6a58d00402bee9791b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-libs-3.11.0~rc1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:f35908c2704a9219002a316958665b6d56092d2fe59d8fcdf20fa3817bb482c5",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/readline-8.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:1caadea1fe1f44be99448485efdd8c02ef616da6a8d0a050bf308a68ec23ea68",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:c832ac1f2b95744b48fe50795ffd8ba136b93b14653b5ffc428e1642c62b91a5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:c63610924ad5aea7867167a2d8ffe3ad61ded28b13319c7d91c7ca0473d95e99",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:689ef2b8d48e5a906d79d5aebe16c3a46843155b236361af5faab189e82a4d6f",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/selinux-policy-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/selinux-policy-targeted-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/shadow-utils-4.11.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:0d2fb53f362a449a838989041b614aa32367816e338edf9d3dc1a58532bb68f0",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c4ce968491bbe0f2db29e9af17f6972c7fed4fb014e56bea40a9585e40dcf082",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:baf1ae39b1ca951a1c3edf73d62f21bc409dd211f447000c1d21584d58847575",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-libs-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:235e8bef01064ad26fcd52f83fb63207d32fa0e8f4ffe32ac19a7e4e5df002a9",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-networkd-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:7809f426ffbbf705762eb4c3a63c5e60fe80d865e8f324e0512af8b426fc8c69",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-pam-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:0741570a6aea320cf433c9576f1af8b6020984cb190fc8b94e9de364b9a16c03",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-resolved-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:2800324594d595ea1d585e149a3641a876d03f328910bca6b8d5146a06f7bbdf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-udev-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:6b80e7b8f67c26eebe534e5d40920a430ae9ea099a5227de5c89cfd09735b19a",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022b",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/t/tzdata-2022b-1.fc38.noarch.rpm",
+        "checksum": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b936514f5a3a15efc8c8eb84e7ee24c062efa954d8c9c25df951f4007c08336b",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3542f5da08d71f2caa8742eb2d632e83f8b31d5fa5a93d771ddc9209be9ae895",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:5e4b581c98a7ca80bf83eaa3859d33bcadc8970ef661a4672f8cc0495af72175",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:a09aa2d7801d61e63530a28bee09de287c99ba11171d6756d8675d31dc754dcc",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zlib-1.2.12-4.fc37.aarch64.rpm",
+        "checksum": "sha256:df409a92f0a1edbf3902e63a7cb692bbb05a91bee87565b108495ae6c5f47b19",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/ModemManager-glib-1.18.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a21e3d9871e35bffbb194952de4bac40bfd2cc4481225c5da610db824d83e3d8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.39.11",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/NetworkManager-1.39.11-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b3f7d94a07fe0bba6fa9b0ec306faa022d6206fab30cf29fa2f5ba3c3909473b",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.39.11",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/NetworkManager-libnm-1.39.11-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c433230048161b2a019e71d4987d2882ee74badcf980cbe6e1a78e6b865b2149",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/alternatives-1.19-3.fc37.aarch64.rpm",
+        "checksum": "sha256:8e59aca2373dfb636f7a5cea8f4d085d1fdc18577dd6aedd6ac19b6b937bcc9c",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/amd-gpu-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:c568f1d12548ff1f2a379c6d6892982a47b2d303f886f98b2924f8ac354e5cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/audit-3.0.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:6e954ed4778a06f63f421dc47b5370b6c6b8cc03c0376a63a1f01daa040a5bc8",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/audit-libs-3.0.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0e8db2cef395cb3ca7940fcb712a27e50a279da1aaed63e019b96d003e525840",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/authselect-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:fd15bba53fc3e0c82c546a080c6f5441bed7d87587195843516949e230faf66a",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/a/authselect-libs-1.4.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7347986518175c4c649d2cdab6378d55a565fdedc1cd6519fc5e8140e06f8ca4",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bash-5.1.16-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1ef317581715089895fc30425b3eb3f351138894fbe86f4594c8512ba7be19fc",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bluez-5.65-1.fc37.aarch64.rpm",
+        "checksum": "sha256:1e78cf0c9744c640f0eee419d5c5b4ff057693be4b8cc99bae3367571b4c5bb6",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bubblewrap-0.5.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:86e5cb2ff99e096a1d7a31bdd0a0038ba0aa6831ccd8804f5a04b262e2772dda",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/b/bzip2-libs-1.0.8-12.fc37.aarch64.rpm",
+        "checksum": "sha256:bbfa023e35aa0c917ca8b0f451b24af4582c769c65571e4c0d90c7dbbef92615",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/c-ares-1.17.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:73793bf267725e2ebbf2fa5d32aff363a614d1cbc98624258ac8df564d158e4b",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/coreutils-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:25378e75b524c602a0af5c12da1b68b4699a61bc165b487040a2357cfdc96683",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/coreutils-common-9.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:615d42a7ea6822fa0564ecff628d5f0cb725e7578bc5fa3b27968faa3cd9c108",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cpio-2.13-13.fc37.aarch64.rpm",
+        "checksum": "sha256:da2e61e1c7998f724d50a60279f03af089d470c009b77adb4a8e93b95d199bbc",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:c0dc904e2d0c90613dcf2c9db3b7f9dde1cd682030b14cbde677beb328a93d8e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:240fd2e4f0ab37d475a1e981921729bcaeda85a38c0d3e44079b1006769a77a8",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/crypto-policies-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cryptsetup-libs-2.5.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ca5a06cd3eaa5701c9be12d3fabda97454e9a9e6aca9ffc586b9e14eb3952520",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/curl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:fa9c0ac890e8264d5b44479c8fea74ae79bdeb6a72c474733c7d06100a893144",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/c/cyrus-sasl-lib-2.1.28-7.fc37.aarch64.rpm",
+        "checksum": "sha256:a52bd1031b97bf1642e0b56f460b6a88b426755b9e1fe218af359b215585175c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-1.14.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ceee888ce84b6d50e713fddf8e4f876f779a6f662f27d781bc8942a73d798750",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-broker-32-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a3124d8a892116345eab8f50b79835214599ea061cf66665397e9a1cf0f05ba5",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-common-1.14.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dbus-libs-1.14.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:42eb0c3836c6e593a371009808dbd1013de30cd0e636f6c668eb79475b6c42ae",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/deltarpm-3.6.3-4.fc37.aarch64.rpm",
+        "checksum": "sha256:608b7df709cddea3a9733e93502f1f1c052d3cd6044f2b00af6116b4cedd10bc",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/device-mapper-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:1e9178f02120efcfaf723da06ee73725213a3e67831fea796e21275899b0fa54",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/device-mapper-libs-1.02.175-9.fc37.aarch64.rpm",
+        "checksum": "sha256:b72109015ff0f8d68698d2663bab1c417576f237733ec53a32e0e6835c6b2a6d",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dhcp-client-4.4.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:3fc4b0553bef0015b8e73b00ea5c247e5eeb069583bdda3be4b9c97c3731efeb",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm",
+        "checksum": "sha256:351b9f8911296b57b7f69f8b6f04bde3715648ed827aa6f5fa6b6ea44168341a",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/diffutils-3.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:786cec3721ba9907a4c69620cee6bc3952de8f27dec33f57d9939619b8514f87",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dmidecode-3.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2d2bf7377a0181175b289acae55b3afad0dfb850ad9f65695818ec80481abccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:3a630412a9094d1294745986fd77c6e99762a667e8265c9859feb67651996785",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:b353a0995c13684076f30b900fa47ce16652145302f9670ebd3f7ca1397e46c7",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:828ccdf867dea1145e90a327a3556465d1076c5d749b1976c32f1cfb3f3468ab",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dosfstools-4.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:38e6676864f276c4364b6324b787b6e19ad4d160107e9867a57fbbf84530a7ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dracut-057-2.fc38.aarch64.rpm",
+        "checksum": "sha256:81ea9684679162bb4cb55a5742714b72491f8b4ddfd68d713564f0ad87f08d47",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dracut-config-generic-057-2.fc38.aarch64.rpm",
+        "checksum": "sha256:df6903cc9da281664fe8d9648f7e0cde1fe6b09006928daa31143bcb5c65efc1",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/dracut-config-rescue-057-2.fc38.aarch64.rpm",
+        "checksum": "sha256:249f9d67685549d38500d41607dcc2af37101d967d23e3b47decbe60566ec250",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/d/duktape-2.6.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:015477e0760f1cc1f080ca43716bcf05c9e40ff7394c26f25e5a4e5512f4074a",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/e2fsprogs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:34eaff2e19c7ecf3be38670103a4ca8655c5670f42a3c32d4d1fd13de76be842",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:bdecabcb7a7e24b2c2d52220d2e958b42466e868416553a079a7f01c0d5ff0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/efi-filesystem-5-6.fc37.noarch.rpm",
+        "checksum": "sha256:433b6f621d595b607c4a9f73201e4be9b2a54535191b214b5905278e064c32cf",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/efibootmgr-18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:19a1bf0b6a02842ec4d86d9a26a0fafb3864b8a18a05eec266d52bb58f3d1feb",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/efivar-libs-38-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b11aea62a9e6e4295e33c6856c1a32b8f50af5ae98750836d1f97163a8a17bdf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:20e2b9a751fcd737d09916932cbc7be84e106507393ef386da0057152aff5a2d",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-libelf-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:e5fd6952e04ab59dfb897d8407ec2724c98f364e8ac7212677531725da941fcf",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/elfutils-libs-0.187-6.fc37.aarch64.rpm",
+        "checksum": "sha256:51668bc8aa5ef6c3552fa6e5e7d7aa9acf02a0297badacb707adf0f5ca432f32",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/e/expat-2.4.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:503b9b7f3b947c4d1a50dfe8dac8064b726a09beade31f116c0e3fd5df5ad78a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-gpg-keys-38-0.2.noarch.rpm",
+        "checksum": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-38-0.2.noarch.rpm",
+        "checksum": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-common-38-0.2.noarch.rpm",
+        "checksum": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-release-identity-basic-38-0.2.noarch.rpm",
+        "checksum": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-38-0.2.noarch.rpm",
+        "checksum": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-modular-38-0.2.noarch.rpm",
+        "checksum": "sha256:85a7acceec5dbd64452b50af82887038c103768790a8a9c666caa048263432f2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-rawhide-38-0.2.noarch.rpm",
+        "checksum": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fedora-repos-rawhide-modular-38-0.2.noarch.rpm",
+        "checksum": "sha256:15b79ceb2f5777ee511f9bcb722c4affc72a5e994fc3dcb250fd4e49c25814b2",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/file-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3d7d9e4cc7520cba86f679322b635238761b4a8ffb443cb3b2e8228d88a5bdaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/file-libs-5.42-4.fc37.aarch64.rpm",
+        "checksum": "sha256:3a4df46e9482e6dd68f6ff70603e36aaf846d4767ecb69b034900813566f705d",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/filesystem-3.18-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0ccaefa2ac125fc90c752808872eef3f72d0e159e4497a58a2b65ce0ca863ca0",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/findutils-4.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:bad9043c625b8d266cf0c817453af694b04d41e204270ce91b02013320e6a66d",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:7176e5bd8f6a7137a54684507a3eec12999fbf23607d87a0f59f165794a80da3",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:0121cf8885d2a35b98223ebb05ad2daf7ea2ed2856227297d556c93564defe7a",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/flashrom-1.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:1b4d3978ec7272aedd39b654ca1e360d1d433da76cafc74e5cc0a4271b4f63dc",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fuse-libs-2.9.9-15.fc37.aarch64.rpm",
+        "checksum": "sha256:7c7b74094a5e268849ad2d86fbeb78b67b52c8aed96a88c855ac8fc7a274a569",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4aa1e45f9951b173954988890143df5263921f2ad9f66b7942e3c4174ff79922",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-efi-1.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:c6bcc3e1b3b6515466f3f771069003d1a7c28be3adaeecf7afa6318ad0f679fe",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:476f42824d9813f4a3dfa9677101e2bada11079b9690ff481d04d8229d6f506d",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:2d33d5a86d00d5c21b25612d5b56ad41941171947ac6cc586f588fe57adcba2b",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.aarch64.rpm",
+        "checksum": "sha256:39d78c38fab0fdeda95d6831fbadf03ce3a8dd6dac641d03592f2b9fd498547b",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gawk-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1b162d37fea25914e42e63e6483127b4ac8889e5587f461989e6be6769e5f694",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1520d5466cbb6f853828e3d8454a0a2a255247a2eb08315b35f5e8e147e6504d",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gdbm-libs-1.23-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7577f8eaa1171a15629ec06c438266b6ce586b59fdf65f8bce8f449a16faea7d",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gdisk-1.0.9-3.fc37.aarch64.rpm",
+        "checksum": "sha256:030e6baed3f298c645ebbc4fe12c87ef0060c9b210c46bf738545f9c265746ea",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-0.21-17.fc38.0.20220203.aarch64.rpm",
+        "checksum": "sha256:12d299008217b4bf3eac42c86b1948c6bdd514cabc600e955e525df3c95b401c",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-libs-0.21-17.fc38.0.20220203.aarch64.rpm",
+        "checksum": "sha256:7af3d490cecbb309a48a7b982cd59a82e2716121436e2b56c769ddd8130ee7dd",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gettext-runtime-0.21-17.fc38.0.20220203.aarch64.rpm",
+        "checksum": "sha256:2afe7a7b8da38f2d0eb619efeb293dda7014682625a7604735d497d99f9203d1",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.73.2",
+        "release": "8.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glib2-2.73.2-8.fc38.aarch64.rpm",
+        "checksum": "sha256:d4ff1c4e2ca4fef57964f233b56ed592551170af0019c55f92f0a82806737254",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:9870ed936bff3d80332751f33239d29ae5e02af4ddab8b0f4eef6d1a2749dea6",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-common-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:281e37fa1e91648a82ba5a41bc03757457c532f22d6cdb183c1f216e66b82d94",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-gconv-extra-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:d6119bfd75ce7cca0ccf7cb439ba6f23587eb563058c0c4ffabcfbd550767210",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/glibc-minimal-langpack-2.36.9000-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8a1d698bb9f754af6fa35a4145f147851dfe7feadc3b058e0e6821876060f188",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gmp-6.2.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:25a8c9a2d2b341f6aea2cac2dae0d1cdd01266fbd7cbbf4bc9a044039944f380",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gnupg2-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:b0c4b4986edc058f49dabeb5ce6f9759546e23b165c7ee20fd0e161161a25255",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gnupg2-smime-2.3.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:5c46f78fd60d3cfb0decf559edcc1d67f52cfcc4db6b8da58c2a8112f72aba73",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gnutls-3.7.7-1.fc37.aarch64.rpm",
+        "checksum": "sha256:469f29bcd47822c46be00e6c7ed76000dc58ee3be1008b26d80e1e7a529083e7",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.73.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gobject-introspection-1.73.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:050de9d7c87944233a18b8c0bc96c2ad55ca3f4fe87b786143421c5cbce64d90",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gpgme-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:12b45030df4dad11f26ed6e6d0c1c749941fcf96dffd72bbd4c122293f85994b",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grep-3.7-4.fc37.aarch64.rpm",
+        "checksum": "sha256:124d0e3f779e3bf7cb2fc8635aa1ed73a7d1540dd1bc22420542c26e6fb3e46d",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/groff-base-1.22.4-10.fc37.aarch64.rpm",
+        "checksum": "sha256:6d5f46eddc547cddf4a2d33b952322d7cca7d32cb44891490f9de31c75b12652",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-common-2.06-48.fc38.noarch.rpm",
+        "checksum": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-efi-aa64-2.06-48.fc38.aarch64.rpm",
+        "checksum": "sha256:659fdc4df649e574f48e2e60bb2e728ca910a7007358fcc196c1a3e1f162ae47",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-tools-2.06-48.fc38.aarch64.rpm",
+        "checksum": "sha256:acf993ab622bbb03d6b0561ebf654e777254425aff03de0b87e9a18a7a252428",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grub2-tools-minimal-2.06-48.fc38.aarch64.rpm",
+        "checksum": "sha256:d42d31e6e5433ac1e9aca4fe6573dd57ce66a6dbec09bb75addac05da9c4c3e2",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "64.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/grubby-8.40-64.fc37.aarch64.rpm",
+        "checksum": "sha256:0ff28ea3ed7b69ab47e64b3625eea861b3f3c4903682ce94aee46d8fbb8e58a8",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/g/gzip-1.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:2b817b5ef5565a9190d29d77513dfbae65222fb156f80c4f64a03a12f0b8df52",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/h/hostname-3.23-7.fc37.aarch64.rpm",
+        "checksum": "sha256:a77017d08f6b0be4bcf52fbb6b471465a7cf6c6361195167b07e81feaacdb10b",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ima-evm-utils-1.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:27c7f18e0360f10badc8bd3156fcf255dcfd0500ac86c7793a5edfef02a3647c",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/inih-56-2.fc37.aarch64.rpm",
+        "checksum": "sha256:7520ccf6e89c32dabf2d57bfaeef54a560bd751c521a045baeb93572489f062b",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm",
+        "checksum": "sha256:c297a9d8223d4cd595d89d3e789b86e2558b902c9ba636af3f49587a17541dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/intel-gpu-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:16a7a3f9d73ff11170a6f0fa686d03ef9a491089e8a3ddd492c93a865ed75aa3",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ipcalc-1.0.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:c208a19538792b5664edf16eb9e1fa4e41a362a07879ef452f103eed5e3d9447",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iproute-5.18.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:76e56ea613d2ed02b02b6d707e4a09e53d99b6e3ea5151a069bf9f71fc126f25",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ipset-7.15-4.fc37.aarch64.rpm",
+        "checksum": "sha256:20a0b23ad7f8f14327251b64491802cf457aba161d45e364240797fd608186c4",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/ipset-libs-7.15-4.fc37.aarch64.rpm",
+        "checksum": "sha256:d0ba009ae3f8c15520952b6c3a4f56390411f66bec7800209e482913e71cb196",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iptables-libs-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f8429326af23a76cb51e2944b846a141b9d3d121a3cc455b4a83e319bd2a1d6c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iptables-nft-1.8.8-3.fc37.aarch64.rpm",
+        "checksum": "sha256:aec24794b31ece49a4cc72a2e038cbf4f58cbe5606a28bf40d231b53e0832542",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/i/iputils-20211215-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d48d0bcb1de7ca243014616e40871ae85fd905923636d46917467f947deef1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/jansson-2.13.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:e59f2bf60be15a82c13bf6532a12b19ea2951c6b81f0f07dd110bd9747175c84",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/jq-1.6-14.fc37.aarch64.rpm",
+        "checksum": "sha256:36cbb69f70b77ab95176533a4b35ee1cc44755804d958038524222d50edb9238",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/json-c-0.16-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b850dec7cc93073fd5c1dd6a86fcd4c300d046acb29c81d0cf1c0324a84a13ca",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/j/json-glib-1.6.6-3.fc37.aarch64.rpm",
+        "checksum": "sha256:686fab2c75a3ecdc1573396c9dd97e7cdfc86da250bb0c01345ae0f0bb3831e7",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kbd-2.5.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:61ace5783032cdbc1db06545a0adbb52122996697f10512c24c8b5a6d36c9900",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "0.rc1.13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kernel-6.0.0-0.rc1.13.fc38.aarch64.rpm",
+        "checksum": "sha256:8f876f764c6b29dc77e092e7e2f924b9a4a6d9f2cb3896ffe0fbc2cd575ddbe4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "0.rc1.13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kernel-core-6.0.0-0.rc1.13.fc38.aarch64.rpm",
+        "checksum": "sha256:410020e00906f7983cc262d2dee2717eaacc45e1a58b58ac1abbc1280444170a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "0.rc1.13.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kernel-modules-6.0.0-0.rc1.13.fc38.aarch64.rpm",
+        "checksum": "sha256:11c357d57555231335ecb6e287804e1969d8b2c0c00d7e509de5347e3144864f",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/keyutils-libs-1.6.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:73d3c84d2bd0f897c46f04fd4d3e816b0a77c5e1a5cb3e8b5a5ff22b86065351",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kmod-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a1fb07220d23a99fd4122fe207749d09122b7781719da301a6f43d5bb9f14ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kmod-libs-30-2.fc37.aarch64.rpm",
+        "checksum": "sha256:821d92639d372d0a91b18587c5b9c698ab93aa47260f100531ee57cf2d0eb13c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/kpartx-0.9.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:5f257703df5320763eb8a4d20b2ee9f4ce209840ac986237274190f7a1dcc88d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/k/krb5-libs-1.19.2-11.fc37.1.aarch64.rpm",
+        "checksum": "sha256:48ff03b4055e7d41b519fb552410334f9702a955981b06ef9bedfb7ddcf8181b",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/less-590-5.fc37.aarch64.rpm",
+        "checksum": "sha256:4623dd1d17576dc75dc5e017429ddad453ae03b424c27b1f119628fa8f7b2c05",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libacl-2.3.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:fdc0d4aeb8f58c2ff8afdd4e4716145c0f6dcf1d71ccc44e3e0c4986e0054913",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libarchive-3.6.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:07041e5bfeb6f98229333d7a77210942f67a5e6bc82bec5af0f7a51d401a68be",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libargon2-20190702-1.fc37.aarch64.rpm",
+        "checksum": "sha256:ad059e8b67b65d9a0c87f6dab6c27e710c1e232b880475538d7f300cf763855e",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libassuan-2.5.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2cef5121f03115ec8c49b55f61ed2a990861b9cde76f89645df461e34478c1f2",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libatasmart-0.19-23.fc37.aarch64.rpm",
+        "checksum": "sha256:44ee380afc6f438f608704b108853ff0d501b700c4a8196fa16a824ac31e777d",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libattr-2.5.1-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b5c2231369227e12b0c9e380a8ea0b6459a34eb73469b8e424a7467d11bc125c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libb2-0.98.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:33445abbe9ea176b4a1f40a3ad3bdc7aa3efb8398a627cbdc25dacaf5f95a74f",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbasicobjects-0.1.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:8cf395ef797a9aac4df6b7a02ce18a0032c76092bc9c4afa1471540c263e79ce",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblkid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:28b17f73ce6ca866b7e8af7a4cc354e7f2443f1f7d2fc99386834b84a5938c89",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0c230ca1e298337fccf4038a6380d7c8a4662758bce4bbe55b7c2a5e02fb439a",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-crypto-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:bbc018ba524a54968bf5706eb7fff65eecc0a32620e5ec8c92dd2e60c4501b92",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-fs-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d53df41d99d85cab778ade553f245e5c8f22633e8e55ce0a55bad1c4b68a2e38",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-loop-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:6e5b41cd84ac4bc60b1797e0eabb501a699eee13ea782b8e403671c2ec985622",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-mdraid-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f17c50a820abc4257dfcbcca511f551502cb7262d926db6ddbdee27969c8f728",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-part-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d362d886ed77c4dcd6920b598a6af73a3a82223ad8f4ee4ab6c8095c21525cfc",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-swap-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:be2f40da21ea9ac1b430fc98c3a06b6e1e140d61b77d5d5f1e056f9f41a066e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libblockdev-utils-2.27-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d39aa564715fbc725187e35df5d857ae947827c3ab71660024b7f5d93ed92c4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbpf-0.8.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:85a45ca1842eef2537163421043df629daf951705453a8a6ce4c6b4d80c45a31",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbrotli-1.0.9-9.fc37.aarch64.rpm",
+        "checksum": "sha256:b5319b25ee50ebf4c3e1f0e20a627110459179858455dfe4e5ea9ef98ac3a0f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libbytesize-2.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f11d4ef320502bcd0fe26ccbe1850a8969bf04cd28f04efe5b9e913054841fa8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-2.48-5.fc37.aarch64.rpm",
+        "checksum": "sha256:35d5d6f894585c851435e1eba94c6fc5e9c7cea6eb689f40b560b98d2542ae20",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-ng-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:640116bfdde14e93341912ea1624c7a54944ed5335f79669c8da3c865ef4f900",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcap-ng-python3-0.8.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:331103386328c4cf8d8620885a847703b5844b568ed842383d4ec454ab8e1846",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcbor-0.7.0-7.fc37.aarch64.rpm",
+        "checksum": "sha256:bdd1cffeb7fd0ce84ee0223c0fb1325505d96803a781c399181ee8f86a0bac8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcollection-0.7.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:add4f6ec969242fe36a7c88306688551123f93fcc74864671956683aa1d86339",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcom_err-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:1fa19567790fa568c37734961a36d3055308b0b640e67f58a5a25c0dd4c8e791",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:b4ca03301fe8f6074211c3be890a2ff44d14c8d067c469f92b111d7d841da3fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libcurl-7.84.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:42dddccd8a02d172d8894796d94b329a3ac38d69545a085e3942975a59ed9c4c",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libdb-5.3.28-53.fc37.aarch64.rpm",
+        "checksum": "sha256:659e775e54fc94630a050d8ad717ab4bf60ec1ce5771936233b01764456d8573",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libdhash-0.5.0-52.fc37.aarch64.rpm",
+        "checksum": "sha256:72859b9721f0c6e7d2a2fdb5c2e928eec80becbf1761dd723c8ee912dd5e4de9",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libdnf-0.67.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:78edead1498bac0e459ac199ff65a513510af4a32786c41b7d365e6022c510c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libeconf-0.4.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:5d678daeae88dedc53e06a79694ac5917341c30f2500e5e09928d0ed74c08a59",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libedit-3.1-42.20210910cvs.fc37.aarch64.rpm",
+        "checksum": "sha256:25710922f3156fe1f06171feee1256c577416f291e389826f6d661b010124752",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libevent-2.1.12-7.fc37.aarch64.rpm",
+        "checksum": "sha256:0dc74a66395954759fab10903160f3643a43d6b26497c68c36588726e2a83e5a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfdisk-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:9a7c69315a2b7b355de4551d4ad9790a7ae0ca86dced94d35670030b55371ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libffi-3.4.2-9.fc37.aarch64.rpm",
+        "checksum": "sha256:0a38680aa5eb19d5f694ba4a6c15ba55a2439c29d2003ff7586f2268cb01f14a",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfido2-1.11.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:170ad90a5f690e3998db2350023f9212aa688d71bf7769fab4a77eecc164332e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libfsverity-1.4-8.fc37.aarch64.rpm",
+        "checksum": "sha256:b6339453924f503b9d3cb4dde921f7b705528e2cb7f562243444121e7dbf19b3",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libftdi-1.5-5.fc37.aarch64.rpm",
+        "checksum": "sha256:d42939c39dc1e978f4fa9530f3253d521cace197a18dc566454b0143c48bb0d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgcab1-1.5-1.fc37.aarch64.rpm",
+        "checksum": "sha256:a317432b034404123e89b883bef600c1771247fe09f463fc1b39313bfc2e80bf",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgcc-12.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:60d3707ed83661b28a1f859cea78367c77aa40e4cd77a6e8011e756ca35ac807",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgcrypt-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a1eeea74b3fe8500ee50fb3ad828ee4b980d41f568ad31c441df42b2daeff71c",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgomp-12.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:d5f5ee0665ad3d629ad53471359e5a428623666af22781de4c37aa5f646410af",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgpg-error-1.45-2.fc37.aarch64.rpm",
+        "checksum": "sha256:912776644a49202be3407010dedc31cb4d31fc2411b97629a5ad8e537a093892",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgudev-237-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d5bdb1c4df2bf524e5800bb8f530181e31842bff8976a14d7c77360352a646f7",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libgusb-0.3.10-3.fc37.aarch64.rpm",
+        "checksum": "sha256:917d4c028b5c6e8f79e4d0f21fea12c178d27710da0aca052d7dd0481b502898",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libibverbs-41.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7afa5da1ec37dad4230b57f2df4d6c07f404b31248fcd171d330d2f8b7ad148c",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libidn2-2.3.3-2.fc37.aarch64.rpm",
+        "checksum": "sha256:aa45ab2259216391b465c4b9ccdb89fb7908e90fd34ee7c6973d862ef518f637",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libini_config-1.3.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:3db76609448c443df02b8277429507b64f3ac814616778b80a7c5a2a0409cf96",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libjcat-0.1.10-2.fc37.aarch64.rpm",
+        "checksum": "sha256:6989d53b95e3903b59516440bf56ee1002f01ef0e8318d9b0f4d00782836a8b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libkcapi-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:b3f83992a7dd875f0ab4cdc421e2f96f36ebcdd06077dcf3c685b349fa25a553",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.aarch64.rpm",
+        "checksum": "sha256:2396e128877a15edb4d75caa013a3bedd1bdc4f923aee8a967c687a702d72892",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libksba-1.6.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:c71c0014b26dd1a4d897f53cafbb671b76ef1bd5901a6c27178e2754e29d4256",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libldb-2.6.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3c156e8db644666cd02c17335383f1e33513f71ad05aa279fb47d7746b8ea595",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmaxminddb-1.6.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:74f2aec75861452ac25eaf371cba7dbc3cbbec4600555131d34b9b35a8ea0132",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmbim-1.26.4-2.fc37.aarch64.rpm",
+        "checksum": "sha256:f9b91a1c6f4e194acd077ece95b995b3c0987734d75dfc3a0f2abdcdeedf1be1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmnl-1.0.4-16.fc37.aarch64.rpm",
+        "checksum": "sha256:6b1e845a8c68c4af045a34bd920650e6a21f9852652baf756200bf3c649d2397",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmodulemd-2.14.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:bb473c20d69060ea166d4e111ac457230d35e8e5a440ed1fae3db4b6da5dc4b7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libmount-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:75e807735799d981a5cf395879065b0cb5147e70923dc9314d3ba7eedd219893",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libndp-1.8-4.fc37.aarch64.rpm",
+        "checksum": "sha256:9de5d871550544523eb64203df597c0eb2e3b4d4471d0f118eaeadae72055fc5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.aarch64.rpm",
+        "checksum": "sha256:051a659d539bcbbeb00f6c4f76a927fcf2939cc351302ccec6960d4d92305ea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnfnetlink-1.0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:9d044d167ba9209a4dfe0314501e0f0cc1a589b45a40a65775bf7e433e71cbae",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnftnl-1.2.3-1.fc38.aarch64.rpm",
+        "checksum": "sha256:378bd2a9d051665b960728fd8a562c5b776ede0f8cc4821b5ceb92b470153503",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnghttp2-1.48.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0718fa539da95a64b3d2449af8104217f55e9379b905bc5fb87c3c3274130186",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnl3-3.7.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ade9a1cbf3063e2284c79fb80282dbb176de4578e9de53f96e45bef1a50a6c19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libnsl2-2.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:2f04577c4ac4fa114df989e3ff36c69d10cb2e4fdbf75691ac1498c770bc28a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpath_utils-0.2.1-52.fc37.aarch64.rpm",
+        "checksum": "sha256:0b694b01bb2873bcc3585bb65ace24e92948af31e1f1f2a8211dabbea1424188",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpcap-1.10.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1db6355fdeda942720b166dec938b0e7a081cb87de80e72f23d30f5896f3bc97",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpipeline-1.5.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:875e1ad123d2c83aea326805a53f4140296c2a6afad6c45882e1cae2c8d7ca8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpsl-0.21.1-6.fc37.aarch64.rpm",
+        "checksum": "sha256:a09e3668ccadb40503e28e2efd8ed3d0dec2946fc551856b25c845d8c6d08794",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libpwquality-1.4.4-11.fc37.aarch64.rpm",
+        "checksum": "sha256:cbe6fe8f74c609ee672cfb35b75497ace1cdf17501a41f205bef49a806097e67",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libqmi-1.30.6-2.fc37.aarch64.rpm",
+        "checksum": "sha256:fc3310c7d92abc3e42e89af3afd7b9b050000878db63cf08167d331bf4cc3b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libqrtr-glib-1.0.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:60cdfaff2b8bd8de04414164dcdbb106e2fdb6846f2b6cb2540bf51eb9a80510",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libref_array-0.1.5-52.fc37.aarch64.rpm",
+        "checksum": "sha256:dcc4bd4d5fb72f38b7c23f32047cb820ec2dc2242f08ec69619e62582b909f73",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/librepo-1.14.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:6d08064f5cf2de564b49ea4391cf45ede95f6761b11bc31ca218e8dfd264a476",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libreport-filesystem-2.17.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:29c61e3a7856ed3e31ae8d42777b571ae7f08644bf27acb1f0a1c1856c308b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libseccomp-2.5.3-3.fc37.aarch64.rpm",
+        "checksum": "sha256:a685678a81eadc35331a74023672a94d7e8a71ebb15aa19ee3e0c2b79d4c625e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsecret-0.20.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:01b4d4c566896c87ea8736a1a0406eb3480e5e9dec581a49c973ea30774cff52",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libselinux-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:2abcc292c06a17a25e60f0e8151c66943da7559c357e025f6acf0ece1cc1fea9",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libselinux-utils-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:59035fd7df5f840f60fb189f96c5d12c2f0be34db6d91ba768358f797263d210",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsemanage-3.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a9b3c5a71bd562a3c71f6510b8562ae093a683db22448f03fdf91814123dedf8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsepol-3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c6871fd28de18a80a42d8b5a1088210c32e9dbff12c5395d25c76cf8b4e65612",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsigsegv-2.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:044b32d2bb74e2ad1bde221b87c476c83c8274fbf6f30e928c7ef721f59c518a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsmartcols-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:7fa45aec5bae3e6c08fad86e13a7f4185ebf53912687c707a9d88e7b815b1da1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsolv-0.7.22-3.fc37.aarch64.rpm",
+        "checksum": "sha256:ec60544d1423d5ea064e6edbd7beb3cf98e78fe5de2980cc9200428aa3452516",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libss-1.46.5-3.fc37.aarch64.rpm",
+        "checksum": "sha256:76382f66152a11217bfc5fa63aa8cc51ee0444bddab95f4810694eb83af21518",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libssh-0.9.6-5.fc37.aarch64.rpm",
+        "checksum": "sha256:9071b0957ceedf8bbeb2acb80ab91cc43302525dfb14184d540f1c133d6fa298",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_certmap-2.7.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:4356080dd69f765842adb5b43e6dc036529d404afc93c2b03c516d2b9f5c6199",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_idmap-2.7.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:7a1ecca6298a044afa3e3ce0b15f871fc31e32f8dc80c43f5c9a088b70c771ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_nss_idmap-2.7.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:5fb2ab129465aa9b8b2112eb27c9c156dc3eb7e2660ef63cc3e8a1c150467a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libsss_sudo-2.7.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:c8be1e8abe310fc2f8d9a8e5c52398e17fdb9975a416e208608661298492e05b",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libstdc++-12.1.1-4.fc38.aarch64.rpm",
+        "checksum": "sha256:5ca758a939959e0bddf5a3590c888df07db7c1fab55beceece1a3548bd1f17f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtalloc-2.3.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:dbdaa37cc9bf25cabe9cb48e86720efe609bbc2d6244c115d601d932bac0edd3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtasn1-4.18.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d63275a7fba7a2bf7a30df0e4a32f9955eb932bd32d80ccdf70b0ca45f138b90",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtdb-1.4.7-3.fc37.aarch64.rpm",
+        "checksum": "sha256:cd85247a2b661c62ae903219fa25cff5f583fc2c6b193e02d201dae26f1ce84d",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtevent-0.13.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4c6c0d8654f12e0f6b2fbb06d8ef55081e97f530a48562d4c844127d1fcf6b7c",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libtirpc-1.3.3-0.fc37.aarch64.rpm",
+        "checksum": "sha256:89fdf49c17b8e2ddc9b8860ccd6ffddda6656589faa7adf9b0bd701ee89b0e04",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libudisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a3ebf0ae35c1fc16342a8778cc9212b5254c9ee5162cf439dfe66eedfda5c39a",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libunistring-1.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8b21c89fe2abd9e577631d2541cd7cfb1af5e11e9493c90b354dc772bef35aa1",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libusb1-1.0.25-9.fc37.aarch64.rpm",
+        "checksum": "sha256:ef78de9d48882e3e55be59b9ac421e6eda50b38bd79e0f5808d72bc7625a6216",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "12.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libuser-0.63-12.fc37.aarch64.rpm",
+        "checksum": "sha256:249dd0b9c3b3714e92a53596d0c800a1baacd8b005235ffa5fd4b0422004876a",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libutempter-1.2.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:b81eff17b72f9d25482a25eee089dea76ee1c2f853deae9b65e0fcad01bb8b66",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libuuid-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:31e4f1c33720828bf97cf768939856eb49531e6ca0805720e9946fa354f03537",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libverto-0.3.2-4.fc37.aarch64.rpm",
+        "checksum": "sha256:1ab69d4c9c6e320955b7b0c22e808995107c42978009738535b642a83e58a164",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxcrypt-4.4.28-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f35d38bf1a573e6dec25fab79a39f29dce274b3e617f5628999a3a6ff0bea009",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxkbcommon-1.4.1-2.fc37.aarch64.rpm",
+        "checksum": "sha256:56ec328ba2bc798113071cb36196e69fff2e5bc3abb48be4cf263bfa101c827c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxml2-2.9.14-3.fc37.aarch64.rpm",
+        "checksum": "sha256:0235e965a1a21a4e548625abcb562f4a4181e9d29830ac208d2decee3067c644",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libxmlb-0.3.9-2.fc37.aarch64.rpm",
+        "checksum": "sha256:77cff9e52636e1db952b872e7b2f02393772caf0285ca5d7ed81da5db173fdec",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libyaml-0.2.5-8.fc37.aarch64.rpm",
+        "checksum": "sha256:9a2b564a7855fd993a70efa5e5b2e8fdc1c5ae8635ab8314eb3a2df544764d60",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/libzstd-1.5.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:e5f8a73efcea92b3d5df1e23cbbbf19dc32382bc367632850c3bdb717566beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/linux-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:648e27449350f50b6fbed7bce4ecdb586976446ddafcfa100cd235e74d3a2c38",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/linux-firmware-whence-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:607d9c1a9c9f80a1bd21b1d3dfe9dad0b564c6a90d3359bd2d7e6594fc24f430",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lmdb-libs-0.9.29-4.fc37.aarch64.rpm",
+        "checksum": "sha256:dccb33ffe4778bee0967443755e55e7ae96fdda9e827bc61ea6287d11bda1a19",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lua-libs-5.4.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:272a4e9b637d1732477e24c751c5e2561996ae3d82ea10cdac822d996ab68143",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/l/lz4-libs-1.9.3-5.fc37.aarch64.rpm",
+        "checksum": "sha256:b8b26543b81a634855287185000dcefe6c0e09f35bd77347e8215969aeda5959",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/man-db-2.10.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:710f24b54f1b3430cfd5070583c82a193ece7e6a99a8888b68f4c8906193de13",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mdadm-4.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:03ff91894dcba5710060a913dee3387294d5d918b4d92dab96205afd50459ae0",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/memstrack-0.2.4-3.fc37.aarch64.rpm",
+        "checksum": "sha256:09f8de1e0c90ea397c7677df9e550a1296668a3e018bd58eb1f704b77d7e815c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mkpasswd-5.5.13-2.fc37.aarch64.rpm",
+        "checksum": "sha256:fe81316360f7512b27c3740e22d0c42b3bdd383e21e8d53b34239360b9538717",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mokutil-0.6.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:e6164c42552319cacc4226dbb680be091ac0e0853a91b63c496822daff175b68",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mpdecimal-2.5.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a7bfc2e27dc453726495f11d21f2f4e79716be924d744a92d0a4e4fcb96acca8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/m/mpfr-4.1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:8753e26208dc659797cafc163c8fa06c3924d2dc9fdf6ccee94647ff4edde735",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nano-6.4-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3c55024a1b2106ffdf399590f6ed7ea33f5ae534b601d7eb726a02ac02b687bb",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:c2fb53692b291acfb5641ac4128fbf5f34703f04dede9c51994fc247d13739c0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ncurses-libs-6.3-3.20220501.fc37.aarch64.rpm",
+        "checksum": "sha256:d3b7939b663a7c169c436d40adcbf78b20386928ffb620e951703ef5e20b3ed8",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nettle-3.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:a17d3ec2925c94030cf456e706bc96b7f4cccfc4119d5b1f5a89aa302da12ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nftables-1.0.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:cef75ed0e5383138263d81e2cf31d65c1bfb2416f3fa33d91dd56f772a1aa8fa",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/npth-1.6-9.fc37.aarch64.rpm",
+        "checksum": "sha256:76bba9ac90c720b8513764aefd45dd4426bd670f45855a95faba47a66317faed",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nspr-4.34.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:b5ea004644ca56e10a6be724759a43c86e26d36968f141cd33bf56c00ded4a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:4705cbebe0f2b86173f7501909e174f47f2af99df540832d15c4ff8e3cb0c506",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-softokn-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:e9e9fc9a4fdb8861f7ceedf4e9a2652c9a2f23c37c09526b23277d5a0d384495",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:cdb3e216a7792f00636cd5b2d28f45061cf957e6001909143da86d53f2b68413",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-sysinit-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:68cd6c6f8302389cb00e2b00a159fdeac24f644fe9daf6378091f000f1a7fa41",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nss-util-3.81.0-1.fc37.aarch64.rpm",
+        "checksum": "sha256:d7f1ed9e93ac0034d350f0129af8bd2bd068eb69a9783f4f3e33b29d2a64c6f3",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfs-3g-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:ff128f537a012f30dfec9fec00d38f9f50268198a124783e2c2c1dbc54a79873",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:89013dbf6d1eda9b50402fbe4691d2d911d7f9a1cf69657cd88e9a3232fa0ab5",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.aarch64.rpm",
+        "checksum": "sha256:03e753dd69715f7b1b4bb994eb3d9a0c9b26fa611603492f6b5554999f8e2114",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/ntfsprogs-2022.5.17-2.fc37.aarch64.rpm",
+        "checksum": "sha256:73e74e9775bebc30a03b4407bb2b20061c09ee6b354ccac53dfed96205fc092a",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/n/nvidia-gpu-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:eff8922a8b9fcc415fd0b2b058a35b3a3adbf782d947355156b2bf4f97fe1f8f",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/oniguruma-6.9.8-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:6feb03f1014a2af15478e2d4087f550d1b69a32452d21aaf85745f6cf0c463a2",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "5.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openldap-2.6.2-5.fc38.aarch64.rpm",
+        "checksum": "sha256:bc5fe78e55afe5528e6c133d08ea96465ae2dc223499adbc1d3d314eb822ee26",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssh-9.0p1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:0052b724fc75638091e64feae206e56472f190038d1ddfe9788b207cd71fd360",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssh-clients-9.0p1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:bdf455b6e7d7f099b3730996445cfb32f9743f519b32e3514f7dae468a86996c",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssh-server-9.0p1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:8df95fe668cd67887b961dab177b97947039d7002ce74f7ae8bf0a9b6d5113cb",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssl-libs-3.0.5-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c6ccf60e3629f33ff9dd2b3b6215e0b8e3b81a3219cefcc11cde083ecc4664f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/openssl-pkcs11-0.4.12-2.fc37.aarch64.rpm",
+        "checksum": "sha256:cae55e7380b67c572cd4f793412c604707f77b2ae5e1bbb77133b17f35ab5e92",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/o/os-prober-1.81-1.fc37.aarch64.rpm",
+        "checksum": "sha256:f811cc8fc811d631471eb6adabcc1014ea329258cf37c2a5f7b936830e3b2e57",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/p11-kit-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:c568a007b9dae0d471d6badf723161e565f921c2b1eb04e19aee5fbf7dc6e61b",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/p11-kit-trust-0.24.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:f54c232b4713ac362a343800003ff7deff1c5e7c75710235b9cab5df55ef94a9",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pam-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:7c508a709e816951b3650e600925e691f180f25f92b68f2b0433ef3d787137f3",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pam-libs-1.5.2-14.fc37.aarch64.rpm",
+        "checksum": "sha256:ff3cb745172d9bd639d22e13dc66e94b2df4dae847cbc55d63ae6a6c1b69bf49",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/parted-3.5-6.fc38.aarch64.rpm",
+        "checksum": "sha256:818131ccd1235feeeb708903406eba00731ab0028b2272004b06235c75a121b3",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/passwd-0.80-13.fc37.aarch64.rpm",
+        "checksum": "sha256:b9e3aa8ab64ac34d90ce78c5911d91d7574de4c42bacd5ae9563b6d945147bf9",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre-8.45-1.fc37.2.aarch64.rpm",
+        "checksum": "sha256:cd7dc65be232b9b7b011932367eca95f07fdf271ccd88c1fafb65d152d547a12",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre2-10.40-1.fc37.1.aarch64.rpm",
+        "checksum": "sha256:6835ca1b00813eff887ef180d9a41f561f9f096a39a6446e5b25dc9da283f8e6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcsc-lite-1.9.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:b9a9a6191cadf2ce8c4dd682c3e532c48b8ee7caf2465fed0190086c22b9492c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.aarch64.rpm",
+        "checksum": "sha256:25930a2fdaa748fc28850dc1afd3e02a497b0e4aac518d36be8c80a9fee91a24",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.aarch64.rpm",
+        "checksum": "sha256:06911316ac07b9abd6ce0bed5ac424ce4e3e9e8e47ee8230118fc5dd2f4b48a8",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pigz-2.7-2.fc37.aarch64.rpm",
+        "checksum": "sha256:40ee09498cf64c1474ab90c473c9f363bf51611b18d2a929bb57cb8b6be505f4",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/pinentry-1.2.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:c27a813e7139bd63a370062a37235d90a6885258629358db2247f9346235aa91",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/plymouth-22.02.122-2.fc37.aarch64.rpm",
+        "checksum": "sha256:89532cc989331b5ff07dc381067d087843137423fd2bef1bf2223f5f6b8f0d88",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/plymouth-core-libs-22.02.122-2.fc37.aarch64.rpm",
+        "checksum": "sha256:0df4a8e191bbab062c549daaabbe6ba4809ccdd9b87b61b4844c8c4d66b790a9",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/plymouth-scripts-22.02.122-2.fc37.aarch64.rpm",
+        "checksum": "sha256:87e52531506685cb0f20dc15358bd187e5d38281c3b552bebf6e6d1e42ad92d7",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/policycoreutils-3.4-6.fc37.aarch64.rpm",
+        "checksum": "sha256:315ad79fbc53c6098168be87264263dd332e9b8df9fbc29a64b6fc44da182344",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/polkit-121-4.fc38.aarch64.rpm",
+        "checksum": "sha256:283b9a24381d643403c7957c5df4cb389890564082f1f16f9696ca8b35322930",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/polkit-libs-121-4.fc38.aarch64.rpm",
+        "checksum": "sha256:7d101e3624bb04eee8fedae8425964f6276d2b50badb75b6885ac255ad2101ee",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/polkit-pkla-compat-0.1-22.fc37.aarch64.rpm",
+        "checksum": "sha256:e1a639fc3080b7266b470b39ddb038e711b1c758e522b5cda2618fa3cc22c433",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/popt-1.19~rc1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:7d31be2cd877d2f6a22ed9efa52d27f287d8a33036cb7833c545f00188e6a477",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/procps-ng-3.3.17-6.fc37.aarch64.rpm",
+        "checksum": "sha256:909fb5490bb5df6c877668ac18bbf73cda213d7dbb3a1d2a8d1013bef4f8ed22",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "6.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/protobuf-c-1.4.0-6.fc37.aarch64.rpm",
+        "checksum": "sha256:e95d6e0acd379be9b199113235c64c921223faa213b4e5f91f215f056adc1e69",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/psmisc-23.4-4.fc37.aarch64.rpm",
+        "checksum": "sha256:d6a0316b7b4713c22e093abc05a5bf01541c77ed24578fe1f57fe437a4208a25",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python-unversioned-command-3.11.0~rc1-1.fc38.noarch.rpm",
+        "checksum": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-3.11.0~rc1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:349e77eb1fca043555141f1aeb018c47079c147358df4d6a58d00402bee9791b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dbus-1.2.18-5.fc37.aarch64.rpm",
+        "checksum": "sha256:a3c713d2b9d613fb286082decaf8ae0d44222855874a746238482a4c268c0bf1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:c2bb600208d5a9cfb7f7df7e54bed27a8d3041b5657eddc74474edcb4e3ede12",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:bc3b99028b610bd236645eca33d75b98fa9f07eb82239cf6031385ceb825080f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:3e62bca2c90ace2b9e000d02bc3538cfc3dd5bb25b0c9740f47b4fbf1e6b6a00",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:e746f59d62344dcca7f14582affd2b2543e3204d3ecf6525513381057c7c2fbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-gobject-base-3.42.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:44eb78b7f830a5cddf847c541080f8d2f54aed8ffbbf9e9e0a82f148893dbe5b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-gpg-1.17.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:c944c353ce1d26e0cafbe1a171d2bd8002d9588e6d217c811e8862ff12aad4dc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-hawkey-0.67.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:d82fc296d351848a187b975166e77ff1740ab94dfa50e0ad40bbb368470653dc",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-libcomps-0.1.18-4.fc37.aarch64.rpm",
+        "checksum": "sha256:a42215e87f56483854177094f00a56dec2355e2cc0346091c0d131696114bd81",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-libdnf-0.67.0-4.fc37.aarch64.rpm",
+        "checksum": "sha256:88dd22e6b6c0b82f58b8bfcb96a718b61175ed6b5a174b71d87c19e0f260af3c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-libs-3.11.0~rc1-1.fc38.aarch64.rpm",
+        "checksum": "sha256:f35908c2704a9219002a316958665b6d56092d2fe59d8fcdf20fa3817bb482c5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-nftables-1.0.5-1.fc38.aarch64.rpm",
+        "checksum": "sha256:ce92079aa9854b25e8b0179e884c7fac36787f1227f087caddcce1cbc3f42568",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:0b1505c9797a351ba292b3ecd9d525e94bbe96cac0f5cb5a3d024aacd7aee2c5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/p/python3-unbound-1.16.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:563be3c9ca5d1cfa3fdbab3ee89c769934d71987d61770a8723176d8fde3da24",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/q/qrencode-libs-4.1.1-3.fc37.aarch64.rpm",
+        "checksum": "sha256:4a9ff34d2b8abc163eff8534a8798e95e077d77936838930240b6da876cf4c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/readline-8.1-7.fc37.aarch64.rpm",
+        "checksum": "sha256:1caadea1fe1f44be99448485efdd8c02ef616da6a8d0a050bf308a68ec23ea68",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:c832ac1f2b95744b48fe50795ffd8ba136b93b14653b5ffc428e1642c62b91a5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:b0eb4b37fe8a8bc9c452c58ebe200fbf49f6d436210014c29c9c1f9dd57ef8df",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:c63610924ad5aea7867167a2d8ffe3ad61ded28b13319c7d91c7ca0473d95e99",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:689ef2b8d48e5a906d79d5aebe16c3a46843155b236361af5faab189e82a4d6f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:e348e94e73ce1be18394a47c2a6805fd50908c087f362586dcc3ee3a1e58d654",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.aarch64.rpm",
+        "checksum": "sha256:9e6bf9e329baa9ea5b348a16a2fb38fdc05ccafc393fd99fdf773f735a9c5573",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sed-4.8-11.fc37.aarch64.rpm",
+        "checksum": "sha256:b2c4f6d1944d3eee2fe5bbd79c89865cc89bde742fdb9538093048cc95ca6d71",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/selinux-policy-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/selinux-policy-targeted-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/shadow-utils-4.11.1-4.fc37.aarch64.rpm",
+        "checksum": "sha256:0d2fb53f362a449a838989041b614aa32367816e338edf9d3dc1a58532bb68f0",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/shared-mime-info-2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:8c0d4a908b2cf6051da6d5ce3171f65cf193acc1b10968a376424f11ad7dc60d",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "2",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/shim-aa64-15.6-2.aarch64.rpm",
+        "checksum": "sha256:700764e38ea8bc1c019d0aec39542b1af5f0c00f169a2210ff8d80504d0ce2ee",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sqlite-libs-3.39.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:c4ce968491bbe0f2db29e9af17f6972c7fed4fb014e56bea40a9585e40dcf082",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sssd-client-2.7.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:f7f71897aad9420b8c9e67073d7ed86eb969c20d8621379a7bd24aa1915f0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sssd-common-2.7.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:82c1bb049f19de6ebae1f17bad545e8093fa91d586eff77a57adb306f2d187e2",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sssd-kcm-2.7.3-3.fc38.aarch64.rpm",
+        "checksum": "sha256:137d4c21c59430bd54523fe68df630ecbe2f5d226e587cba32161808dd248183",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sudo-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:735bcb34d97de94e5515acf7b70bf6680e5f7a7235fe653bae666e9e664d41cd",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.aarch64.rpm",
+        "checksum": "sha256:679728f60d6d1a342c06aebe3830dad314a5e46ef4295ae8a0494c04f34fca08",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:baf1ae39b1ca951a1c3edf73d62f21bc409dd211f447000c1d21584d58847575",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-libs-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:235e8bef01064ad26fcd52f83fb63207d32fa0e8f4ffe32ac19a7e4e5df002a9",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-networkd-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:7809f426ffbbf705762eb4c3a63c5e60fe80d865e8f324e0512af8b426fc8c69",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-pam-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:0741570a6aea320cf433c9576f1af8b6020984cb190fc8b94e9de364b9a16c03",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-resolved-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:2800324594d595ea1d585e149a3641a876d03f328910bca6b8d5146a06f7bbdf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/s/systemd-udev-251.4-51.fc37.aarch64.rpm",
+        "checksum": "sha256:6b80e7b8f67c26eebe534e5d40920a430ae9ea099a5227de5c89cfd09735b19a",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/t/tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
+        "checksum": "sha256:eb62b4c7c08929750ed58268b2552105c360e8c0e8adfc4e1a53bb398e69333c",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022b",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/t/tzdata-2022b-1.fc38.noarch.rpm",
+        "checksum": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/udisks2-2.9.4-5.fc37.aarch64.rpm",
+        "checksum": "sha256:9e33a4dbe7d2fd2760c6912b6a5b8efc055d6ad93c9936689a940f3204aee55b",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/unbound-anchor-1.16.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:d2cefaf35e48685298b803f2c9e9ad8733d3e22b378e50d359f1535c0310be46",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/unbound-libs-1.16.2-3.fc37.aarch64.rpm",
+        "checksum": "sha256:aa756c8a894b19f1296c821caf7e9aab5316f822612d8a32758b906b3c0ce364",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/userspace-rcu-0.13.0-5.fc37.aarch64.rpm",
+        "checksum": "sha256:5f0f886c8994e9def478076bbc14120da42450dd342b085a99b9ef8084af9aab",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/util-linux-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:b936514f5a3a15efc8c8eb84e7ee24c062efa954d8c9c25df951f4007c08336b",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/u/util-linux-core-2.38.1-1.fc37.aarch64.rpm",
+        "checksum": "sha256:3542f5da08d71f2caa8742eb2d632e83f8b31d5fa5a93d771ddc9209be9ae895",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/v/vim-data-9.0.213-1.fc38.noarch.rpm",
+        "checksum": "sha256:0687cbfe5b9e9a63521b4a2f1e913ecffb35bff038211fc8bfc4dc277c193d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/v/vim-minimal-9.0.213-1.fc38.aarch64.rpm",
+        "checksum": "sha256:234a225028a09eed2d7747a72e447b5734318c4406b9459f5b689a6bf93c5d09",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/v/volume_key-libs-0.3.12-17.fc37.aarch64.rpm",
+        "checksum": "sha256:72e04c6d932e87f097a4bc344d67c2fdb383f5f5a7a532a236321f6a4dcfbb66",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.19.0",
+        "release": "1.fc38",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xfsprogs-5.19.0-1.fc38.aarch64.rpm",
+        "checksum": "sha256:f99af7003a71fc0afacf96968a740ea2892b2fc8c6b45ed8321fe7fe0260c4b4",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xz-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:5e4b581c98a7ca80bf83eaa3859d33bcadc8970ef661a4672f8cc0495af72175",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/x/xz-libs-5.2.5-10.fc37.aarch64.rpm",
+        "checksum": "sha256:a09aa2d7801d61e63530a28bee09de287c99ba11171d6756d8675d31dc754dcc",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/y/yum-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:b57f465bbca8c4ee064a73e3fa044b4fac3a158e1d754611a63db7feb7ffeec2",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zchunk-libs-1.2.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:3e6022327fc69de2c0c3b4f95a35ddc12104e5c41d9adf74f4c1d50a4bfc8f78",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zlib-1.2.12-4.fc37.aarch64.rpm",
+        "checksum": "sha256:df409a92f0a1edbf3902e63a7cb692bbb05a91bee87565b108495ae6c5f47b19",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zram-generator-1.1.2-2.fc37.aarch64.rpm",
+        "checksum": "sha256:37596c9b03d1beac82964c6cf5b1e5abe75c4a6975d82973ab2d4dda90a2faef",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-aarch64-rawhide-20220817/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests.plain/fedora_38-x86_64-minimal_rpm-boot.json
+++ b/test/data/manifests.plain/fedora_38-x86_64-minimal_rpm-boot.json
@@ -1,0 +1,11511 @@
+{
+  "compose-request": {
+    "distro": "fedora-38",
+    "arch": "x86_64",
+    "image-type": "minimal-rpm",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-modular-20220817/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+        "check_gpg": true
+      }
+    ],
+    "filename": "minimal-rpm.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora38",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:699c7614a02f23e068ef5cefee980ca70da47823610e27742e29fcfe979e5690",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f017dacf544a17d271361f78924c29eda45f0f52fa77fb9514042336d68ef7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82b232d1dec388528421f451420a5e2111410113ca495a0b662a3bf0c7a82646",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2571429544288cf7a61867a063e7d10d0f2c2709a9e5e802039aee454dbc9e41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c94d4dee58512f7fcd79e55434025062da0cbf4c995ecbbce5a3f21efeb6a93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f894b52e533562c47b9bbf8e00d1131b4c7dc2db7da0e40cad045ee49bbf5eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e6b4a62d8cda8eb663df9365c93d3201bb1faaf1816adbc400d56262afdccbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54b4b997573536fc04bd6ce7aeaaade4d0a9ace438d804f9477198437ec78249",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:011fd0372136954d6dd7523e327547b3dd718e7c6e34745d990fddfc52a29238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d59f7a80a28be4afb428d6038a39a6a3741ed283e2fcbaae7a6ee7bec2c2bd55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeb18fe98ed3d835cdba202e2c55112f9b7f57656c383e845abec682963b516c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c67f867a6bad6badc7c27ba481280b6116c6c1b18bb0935c28b843a83333f00c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13077b608f650173e1fba77045bc6608c93e87f58d532cc9f408ac2cc35c86c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11e9cd35f16ce7dc5765667a062276dc6cde1099b09f8d956adb1d58127db25c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd45fa047049031a58bfc4dec681ca81f3c031b61305826421423dfea5b2bd8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d413c4373f19d35e6e743930b2ddb34f3d53ff0c33ed42826e0cdc08def5e994",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d2f5dd86aa96c1afbf32cc3d98a7f9c06c0685e15ffeafb12987e47c0e389ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89d05bc19b065b78b97320f26bc442874279b8dd14ca77893ee4370497cb12c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fab563924947367fc91c4c5b3182d3ef8e526fc9a16b5b67c85da62e0a809084",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09b995e278193e02bd80451ff807a5f4d3712b2346724567bed3729c2508bf1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddd8d068c38efecd8a06ba1b0022cf6d59c9f7b6b54c0557bf792dadfa971c01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44b7cb6f7ae43a99383954f49b273fc9c574cc6c47cfaf5b297549c35f5444c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22a9001f0c13eaad184ae9a019e7b14d737f8015fb50a157f06435c361cb7fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c19d2a133bb48c61325b9b6fe63f02aefad65ce200b67006bfbadd54b324a024",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aabd27aa8687b29d4334ac2e40ecbe14d7adc18df0f430505f0c8f1df3e9f55f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6d2a12382aa9c1de1a9867e6bf554aaf6a25b6e6fd08ba8eb04fdf177de82f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75447f4c68574c2504b27033da0e611b5fb09e0e7fd47c94c6a8a899501e9a33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5ab4cbdd3a100451cb6f79b2b6dfa1ca47a0e797e9f6b7dfae393b56460bc93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5468fe904a1e33354ba552ba41e5a034cb97da57a78ae7c02ff163196a1f3e1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd47d802aaae00fb7498f98cfb3951a7dfe8f1cb412bd0cdac2aa37f0e6ad5d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6959b36d7ef7afd316fa0c27e84ce21ee1c191c0b76ea50ae39cbde275d0606c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:189f3a35a9e06c3a16454bad74b941dd2f15619b60bc6c2ed1468f4f38ee8108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4431de14bd2612dde9090d20e4727a0bf2deee21cb5eeb08d82c4196c367e0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4d23a66a6afc27bd19b01eabb811b4ce00fe16faa027d702529e51f41dc0c99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a71f4fcdbf0a1bb2468bab1fc2dc49a57a25aa9486afb02708990cc97249f0eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50b0dc3d33070a6cad724e373a473b2c7ce2127090adcf6dc175173f0ce5d1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb053b7bfdbdc452cf439e3a067b157c950256bcc50b2fd57e0527564c924070",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85d2fc0fb54bc8635d9ae51a2b692d592644fb4a39f34b70418ef1e241858ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9dc143ecd8d941b96d556a2dbad4fe03ca1897d8e6147a46c672e5f6498f2ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ffa143b2cc5980b96e460a8e926a3211dc7b04613700f5810a5e957915bf8ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50bff8587480cca84236252ee99f2f306d21ea476bf4b9f2e85b6ddcd565f3d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75e438745d6d681c3de20f7f4b07deea33b964eac73fa3ab17e32df8e5d9ad79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02f7656240a7a817fb9abe5a8de0d38b6f9e3c3e4d421624819e3af365830995",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:942d78a457a63542875bebe56dacd55dbdd19efa596e78e5f07fe2fa4a0aa959",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7f4d5badc8faaca874d2abd39202e4340e5e352998bad2da43af805a5fad26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5766eb61aed8b117ba04b36715ef5fbf1b52792babb9f15471df59a68e1e65d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53ec41e569ebca5a02dc2ae3148c05e6dd7127765a6fe4ddab0e26874f24389d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05d2f64fad5473ce1f46ae2f1e8d8be03cd32403fafa6cc8b3f27fc953895f96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e41c308c4cd335ce5a0e306977fbdec18abbcdcc8ed4811ec14784ae91f8905",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd33e3c1b8730844a570f9e2cc1bc818d7ce4d71ed345d48e1db4c120db3e209",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3786cac439d6e4364fc636ab88113449a725b2b4600d291037980d9418e8385",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:783787153af3229bfc3214929ab49002df5b6454edfc7a25756a139457908a6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3d14194ed32384f4050402e37484ca375a6a32df20d92e2e56e50141241cd1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e797d933f72843c6807e432359ec97e1317a1116d7d0effa57265a5e0acdc97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eefadbe8b3e74f1b171269c86b218dd808d5cc5e3a39a1d6b24d8705cbaa0c25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6003cd293b27e79e5b0a2ce42d2de69e5fff97ed9f968ced438d15371e63d2f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7d469f950778ff8adef1ca289cd186afcea961258f9548fbd41e4e75a723ab2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:feaf82298552968ed6b93fce62514a23ca6e387e60fd8d822d06b31b746d6580",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ba6e32620cbf52fa6a2569c05c87012acbca0622c385ca79a2a3530e8b91ac1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1824a7ff7e02feab54f1ddaaf0462efb842e6c68ee5646ae33c93cbd4855f917",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:14e228653909101710ce5e9b5ae448b1a92906f76b575d64339c6dce36462820",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc6ebe507afadf828aaabf170689006435c8ab334b5e8289ee9eab9492cfcda0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f43907f08625aefe9de6e3e33c18cb2d9835a1a26672994a951000ceb8557d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d29ce0147d6a1dc333b111baec1f0ab3e9079c8c4820ca2c2349e1576beb4b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0cb041ab0d613e62be3897fd8f0b3e02c2f720244efe83b3205efbc26eb065f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0e526b1bd8a24ae49c2c408de73f32a54b1136fe6a404580e9e702aaa58f93c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65f1521372f4e3edd032f7379cd6f4e021a1aa69199db6382e34ce7e7cea2413",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78693b8c775011e52abb0719a4f643fc29d38b7a8c756bf20d7937ab4cd80a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc7f0cd491fa100062e4901a2a30512dccc060b1cda2fb291cde05561e948794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8571bf4b6c8648679ce401f7c9a619ee105eccacf6ccc731c75a60a449b80345",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:344ef345e55df5b4de878bab40afc3f2fc6d4362f6fe78d9cd2a6c19483b9e3d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc213083bf978b139113ad37c607b772b2ff621461e314b09fa21a3d1da1e842",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:777f6e31853070aba2797e9332ef135032be2a40291da87e40795dfd0b7c6e07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4901f13daa6c7c034e1c42031c50053a6a94b406ad23cb0dde0c37508a0df3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:befee2bd06f9e9ebd716791c4613957049dc7c847a8ed9a841e6e2fb33e50026",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:699c7614a02f23e068ef5cefee980ca70da47823610e27742e29fcfe979e5690",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c568f1d12548ff1f2a379c6d6892982a47b2d303f886f98b2924f8ac354e5cbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d013334b24315ea9b3540cb035aabf117f793aa0f4e8a5a96067a348102265eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f017dacf544a17d271361f78924c29eda45f0f52fa77fb9514042336d68ef7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:82b232d1dec388528421f451420a5e2111410113ca495a0b662a3bf0c7a82646",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc515828054d44f6b85901e83169e1a8e022a2774d7544b7161bb00f0c4c3071",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d1768c630ebaa6f90c6b80d15b58bd2c2304e1ce939335c3823273a33ffe253",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:627a4f6c12cfe958371ed4829de0eda73ab4fca3e696167f5780586d0dfef5c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2571429544288cf7a61867a063e7d10d0f2c2709a9e5e802039aee454dbc9e41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c94d4dee58512f7fcd79e55434025062da0cbf4c995ecbbce5a3f21efeb6a93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f894b52e533562c47b9bbf8e00d1131b4c7dc2db7da0e40cad045ee49bbf5eec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e6b4a62d8cda8eb663df9365c93d3201bb1faaf1816adbc400d56262afdccbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b6c32d4748460d2bd442c4b813593b9711507caa20c8cf9140beed414493cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54b4b997573536fc04bd6ce7aeaaade4d0a9ace438d804f9477198437ec78249",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:011fd0372136954d6dd7523e327547b3dd718e7c6e34745d990fddfc52a29238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d59f7a80a28be4afb428d6038a39a6a3741ed283e2fcbaae7a6ee7bec2c2bd55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f615d35f78e1f51d61b46a95205a8e3433f46966ed5a140b53fc901b83a119b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39b86b1de69f52c26e72945d84c5767248a6ef3280289dc7c3fd5d55d251b504",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeb18fe98ed3d835cdba202e2c55112f9b7f57656c383e845abec682963b516c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c67f867a6bad6badc7c27ba481280b6116c6c1b18bb0935c28b843a83333f00c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74f679016b4c124834a072830f7baab7c7e0193bb8f8a6024357f08e44101ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:351b9f8911296b57b7f69f8b6f04bde3715648ed827aa6f5fa6b6ea44168341a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d96a131abbdbea273866174699f0c7c563fa35481fc8ea198064ad1857d5e979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a630412a9094d1294745986fd77c6e99762a667e8265c9859feb67651996785",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b353a0995c13684076f30b900fa47ce16652145302f9670ebd3f7ca1397e46c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:828ccdf867dea1145e90a327a3556465d1076c5d749b1976c32f1cfb3f3468ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13077b608f650173e1fba77045bc6608c93e87f58d532cc9f408ac2cc35c86c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e29bf7ae154d7c5485c493652836dfc189b0d5a0323052ac0cda7d8509094e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18f49193ba10e94d9d57ad445ee8c9a6ef454577274bf88e7da23c1482e87fe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6e1018e5327403c955cb766feaa112687b3210f06afc7702abae185de061506",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0c0c018d4123a23c789a078f73a0bc4e026b74281e5dbfe049c5f2b8266937f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11e9cd35f16ce7dc5765667a062276dc6cde1099b09f8d956adb1d58127db25c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd45fa047049031a58bfc4dec681ca81f3c031b61305826421423dfea5b2bd8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d413c4373f19d35e6e743930b2ddb34f3d53ff0c33ed42826e0cdc08def5e994",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85a7acceec5dbd64452b50af82887038c103768790a8a9c666caa048263432f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15b79ceb2f5777ee511f9bcb722c4affc72a5e994fc3dcb250fd4e49c25814b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7176e5bd8f6a7137a54684507a3eec12999fbf23607d87a0f59f165794a80da3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0121cf8885d2a35b98223ebb05ad2daf7ea2ed2856227297d556c93564defe7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2af369b0f500f875bf394b437524ba072cc317b0841cd62815691bc36d487ff1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd33ffe6445e9fa5aec6cce73d9a57eb52a2c819487ace6e96e63d51147618b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd8987f528bf3bd926c809d492f64374dcbf4a95252b569fd9cbf804848c319f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50ba63b1632e6c2de313206a9a0cc02aaf4bf6695fd3e5a4cc6132fb6e58d7df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c74e1647f0c6288a1f4f268f16f8b7bebcd53cb5f8bc9b3cea32af1eb24b6c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfcc4c16a94c401145dab64316d66cef8d2a579da55a46f4726cced30eb8b474",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4b88b5e76ec10eea9c09bdff3c1078cff3cd2d82481ffb4974fb595d22ad2e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d2f5dd86aa96c1afbf32cc3d98a7f9c06c0685e15ffeafb12987e47c0e389ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e89d05bc19b065b78b97320f26bc442874279b8dd14ca77893ee4370497cb12c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fab563924947367fc91c4c5b3182d3ef8e526fc9a16b5b67c85da62e0a809084",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e625693911f27f89ba5165242547d76893ed7bcea095580ecea5ac33c808c1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09b995e278193e02bd80451ff807a5f4d3712b2346724567bed3729c2508bf1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddd8d068c38efecd8a06ba1b0022cf6d59c9f7b6b54c0557bf792dadfa971c01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:44b7cb6f7ae43a99383954f49b273fc9c574cc6c47cfaf5b297549c35f5444c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:22a9001f0c13eaad184ae9a019e7b14d737f8015fb50a157f06435c361cb7fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:273a3901469983516f69733d0e773cfac3f13c183d12dc1018ccfdde3e1b9455",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:843fa03aed0edaed163739cdeaf432398287e480b0fbe2b181b6b4a939e8c9f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61dc36c13af2246b88f013ded040cb9e5e90377bd017be5a084c013280d5bdb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c14525cf0bc24724c32b66015c4c82b27eefa76e65d3621e94be54936cf90708",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368fb99245a0a78c0c229a9a53791b7ec0c4aaaf22d64451f36637d652a4aa55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c19d2a133bb48c61325b9b6fe63f02aefad65ce200b67006bfbadd54b324a024",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:648b73a8211d7b165c80bf366895cb39a3b86dbbf1d971258de653be0b6cb289",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aabd27aa8687b29d4334ac2e40ecbe14d7adc18df0f430505f0c8f1df3e9f55f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6d2a12382aa9c1de1a9867e6bf554aaf6a25b6e6fd08ba8eb04fdf177de82f3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75447f4c68574c2504b27033da0e611b5fb09e0e7fd47c94c6a8a899501e9a33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5ab4cbdd3a100451cb6f79b2b6dfa1ca47a0e797e9f6b7dfae393b56460bc93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5468fe904a1e33354ba552ba41e5a034cb97da57a78ae7c02ff163196a1f3e1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cd7cb3a9dcb03e1a3322200060b02fea694400f5c58ca1143a78758c55b6304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18238fedd785dbfe55bed864c13635a9feee9f4b929ffbd258c58e61736e4236",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12cb09ac132e4945809adfa22d3edbdc7fb458361d37032d6300830c052490c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c297a9d8223d4cd595d89d3e789b86e2558b902c9ba636af3f49587a17541dcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16a7a3f9d73ff11170a6f0fa686d03ef9a491089e8a3ddd492c93a865ed75aa3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7931f5dc4a593808c00346a9a452e24e79d5a70201da6ffbd3fc18d9a0e04a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:021567d8ce7baa4198a67eaa4f5a07311b3a3f3697c35f79ac3604e2389611e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:422d37180e8f7b3b2f7df2460c2697bd7c7c29241f809212947643351127eaf3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afbefb63271c859ba3e8b38aa4d34d96dbf2c97c7faee77aa1929aa791a6b9a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d3f733c72e0a227747d0c3319f35c197126a84cea362b4c32f34ea253d0e3b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:089e516a282a6611d8ccb37ed05870860c71d0fe0a00fcc75dfdc70e082d49cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dbb1fc38e0bac0925353d24aa78aeb2030f5eed9ef4b2637ccf5811d37fc807",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0bc33ff5df85f2c9a1bf645a20c77b60a7c270b1dfd54305d5ae3b75e89f4a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b39adb12197f08a665204c5628eca9a8025b24f12a77d6c7b4e04a2e11532a03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f74da1c044980e6bfcdfc8340fa91899f9a944800e3e6f71bd6e99e7693df5e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd47d802aaae00fb7498f98cfb3951a7dfe8f1cb412bd0cdac2aa37f0e6ad5d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ec5068f909fbbe589275596543d4664a5b9790a6d0effa3145f1d8824e01a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9e42a34622ef6f84da6e709a09da1ed4706540d9cb2d248a3d717e43a050946",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5230b318ee68400f8ec1cb1438667d236e23a3d476228e943ee44b6df063036",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6959b36d7ef7afd316fa0c27e84ce21ee1c191c0b76ea50ae39cbde275d0606c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3a4e9b6e68360f24bb2b92bf23068c47e96d6d705f546648b2e10dd88e44e84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e66f6a75e909357289e07d9ce9801a0662527aebee680bc255637012b956e66c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b79e53815bf9ccfdced5dc732b9d20ef47ab8dd20a5777e136adfc1740bf570",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:193f1fe42eef13e768d599bc89b07a2bfaab4223e66b35b1a6f89e3712fa73f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:189f3a35a9e06c3a16454bad74b941dd2f15619b60bc6c2ed1468f4f38ee8108",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29252f846cee0db551a9591bb0b9ccd1a67c79acefd4f5d034673bed15c082de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d8a26362c8177fe0b5244b4eca9ca46f2c566e36a22b100d03602e2c858d98f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:229016c32a77e76959f06a6f343388f6aa6079562b79d4ec38312348f96bc314",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d7a5f3f3bc6082dba0044531b4cbea7a50cd5731b3af6b87006f59fad9fecd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a47823036727b46b3661b41343b62ef0755cbffe48685c4af916537ead7aa33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b10cc93138634a64bff33bb14207332aaa4283fcd8b9daa798b3bfbb5b9c26e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ba626bdec4c251d6e39faaa5ed247fc26e459d255e50936fec468431b40b3f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76163e9f4faf4017811e2d63491fce611db1dfd5a6e5de24c1c497cc84c1032d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9afc19fb507521ee32f35e2cad4b530d863b2cc3810cb9b8408eb61bbb50b6b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:633d70b8df9fbd3a9a66ac186e5827525a1d01adeed448147e40a2b7c2a30ba4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:115f36517e2b9c7cab9ee7b092f8bfff6c1d53b09d0d774969c3884ecec1b601",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a0f03d9442843a9df7468a5a926a43c76d4c6437405db90598faea2f35434d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4431de14bd2612dde9090d20e4727a0bf2deee21cb5eeb08d82c4196c367e0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:453eec881996f5c80bec7ac779f7973ba8c2244e83d01e87daf4c3381b88a1ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f33c11f27b6953125ef43198459e256a0a75f222b5dfa2581b9dd7866a65b70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e03bc1e73acbe36966bce6df587d60d4081960198225c1fb8f62584b4363d16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4d23a66a6afc27bd19b01eabb811b4ce00fe16faa027d702529e51f41dc0c99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a71f4fcdbf0a1bb2468bab1fc2dc49a57a25aa9486afb02708990cc97249f0eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48c3829c4b7616d6985737c5c8552d49ac9d80e41780af6daa34963b8d5b9225",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b79f85fa9266e4ed110f75e71125593d7de788a3f8242a69acfb4be56e92190",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6fdb21908848e96e58d0ea2b495701eedad190b01f9df44c16e35f760cacae4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50b0dc3d33070a6cad724e373a473b2c7ce2127090adcf6dc175173f0ce5d1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d599d9a7ce446f0c7e2040422fec9a241f6c45dc0371372e9704abdaa8bd21d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb053b7bfdbdc452cf439e3a067b157c950256bcc50b2fd57e0527564c924070",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df65995dbfc5853caf3c3b81ee09334d4e7a7a8674d439ab2778b5047767c0d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50a0828e3f1eba2ec053d15a3412b2ca62ae513c3899ac5a6e88e9d91a21041f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa33eade6ec12857c1d17d8b56d704e1718833de594f6a4115c9528f8465830b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:922d0eab6721af3757cb60b4c0b79abd47e32897ece35bf02f08bc4951c2fc65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85d2fc0fb54bc8635d9ae51a2b692d592644fb4a39f34b70418ef1e241858ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd5ceea29405a70d0751933a5c3d6178b671c80ff97e04aec2614caf6156d238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09fc65ab51d47ada940766c145b96f738bf592e0359bb2a42ba2a398fdc7f6cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d623c4ed5fae679121f36b97a7a47b857c6b69b6647fd42a9a03a2591cd074a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d623b3080b32144b709ed7cf11dae330607dfb65bb5ac27585ec83bd3d99429",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74fd7795d471046edbd2ba1eb6a984025519aa076b2e856363ca8c2c4e26e6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7b9be0289d003cca9fec06b13b62aa9eb35c58651ec28404ad6ac863244cb394",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65d61922e3a2b117b79e44ffd2945ee5c8ee53e6d3603dff792982c04eb13d9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3aa53c7eb54ad2acaeab5231a44387ffa3f03dcd99a9f75ff4c8c592dd1cfe90",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15358af44d005789cfda790606bd60c162b673167bbfe7153a97a043e1083768",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9dc143ecd8d941b96d556a2dbad4fe03ca1897d8e6147a46c672e5f6498f2ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:092a0396068edc5fbc4e77aa49aa5c312184ef4b0b7435c604107a52f712a19e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995659e1f0c39fb758160120c68ece8446d14ab3e3b0527aeadb90b0547e5a7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a056805ee78f023e3dcabda0c298c6dcc16515a86153459c01905ab2b43e9be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:324c6e6d4a55b3ac12198e8c6a528be517d57cb38d27e3dd961bc0efd487b292",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ffa143b2cc5980b96e460a8e926a3211dc7b04613700f5810a5e957915bf8ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:118b3e835f01f45feb29c6c1eea1a50925ada9d5ff2804d6d7de74453aba5fbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd593e435ea68265fe742c4c6e3acc7240abaf9b9d75882205c4f434b727e1aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149011e66fc747517ea929ff80d4f88e72961b10e352a324a7ea4ec3d20503bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ca34df9ec9bc66a150d308568c53e462a6f35b48a07354982a1773eb9cd0abe3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7f3c8c057eb68b6b5838ff0738826b996c847f2452ee62fb5c1c344161f633e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0315d368bde2128992a58c09596af85d39ef7a37e097bfc94612f3dd7178dad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cfd13bf9a8723dc1d74d68155e59692e83707928c7f1366be13472da7612acb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84b3ed0958b484d83a0c189d674357f1287a60125cac6bf34a6e87a54c1a5505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29c61e3a7856ed3e31ae8d42777b571ae7f08644bf27acb1f0a1c1856c308b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89fc69c405e600d7667df2cb98d4c7d62259c72545db6267f234b28761244224",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50bff8587480cca84236252ee99f2f306d21ea476bf4b9f2e85b6ddcd565f3d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95aac8f490ae408be49651cba31d9ae7805157013629317cd5f13eaf6ce4696d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:891ca4669541cb323a77e6d2224baeebccb8d0bb892670521f63ecf4a5d490d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75e438745d6d681c3de20f7f4b07deea33b964eac73fa3ab17e32df8e5d9ad79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8c89e22f49416efda631ada91d7b944667d331672f82d60a0a2cb89c5a876c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536faf2906d98e64f4c712e59116f8281466a3e0f0d191a02a679f942a156fd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f97bf6f29d7554e4fb4da8db547d8d5cf9ffb6d608fd473b8c7224e71816892f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5377663e146a6c0ea34ee7f025bbcb12e4c46e3599e2de20cc0b958761fd4bd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02f7656240a7a817fb9abe5a8de0d38b6f9e3c3e4d421624819e3af365830995",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f3e6504aef91fc641678229a4f9d8d5428dd7b837cc4b0fb57038583025cdbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4eb90ba78d6ebbc54758ec1787b3c1adf2608962d183a101da8de1013bcb7cef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eaddcdfd370876db1241bf7251c8f87e0565dc818887d2bc95d7a211c77b3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8afe733f094d886431d500e2c5aac11bf8bcef0a05314160a968684cb006d574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f4d9ea051cce5144c69ba8b8519a5c3ab8b4e3907b391378f96a4e03981681f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae8795f1364c3fc84324923c2b594bd8207006e684d43016c052dffb70825c8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:942d78a457a63542875bebe56dacd55dbdd19efa596e78e5f07fe2fa4a0aa959",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7f4d5badc8faaca874d2abd39202e4340e5e352998bad2da43af805a5fad26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa17e852c5e17fb3caa668f5e8e04b517aa1a1985b76767ea7444f3343416e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6183bae674287b17dd36e3f5c01f0abcb021875895959fa63fb5061f18ccc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:648e27449350f50b6fbed7bce4ecdb586976446ddafcfa100cd235e74d3a2c38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:607d9c1a9c9f80a1bd21b1d3dfe9dad0b564c6a90d3359bd2d7e6594fc24f430",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c28ce263b298c1f526718c1cb0f055bdbb455e1130a4bbcf7113fcc992b448e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5766eb61aed8b117ba04b36715ef5fbf1b52792babb9f15471df59a68e1e65d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d5c1e81de661038bbeb3f2a2e6c2f98db4e1a009915da1f5ab6910940215827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2022bb0fe9c17df96734f4667357ddb956fd82004e9297504649ac60081b5464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53ec41e569ebca5a02dc2ae3148c05e6dd7127765a6fe4ddab0e26874f24389d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:debc0be72012ae50ae10caa306ad14b7a4f61e6bc43161da7036e3091900297f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81b81aee93d47f3a869b2582a53a0b59871b04f7e7c0b84d5e12207a271b0fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7548d4dced9671ae77294541ce1c82c7db90e5e1634413bd49e0d4830452969",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:80d01a8159d6c89b9e41b743a26a7148cb4ba043d2c8667c80738cf2e7efdd8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6f5750601aef9659831ba4e1effd28732bdf86e1f2cf4908d15f6b93b4c8596",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de1bf3531ca177b7bbc957c1447f86b545127d6a728b6dc55cd680af797e90ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a5992a49dfd989b0d7e80507aef401a64a3e071d732a4ecd8780ac128f1f740",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0d46120682f1f84d1cc960c8119a752a607a5f977b800c8886d663b3231373f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6238635b31f4b9dae4879707d1e1cacef4513a98b735062c3e9330d7dbddb918",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf6c10fd5b73cdfa52bc01e316242ae6c1d0712f43b05375d71ac2eb9ddc9231",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:935be10e2da04ce9cc96892f19fdcb53f3621bdf449fcd569ef930f5e5086a1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39e14c4ed790fe4d47bd984afc47f291cac78bdfc9cae7d220979ca52c7301d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fc5af931ae4e106fac29e38db61b4ac4e86331088ab085cb2e9ff0c33dc55bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c6819de5a54218e8d69921d7e9cab759b794c4d65c5b9199e0da3e05fc31ec1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0be81593c6a700d883ff95b06a92afef5790a5fbcdb8d35d6cbfc9c4e87e5a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eff8922a8b9fcc415fd0b2b058a35b3a3adbf782d947355156b2bf4f97fe1f8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcf4603e22813dc3529f3e973711cbf5a785de78c2554da68c74b86391b4870e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05d2f64fad5473ce1f46ae2f1e8d8be03cd32403fafa6cc8b3f27fc953895f96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f20fceba4f2c12cda1b77e788eb9f25b62cda9e31a70e29478703066e68db36b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:426e7f130bc6e13cdef872e9a5d77a0e1feedce7aee993216c1c1570987e7d29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e3d330928099efbf01cffb1f29da318c15eda3feb8aa97a16e0e4978b5c0d85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e41c308c4cd335ce5a0e306977fbdec18abbcdcc8ed4811ec14784ae91f8905",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:003ce0d20116e00e8b521e5b7451ea0606950387352596c066fa983d3b709d9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:873a81a4fe3a7364f2b93cfc72f6a0153e26051cf4937604fd9394e405600753",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4e2edcab2b0876625a00d939f8e415e1ba52c70bc5e21d6ed0713fe7c44a8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fd33e3c1b8730844a570f9e2cc1bc818d7ce4d71ed345d48e1db4c120db3e209",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf9cf9900f3ce7df167ec948605e36d3a616faa7293ca1daabaf0734e8447787",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaad7eb1db33cd9a7d75dc22f93fedf00d5cb5e58c4b91da4efc08394b6a3465",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43aa00d3d59e296bd2c46396d127b4c4622a5dc566462249669fcc560121e13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:105e81dea42d33867b290d41a8b5b7ed615ba05ade804c3b04a7ed01fb6b7cfa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f12201baaf7ada83796e6327ac381de4a5fb761c1455c69f9b7f80054531841",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c665d09c1beb16de5cacea881aee87cf0aef7ff8a79de42595fe80256c9fa38f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f78812b1fe8d73e5cae7d5bf750943f50ddee775f735dbb508f91395400725e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:151d21077d158b81f0b444fe3c819179f235db61e889245610f2474494781055",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84933208c4c2cd87bfdf08817f28fd8b2ea2f4920d63739cea1b937d63c5d0bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d655e5491ee4ced0bf5a9a374e5bd513ec0c82f1d606a534312824280c111fc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e3786cac439d6e4364fc636ab88113449a725b2b4600d291037980d9418e8385",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:783787153af3229bfc3214929ab49002df5b6454edfc7a25756a139457908a6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a34e7ee2f04f7fd376899ea78e1161101ba264cd9875a2d398b6e6adab38cd2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:692a5ce3d939ef1069eb54cdd3c67ca814f604199ae10dd40e1d1a6305d368d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3d14194ed32384f4050402e37484ca375a6a32df20d92e2e56e50141241cd1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2927ca7c2dcea19963acc971bdf3e02a2e5e8a327520c04d34cfce51f978f828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2bb600208d5a9cfb7f7df7e54bed27a8d3041b5657eddc74474edcb4e3ede12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc3b99028b610bd236645eca33d75b98fa9f07eb82239cf6031385ceb825080f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e62bca2c90ace2b9e000d02bc3538cfc3dd5bb25b0c9740f47b4fbf1e6b6a00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e746f59d62344dcca7f14582affd2b2543e3204d3ecf6525513381057c7c2fbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23de5abc3a9620f7f8c5917cfd452892cfcab34fcae502de4d04f83964ca716f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ae53041ff5534b34434f74420fe2726ee16da7807058475993c1035c729d477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1f48a911c68c5ed7afd8ccd83539b76a4e61b775efc19d5815a2a439f7852b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e62e029027cfae50e42f483e2e275cf33f6e24e4bfd8dd0b88b9be7ed719ef6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65a1852efc0080df33c92fbc1a80c18e6facad743094e5a778063150ba1581ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e797d933f72843c6807e432359ec97e1317a1116d7d0effa57265a5e0acdc97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:729c2e05903cc91e4bfa594265d346440e1dc72d52ae17b80edd998223660743",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a47a3377d709b85abdb7ee644cc4d97b13176ea9ed92da72627b80465eeda5cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c59cc4671bd159d06c722bf40df0da69b7336980c320de6c24b6aaa1562d2170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eefadbe8b3e74f1b171269c86b218dd808d5cc5e3a39a1d6b24d8705cbaa0c25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6003cd293b27e79e5b0a2ce42d2de69e5fff97ed9f968ced438d15371e63d2f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9714ed4acee2bba058776da3250ab8e7b0ea18268bc091abd98ded1df0aa14e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7d469f950778ff8adef1ca289cd186afcea961258f9548fbd41e4e75a723ab2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:feaf82298552968ed6b93fce62514a23ca6e387e60fd8d822d06b31b746d6580",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab148da694432365ab80452a1ebc7a9cc9cd76243874551b4759552a21028b41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f03293f178737efb4d4e044d1d4059fbedaba49978c3dc56bd8a0e6edfc83e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ba6e32620cbf52fa6a2569c05c87012acbca0622c385ca79a2a3530e8b91ac1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972aa39dadfa549706a4e5b1e021495060aad322663960d273f06ec093a1c009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1824a7ff7e02feab54f1ddaaf0462efb842e6c68ee5646ae33c93cbd4855f917",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0a922c318960ca36e6c4b398b2b5c8c8aecee3e86184830555cbc198f688b94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67eee198120158693730192cfe76e8c9632e3b00e8550e573aef07bbcc2ee771",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc29d08898d7d829cff570e29d32b7565800cee94358e5e53b314a2596343302",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59613aa4a26e2b338742edee7dc99d5fb1b2c7c81d500b5977a7a69a7174886e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b750d60543a4c45b5d663859d1372a041b2eb1c5d808c460cf536079e64ae02",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:14e228653909101710ce5e9b5ae448b1a92906f76b575d64339c6dce36462820",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc6ebe507afadf828aaabf170689006435c8ab334b5e8289ee9eab9492cfcda0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f43907f08625aefe9de6e3e33c18cb2d9835a1a26672994a951000ceb8557d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d29ce0147d6a1dc333b111baec1f0ab3e9079c8c4820ca2c2349e1576beb4b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0cb041ab0d613e62be3897fd8f0b3e02c2f720244efe83b3205efbc26eb065f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f0e526b1bd8a24ae49c2c408de73f32a54b1136fe6a404580e9e702aaa58f93c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86b85375ee031abc705f8cf1af528f761a5a5ef73418cb52ae58f44d1405f793",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b6187adc0b8facf93e4bd9e64490695517e47b4d67d04e5c592efcb8b89c8f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fded0e1914333e957b98f7da4b80ff785e7b1122f611c48cd2e375dacd2bc07a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e674c68dc9d3b7b254b677696c12743e1fd79e31c9b315bc700d9f545d145fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65f1521372f4e3edd032f7379cd6f4e021a1aa69199db6382e34ce7e7cea2413",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78693b8c775011e52abb0719a4f643fc29d38b7a8c756bf20d7937ab4cd80a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0687cbfe5b9e9a63521b4a2f1e913ecffb35bff038211fc8bfc4dc277c193d0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5bc403cdd722d6adaa0a7bab0b28fa8737a6f2e2b5a537e2b25ab759f3e6b0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0088c48b167cc56fde621d2ced4addc70c1097f0ea57f91939ccba67a2b22f28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc7f0cd491fa100062e4901a2a30512dccc060b1cda2fb291cde05561e948794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7998e07ae6dc75167fbb10dc3ee39e3cff89c129aa84166ee38449b01ac3e877",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8571bf4b6c8648679ce401f7c9a619ee105eccacf6ccc731c75a60a449b80345",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:344ef345e55df5b4de878bab40afc3f2fc6d4362f6fe78d9cd2a6c19483b9e3d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b57f465bbca8c4ee064a73e3fa044b4fac3a158e1d754611a63db7feb7ffeec2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1145e44089cf728566285ecd6419fd1a8f78e47f38dda1c998ac6d38d24843ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc213083bf978b139113ad37c607b772b2ff621461e314b09fa21a3d1da1e842",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a3e46f75e0213db137674dbaadabb14e2164a6146236e1f8bc3f7a6b56780e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGESvNwBEAC7HsCDTlugVeDSMFX6aW3zAPFMfvBssNj+89fdmbxcI9t7UY6f\nHvkkGziUET8e+9jB8R2/wXQCGOw1J+sfmwO4aN0LdVQjhKvVNj+F5jWt3m5FAIBa\nOTWS6Kvqw2ECTpH7fD86541eK3BuCni6d5U3PCd73t976FcUmpQ/1AthqMksM0Jz\ncJapvNmLTCR0NZ2XyyLmn/K1hgNXe8G5j0cSrJiY+Zpz5aQkT96j96Jm6W2A+tBI\nicU4n6V4vlj2TxmCumtXJGXGBGJnof/dCgh45aqi+sk5c429ns+5sooYcaEJojj6\nFYSITv10l+az6ZMJz/j61VYSkhMY8hQ4Wd+yL2JVzLE9N9V0L95sX1yEZ5ILmzwx\noRKe4WHSBE6yMxNWobv7hmC+3ZC5mLPaEDS/g/0xuQj9Sy9eT2mhhFPxOv29YQ+P\nsC3zXHJMMT0tlGd72PVHQQ0JYONfMhcC+7AHGFGz8p4/wor2jIFG1ouqE6Lfzm8o\nXWZMYm3AydlrP/xkYaoWNE3jL/+dskSBr/Yz7ZzlkAqH9lb1HKnXQLTrw6gz6pmI\nKufSDXjEFNxnFI/9gMlshJtk5+QSDzezmxFm+NMviSvDUNAVIzrU1D84dauBYph4\nOrJVeECQHEotny/I53AdlVwLYB4TWkObzTs6vtV7Pz1TK2CmHpe3UW72xwARAQAB\ntDFGZWRvcmEgKDM3KSA8ZmVkb3JhLTM3LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEErLXuToMcdLt8Fo0n9VrT+1MjVSoFAmESvNwCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ9VrT+1MjVSoPMhAAist7kK/YtcyBL/dt\nP55hPrkJT6Ay+e2Dvt4Pixe4iT32Y3jG12aoX2LY//mxVOOpV+EhXYTTb5aLt2Jj\na8/qCKJFk7zuCOxa1hgdRcjoR7ZbU0lNjD9mMCax/YT9QafcaMEib/FlknP3g1SN\nGRSKLObTJd6BbtZXCE80JRIX+Dy6+/Oz7LXRXeKpiimhlXT1wuTaqAJEtuHdQvg7\ndkL4DzAJ2FiURVd5gvgo266WaCMafJjFRrSGHJm0c+V+0Z9NsuH80JbPm+rCUh5U\nE9PMyztqlqtldtqc1+aZ1iUbVuXY059BUmlAhmf5sAlBktY+hEabH/4kmfGccbBL\nTyBIn03Y9q9173okZSUe6q16m/hbbWI8dwkSpIADZbGGJbRi8PJpCg9y6KI355qD\natE2irleoy6eXqpKa+uPTRBk7i/r6jDoA+u+tZyFfcEnwvSWP8cN1j5mNklvITZl\nYF1n5b3fejkZVdOmRZQNkyzMxYEd4UZFQZNYrx0nltAagRS8b5ikqNk2UTl+dyBG\nk9gLOSZhAa2JdmAqwe9rT69jaa4kZMLlxPPC3246s83t0s7lp7vF+zLPfPSvxpsU\ntg+fuT+OFKWYdBFF7VkEA+wezHAznIP6TPyQXbBpkzE889/hOXy4BYs0wy8Bpda/\nVe2Ba329f99dSCZKImi5DPCxJY4=\n=ZmVd\n-----END PGP PUBLIC KEY BLOCK-----"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "legacy": "i386-pc",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-6.0.0-0.rc1.13.fc38.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "minimal-rpm.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "minimal-rpm.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "ext4"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:003ce0d20116e00e8b521e5b7451ea0606950387352596c066fa983d3b709d9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/parted-3.5-6.fc38.x86_64.rpm"
+          },
+          "sha256:0088c48b167cc56fde621d2ced4addc70c1097f0ea57f91939ccba67a2b22f28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm"
+          },
+          "sha256:011fd0372136954d6dd7523e327547b3dd718e7c6e34745d990fddfc52a29238": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cyrus-sasl-lib-2.1.28-7.fc37.x86_64.rpm"
+          },
+          "sha256:0121cf8885d2a35b98223ebb05ad2daf7ea2ed2856227297d556c93564defe7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:021567d8ce7baa4198a67eaa4f5a07311b3a3f3697c35f79ac3604e2389611e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iproute-5.18.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:02f7656240a7a817fb9abe5a8de0d38b6f9e3c3e4d421624819e3af365830995": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libstdc++-12.1.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm"
+          },
+          "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:05d2f64fad5473ce1f46ae2f1e8d8be03cd32403fafa6cc8b3f27fc953895f96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openldap-2.6.2-5.fc38.x86_64.rpm"
+          },
+          "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:0687cbfe5b9e9a63521b4a2f1e913ecffb35bff038211fc8bfc4dc277c193d0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/v/vim-data-9.0.213-1.fc38.noarch.rpm"
+          },
+          "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc38.noarch.rpm"
+          },
+          "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm"
+          },
+          "sha256:089e516a282a6611d8ccb37ed05870860c71d0fe0a00fcc75dfdc70e082d49cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:092a0396068edc5fbc4e77aa49aa5c312184ef4b0b7435c604107a52f712a19e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libndp-1.8-4.fc37.x86_64.rpm"
+          },
+          "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm"
+          },
+          "sha256:09b995e278193e02bd80451ff807a5f4d3712b2346724567bed3729c2508bf1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-2.36.9000-1.fc38.x86_64.rpm"
+          },
+          "sha256:09fc65ab51d47ada940766c145b96f738bf592e0359bb2a42ba2a398fdc7f6cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libjaylink-0.3.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:0a47823036727b46b3661b41343b62ef0755cbffe48685c4af916537ead7aa33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-mdraid-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:0d29ce0147d6a1dc333b111baec1f0ab3e9079c8c4820ca2c2349e1576beb4b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-pam-251.4-51.fc37.x86_64.rpm"
+          },
+          "sha256:0d8a26362c8177fe0b5244b4eca9ca46f2c566e36a22b100d03602e2c858d98f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-crypto-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:0eaddcdfd370876db1241bf7251c8f87e0565dc818887d2bc95d7a211c77b3a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:0f3e6504aef91fc641678229a4f9d8d5428dd7b837cc4b0fb57038583025cdbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:105e81dea42d33867b290d41a8b5b7ed615ba05ade804c3b04a7ed01fb6b7cfa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pinentry-1.2.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:1145e44089cf728566285ecd6419fd1a8f78e47f38dda1c998ac6d38d24843ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zchunk-libs-1.2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:115f36517e2b9c7cab9ee7b092f8bfff6c1d53b09d0d774969c3884ecec1b601": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:118b3e835f01f45feb29c6c1eea1a50925ada9d5ff2804d6d7de74453aba5fbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:11e9cd35f16ce7dc5765667a062276dc6cde1099b09f8d956adb1d58127db25c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.x86_64.rpm"
+          },
+          "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/selinux-policy-targeted-37.9-1.fc38.noarch.rpm"
+          },
+          "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:12cb09ac132e4945809adfa22d3edbdc7fb458361d37032d6300830c052490c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/inih-56-2.fc37.x86_64.rpm"
+          },
+          "sha256:13077b608f650173e1fba77045bc6608c93e87f58d532cc9f408ac2cc35c86c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dracut-057-2.fc38.x86_64.rpm"
+          },
+          "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:149011e66fc747517ea929ff80d4f88e72961b10e352a324a7ea4ec3d20503bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:14e228653909101710ce5e9b5ae448b1a92906f76b575d64339c6dce36462820": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-251.4-51.fc37.x86_64.rpm"
+          },
+          "sha256:151d21077d158b81f0b444fe3c819179f235db61e889245610f2474494781055": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/polkit-121-4.fc38.x86_64.rpm"
+          },
+          "sha256:15358af44d005789cfda790606bd60c162b673167bbfe7153a97a043e1083768": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm"
+          },
+          "sha256:15b79ceb2f5777ee511f9bcb722c4affc72a5e994fc3dcb250fd4e49c25814b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-rawhide-modular-38-0.2.noarch.rpm"
+          },
+          "sha256:16a7a3f9d73ff11170a6f0fa686d03ef9a491089e8a3ddd492c93a865ed75aa3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/intel-gpu-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:18238fedd785dbfe55bed864c13635a9feee9f4b929ffbd258c58e61736e4236": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm"
+          },
+          "sha256:1824a7ff7e02feab54f1ddaaf0462efb842e6c68ee5646ae33c93cbd4855f917": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:189f3a35a9e06c3a16454bad74b941dd2f15619b60bc6c2ed1468f4f38ee8108": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-common-2.06-48.fc38.noarch.rpm"
+          },
+          "sha256:18f49193ba10e94d9d57ad445ee8c9a6ef454577274bf88e7da23c1482e87fe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dracut-config-rescue-057-2.fc38.x86_64.rpm"
+          },
+          "sha256:193f1fe42eef13e768d599bc89b07a2bfaab4223e66b35b1a6f89e3712fa73f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:1a056805ee78f023e3dcabda0c298c6dcc16515a86153459c01905ab2b43e9be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:1a5992a49dfd989b0d7e80507aef401a64a3e071d732a4ecd8780ac128f1f740": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:1b6c32d4748460d2bd442c4b813593b9711507caa20c8cf9140beed414493cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm"
+          },
+          "sha256:1cd7cb3a9dcb03e1a3322200060b02fea694400f5c58ca1143a78758c55b6304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/h/hostname-3.23-7.fc37.x86_64.rpm"
+          },
+          "sha256:1d1768c630ebaa6f90c6b80d15b58bd2c2304e1ce939335c3823273a33ffe253": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:1dbb1fc38e0bac0925353d24aa78aeb2030f5eed9ef4b2637ccf5811d37fc807": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iputils-20211215-3.fc37.x86_64.rpm"
+          },
+          "sha256:1e625693911f27f89ba5165242547d76893ed7bcea095580ecea5ac33c808c1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glib2-2.73.2-8.fc38.x86_64.rpm"
+          },
+          "sha256:2022bb0fe9c17df96734f4667357ddb956fd82004e9297504649ac60081b5464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:229016c32a77e76959f06a6f343388f6aa6079562b79d4ec38312348f96bc314": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-fs-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:22a9001f0c13eaad184ae9a019e7b14d737f8015fb50a157f06435c361cb7fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-minimal-langpack-2.36.9000-1.fc38.x86_64.rpm"
+          },
+          "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:23de5abc3a9620f7f8c5917cfd452892cfcab34fcae502de4d04f83964ca716f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:2571429544288cf7a61867a063e7d10d0f2c2709a9e5e802039aee454dbc9e41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:26a3e46f75e0213db137674dbaadabb14e2164a6146236e1f8bc3f7a6b56780e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:273a3901469983516f69733d0e773cfac3f13c183d12dc1018ccfdde3e1b9455": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:29252f846cee0db551a9591bb0b9ccd1a67c79acefd4f5d034673bed15c082de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:2927ca7c2dcea19963acc971bdf3e02a2e5e8a327520c04d34cfce51f978f828": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dbus-1.2.18-5.fc37.x86_64.rpm"
+          },
+          "sha256:29c61e3a7856ed3e31ae8d42777b571ae7f08644bf27acb1f0a1c1856c308b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libreport-filesystem-2.17.1-3.fc37.noarch.rpm"
+          },
+          "sha256:2af369b0f500f875bf394b437524ba072cc317b0841cd62815691bc36d487ff1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:2b750d60543a4c45b5d663859d1372a041b2eb1c5d808c460cf536079e64ae02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:2e29bf7ae154d7c5485c493652836dfc189b0d5a0323052ac0cda7d8509094e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dracut-config-generic-057-2.fc38.x86_64.rpm"
+          },
+          "sha256:2f03293f178737efb4d4e044d1d4059fbedaba49978c3dc56bd8a0e6edfc83e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm"
+          },
+          "sha256:324c6e6d4a55b3ac12198e8c6a528be517d57cb38d27e3dd961bc0efd487b292": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnftnl-1.2.3-1.fc38.x86_64.rpm"
+          },
+          "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:344ef345e55df5b4de878bab40afc3f2fc6d4362f6fe78d9cd2a6c19483b9e3d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libkcapi-1.4.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:351b9f8911296b57b7f69f8b6f04bde3715648ed827aa6f5fa6b6ea44168341a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm"
+          },
+          "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm"
+          },
+          "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm"
+          },
+          "sha256:368fb99245a0a78c0c229a9a53791b7ec0c4aaaf22d64451f36637d652a4aa55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm"
+          },
+          "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-common-1.14.0-3.fc37.noarch.rpm"
+          },
+          "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gzip-1.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:39b86b1de69f52c26e72945d84c5767248a6ef3280289dc7c3fd5d55d251b504": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm"
+          },
+          "sha256:39e14c4ed790fe4d47bd984afc47f291cac78bdfc9cae7d220979ca52c7301d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:3a630412a9094d1294745986fd77c6e99762a667e8265c9859feb67651996785": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:3aa53c7eb54ad2acaeab5231a44387ffa3f03dcd99a9f75ff4c8c592dd1cfe90": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmnl-1.0.4-16.fc37.x86_64.rpm"
+          },
+          "sha256:3ae53041ff5534b34434f74420fe2726ee16da7807058475993c1035c729d477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:3e62bca2c90ace2b9e000d02bc3538cfc3dd5bb25b0c9740f47b4fbf1e6b6a00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-common-38-0.2.noarch.rpm"
+          },
+          "sha256:422d37180e8f7b3b2f7df2460c2697bd7c7c29241f809212947643351127eaf3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ipset-7.15-4.fc37.x86_64.rpm"
+          },
+          "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-gpg-keys-38-0.2.noarch.rpm"
+          },
+          "sha256:426e7f130bc6e13cdef872e9a5d77a0e1feedce7aee993216c1c1570987e7d29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssh-clients-9.0p1-1.fc38.x86_64.rpm"
+          },
+          "sha256:44b7cb6f7ae43a99383954f49b273fc9c574cc6c47cfaf5b297549c35f5444c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-gconv-extra-2.36.9000-1.fc38.x86_64.rpm"
+          },
+          "sha256:453eec881996f5c80bec7ac779f7973ba8c2244e83d01e87daf4c3381b88a1ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm"
+          },
+          "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm"
+          },
+          "sha256:48c3829c4b7616d6985737c5c8552d49ac9d80e41780af6daa34963b8d5b9225": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm"
+          },
+          "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.x86_64.rpm"
+          },
+          "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm"
+          },
+          "sha256:4d2f5dd86aa96c1afbf32cc3d98a7f9c06c0685e15ffeafb12987e47c0e389ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-0.21-17.fc38.0.20220203.x86_64.rpm"
+          },
+          "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/setup-2.14.1-2.fc37.noarch.rpm"
+          },
+          "sha256:4e62e029027cfae50e42f483e2e275cf33f6e24e4bfd8dd0b88b9be7ed719ef6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:4eb90ba78d6ebbc54758ec1787b3c1adf2608962d183a101da8de1013bcb7cef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:4f12201baaf7ada83796e6327ac381de4a5fb761c1455c69f9b7f80054531841": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/plymouth-22.02.122-2.fc37.x86_64.rpm"
+          },
+          "sha256:4fa17e852c5e17fb3caa668f5e8e04b517aa1a1985b76767ea7444f3343416e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxmlb-0.3.9-2.fc37.x86_64.rpm"
+          },
+          "sha256:50a0828e3f1eba2ec053d15a3412b2ca62ae513c3899ac5a6e88e9d91a21041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgudev-237-3.fc37.x86_64.rpm"
+          },
+          "sha256:50b0dc3d33070a6cad724e373a473b2c7ce2127090adcf6dc175173f0ce5d1bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgcc-12.1.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:50ba63b1632e6c2de313206a9a0cc02aaf4bf6695fd3e5a4cc6132fb6e58d7df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:50bff8587480cca84236252ee99f2f306d21ea476bf4b9f2e85b6ddcd565f3d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:536faf2906d98e64f4c712e59116f8281466a3e0f0d191a02a679f942a156fd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_idmap-2.7.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:5377663e146a6c0ea34ee7f025bbcb12e4c46e3599e2de20cc0b958761fd4bd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_sudo-2.7.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:53ec41e569ebca5a02dc2ae3148c05e6dd7127765a6fe4ddab0e26874f24389d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm"
+          },
+          "sha256:5468fe904a1e33354ba552ba41e5a034cb97da57a78ae7c02ff163196a1f3e1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grubby-8.40-64.fc37.x86_64.rpm"
+          },
+          "sha256:54b4b997573536fc04bd6ce7aeaaade4d0a9ace438d804f9477198437ec78249": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/curl-7.84.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:5766eb61aed8b117ba04b36715ef5fbf1b52792babb9f15471df59a68e1e65d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm"
+          },
+          "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm"
+          },
+          "sha256:59613aa4a26e2b338742edee7dc99d5fb1b2c7c81d500b5977a7a69a7174886e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm"
+          },
+          "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm"
+          },
+          "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pigz-2.7-2.fc37.x86_64.rpm"
+          },
+          "sha256:5d623b3080b32144b709ed7cf11dae330607dfb65bb5ac27585ec83bd3d99429": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libksba-1.6.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:5e6b4a62d8cda8eb663df9365c93d3201bb1faaf1816adbc400d56262afdccbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:5f33c11f27b6953125ef43198459e256a0a75f222b5dfa2581b9dd7866a65b70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libdnf-0.67.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:5f4d9ea051cce5144c69ba8b8519a5c3ab8b4e3907b391378f96a4e03981681f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm"
+          },
+          "sha256:6003cd293b27e79e5b0a2ce42d2de69e5fff97ed9f968ced438d15371e63d2f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm"
+          },
+          "sha256:607d9c1a9c9f80a1bd21b1d3dfe9dad0b564c6a90d3359bd2d7e6594fc24f430": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/linux-firmware-whence-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:6183bae674287b17dd36e3f5c01f0abcb021875895959fa63fb5061f18ccc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm"
+          },
+          "sha256:61dc36c13af2246b88f013ded040cb9e5e90377bd017be5a084c013280d5bdb2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm"
+          },
+          "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:6238635b31f4b9dae4879707d1e1cacef4513a98b735062c3e9330d7dbddb918": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:627a4f6c12cfe958371ed4829de0eda73ab4fca3e696167f5780586d0dfef5c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:633d70b8df9fbd3a9a66ac186e5827525a1d01adeed448147e40a2b7c2a30ba4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:648b73a8211d7b165c80bf366895cb39a3b86dbbf1d971258de653be0b6cb289": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm"
+          },
+          "sha256:648e27449350f50b6fbed7bce4ecdb586976446ddafcfa100cd235e74d3a2c38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/linux-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:65a1852efc0080df33c92fbc1a80c18e6facad743094e5a778063150ba1581ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-libdnf-0.67.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:65d61922e3a2b117b79e44ffd2945ee5c8ee53e6d3603dff792982c04eb13d9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:65f1521372f4e3edd032f7379cd6f4e021a1aa69199db6382e34ce7e7cea2413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:67eee198120158693730192cfe76e8c9632e3b00e8550e573aef07bbcc2ee771": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sssd-common-2.7.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:692a5ce3d939ef1069eb54cdd3c67ca814f604199ae10dd40e1d1a6305d368d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm"
+          },
+          "sha256:6959b36d7ef7afd316fa0c27e84ce21ee1c191c0b76ea50ae39cbde275d0606c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kpartx-0.9.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm"
+          },
+          "sha256:699c7614a02f23e068ef5cefee980ca70da47823610e27742e29fcfe979e5690": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm"
+          },
+          "sha256:6a0f03d9442843a9df7468a5a926a43c76d4c6437405db90598faea2f35434d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm"
+          },
+          "sha256:6b6187adc0b8facf93e4bd9e64490695517e47b4d67d04e5c592efcb8b89c8f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/unbound-anchor-1.16.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:6b79e53815bf9ccfdced5dc732b9d20ef47ab8dd20a5777e136adfc1740bf570": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm"
+          },
+          "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:6d3f733c72e0a227747d0c3319f35c197126a84cea362b4c32f34ea253d0e3b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:6d5c1e81de661038bbeb3f2a2e6c2f98db4e1a009915da1f5ab6910940215827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/man-db-2.10.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:6e03bc1e73acbe36966bce6df587d60d4081960198225c1fb8f62584b4363d16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm"
+          },
+          "sha256:6e3d330928099efbf01cffb1f29da318c15eda3feb8aa97a16e0e4978b5c0d85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssh-server-9.0p1-1.fc38.x86_64.rpm"
+          },
+          "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/t/tzdata-2022b-1.fc38.noarch.rpm"
+          },
+          "sha256:6fc5af931ae4e106fac29e38db61b4ac4e86331088ab085cb2e9ff0c33dc55bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:7176e5bd8f6a7137a54684507a3eec12999fbf23607d87a0f59f165794a80da3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm"
+          },
+          "sha256:729c2e05903cc91e4bfa594265d346440e1dc72d52ae17b80edd998223660743": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-nftables-1.0.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:74f679016b4c124834a072830f7baab7c7e0193bb8f8a6024357f08e44101ff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dhcp-client-4.4.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:75447f4c68574c2504b27033da0e611b5fb09e0e7fd47c94c6a8a899501e9a33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-tools-2.06-48.fc38.x86_64.rpm"
+          },
+          "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:75e438745d6d681c3de20f7f4b07deea33b964eac73fa3ab17e32df8e5d9ad79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libssh-0.9.6-5.fc37.x86_64.rpm"
+          },
+          "sha256:76163e9f4faf4017811e2d63491fce611db1dfd5a6e5de24c1c497cc84c1032d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-utils-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxcrypt-4.4.28-3.fc38.x86_64.rpm"
+          },
+          "sha256:777f6e31853070aba2797e9332ef135032be2a40291da87e40795dfd0b7c6e07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:783787153af3229bfc3214929ab49002df5b6454edfc7a25756a139457908a6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm"
+          },
+          "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm"
+          },
+          "sha256:7998e07ae6dc75167fbb10dc3ee39e3cff89c129aa84166ee38449b01ac3e877": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xfsprogs-5.19.0-1.fc38.x86_64.rpm"
+          },
+          "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:7b9be0289d003cca9fec06b13b62aa9eb35c58651ec28404ad6ac863244cb394": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmaxminddb-1.6.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:7ba6e32620cbf52fa6a2569c05c87012acbca0622c385ca79a2a3530e8b91ac1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/shadow-utils-4.11.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:7c28ce263b298c1f526718c1cb0f055bdbb455e1130a4bbcf7113fcc992b448e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm"
+          },
+          "sha256:7c6819de5a54218e8d69921d7e9cab759b794c4d65c5b9199e0da3e05fc31ec1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm"
+          },
+          "sha256:7c94d4dee58512f7fcd79e55434025062da0cbf4c995ecbbce5a3f21efeb6a93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm"
+          },
+          "sha256:7d7a5f3f3bc6082dba0044531b4cbea7a50cd5731b3af6b87006f59fad9fecd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-loop-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:7e674c68dc9d3b7b254b677696c12743e1fd79e31c9b315bc700d9f545d145fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm"
+          },
+          "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:7ec5068f909fbbe589275596543d4664a5b9790a6d0effa3145f1d8824e01a42": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kernel-6.0.0-0.rc1.13.fc38.x86_64.rpm"
+          },
+          "sha256:7ffa143b2cc5980b96e460a8e926a3211dc7b04613700f5810a5e957915bf8ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnghttp2-1.48.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:80d01a8159d6c89b9e41b743a26a7148cb4ba043d2c8667c80738cf2e7efdd8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nftables-1.0.5-1.fc38.x86_64.rpm"
+          },
+          "sha256:81b81aee93d47f3a869b2582a53a0b59871b04f7e7c0b84d5e12207a271b0fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:828ccdf867dea1145e90a327a3556465d1076c5d749b1976c32f1cfb3f3468ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm"
+          },
+          "sha256:82b232d1dec388528421f451420a5e2111410113ca495a0b662a3bf0c7a82646": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bash-5.1.16-3.fc37.x86_64.rpm"
+          },
+          "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:843fa03aed0edaed163739cdeaf432398287e480b0fbe2b181b6b4a939e8c9f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:84933208c4c2cd87bfdf08817f28fd8b2ea2f4920d63739cea1b937d63c5d0bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/polkit-libs-121-4.fc38.x86_64.rpm"
+          },
+          "sha256:84b3ed0958b484d83a0c189d674357f1287a60125cac6bf34a6e87a54c1a5505": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/librepo-1.14.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:8571bf4b6c8648679ce401f7c9a619ee105eccacf6ccc731c75a60a449b80345": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm"
+          },
+          "sha256:85a7acceec5dbd64452b50af82887038c103768790a8a9c666caa048263432f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-modular-38-0.2.noarch.rpm"
+          },
+          "sha256:85d2fc0fb54bc8635d9ae51a2b692d592644fb4a39f34b70418ef1e241858ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm"
+          },
+          "sha256:86b85375ee031abc705f8cf1af528f761a5a5ef73418cb52ae58f44d1405f793": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:873a81a4fe3a7364f2b93cfc72f6a0153e26051cf4937604fd9394e405600753": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/passwd-0.80-13.fc37.x86_64.rpm"
+          },
+          "sha256:891ca4669541cb323a77e6d2224baeebccb8d0bb892670521f63ecf4a5d490d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm"
+          },
+          "sha256:89fc69c405e600d7667df2cb98d4c7d62259c72545db6267f234b28761244224": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm"
+          },
+          "sha256:8afe733f094d886431d500e2c5aac11bf8bcef0a05314160a968684cb006d574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm"
+          },
+          "sha256:8b79f85fa9266e4ed110f75e71125593d7de788a3f8242a69acfb4be56e92190": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sed-4.8-11.fc37.x86_64.rpm"
+          },
+          "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-38-0.2.noarch.rpm"
+          },
+          "sha256:8d599d9a7ce446f0c7e2040422fec9a241f6c45dc0371372e9704abdaa8bd21d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:8d623c4ed5fae679121f36b97a7a47b857c6b69b6647fd42a9a03a2591cd074a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libjcat-0.1.10-2.fc37.x86_64.rpm"
+          },
+          "sha256:8e41c308c4cd335ce5a0e306977fbdec18abbcdcc8ed4811ec14784ae91f8905": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm"
+          },
+          "sha256:8f43907f08625aefe9de6e3e33c18cb2d9835a1a26672994a951000ceb8557d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-networkd-251.4-51.fc37.x86_64.rpm"
+          },
+          "sha256:8f615d35f78e1f51d61b46a95205a8e3433f46966ed5a140b53fc901b83a119b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-libs-1.14.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:8f78812b1fe8d73e5cae7d5bf750943f50ddee775f735dbb508f91395400725e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/plymouth-scripts-22.02.122-2.fc37.x86_64.rpm"
+          },
+          "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:922d0eab6721af3757cb60b4c0b79abd47e32897ece35bf02f08bc4951c2fc65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:935be10e2da04ce9cc96892f19fdcb53f3621bdf449fcd569ef930f5e5086a1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-util-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:942d78a457a63542875bebe56dacd55dbdd19efa596e78e5f07fe2fa4a0aa959": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm"
+          },
+          "sha256:95aac8f490ae408be49651cba31d9ae7805157013629317cd5f13eaf6ce4696d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm"
+          },
+          "sha256:9714ed4acee2bba058776da3250ab8e7b0ea18268bc091abd98ded1df0aa14e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:972aa39dadfa549706a4e5b1e021495060aad322663960d273f06ec093a1c009": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm"
+          },
+          "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/crypto-policies-20220815-1.gite4ed860.fc38.noarch.rpm"
+          },
+          "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxcrypt-compat-4.4.28-3.fc38.x86_64.rpm"
+          },
+          "sha256:995659e1f0c39fb758160120c68ece8446d14ab3e3b0527aeadb90b0547e5a7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm"
+          },
+          "sha256:9afc19fb507521ee32f35e2cad4b530d863b2cc3810cb9b8408eb61bbb50b6b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm"
+          },
+          "sha256:9b4e2edcab2b0876625a00d939f8e415e1ba52c70bc5e21d6ed0713fe7c44a8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:9ba626bdec4c251d6e39faaa5ed247fc26e459d255e50936fec468431b40b3f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-swap-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:9c74e1647f0c6288a1f4f268f16f8b7bebcd53cb5f8bc9b3cea32af1eb24b6c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:9e797d933f72843c6807e432359ec97e1317a1116d7d0effa57265a5e0acdc97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-libs-3.11.0~rc1-1.fc38.x86_64.rpm"
+          },
+          "sha256:9f017dacf544a17d271361f78924c29eda45f0f52fa77fb9514042336d68ef7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/audit-libs-3.0.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm"
+          },
+          "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm"
+          },
+          "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:a34e7ee2f04f7fd376899ea78e1161101ba264cd9875a2d398b6e6adab38cd2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/protobuf-c-1.4.0-6.fc37.x86_64.rpm"
+          },
+          "sha256:a47a3377d709b85abdb7ee644cc4d97b13176ea9ed92da72627b80465eeda5cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm"
+          },
+          "sha256:a5bc403cdd722d6adaa0a7bab0b28fa8737a6f2e2b5a537e2b25ab759f3e6b0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/v/vim-minimal-9.0.213-1.fc38.x86_64.rpm"
+          },
+          "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/basesystem-11-14.fc37.noarch.rpm"
+          },
+          "sha256:a71f4fcdbf0a1bb2468bab1fc2dc49a57a25aa9486afb02708990cc97249f0eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kmod-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:a8c89e22f49416efda631ada91d7b944667d331672f82d60a0a2cb89c5a876c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_certmap-2.7.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm"
+          },
+          "sha256:aa33eade6ec12857c1d17d8b56d704e1718833de594f6a4115c9528f8465830b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgusb-0.3.10-3.fc37.x86_64.rpm"
+          },
+          "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm"
+          },
+          "sha256:aabd27aa8687b29d4334ac2e40ecbe14d7adc18df0f430505f0c8f1df3e9f55f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-pc-2.06-48.fc38.x86_64.rpm"
+          },
+          "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm"
+          },
+          "sha256:ab148da694432365ab80452a1ebc7a9cc9cd76243874551b4759552a21028b41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-rawhide-38-0.2.noarch.rpm"
+          },
+          "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm"
+          },
+          "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm"
+          },
+          "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm"
+          },
+          "sha256:ae8795f1364c3fc84324923c2b594bd8207006e684d43016c052dffb70825c8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libuser-0.63-12.fc37.x86_64.rpm"
+          },
+          "sha256:aeb18fe98ed3d835cdba202e2c55112f9b7f57656c383e845abec682963b516c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:afbefb63271c859ba3e8b38aa4d34d96dbf2c97c7faee77aa1929aa791a6b9a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ipset-libs-7.15-4.fc37.x86_64.rpm"
+          },
+          "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:b10cc93138634a64bff33bb14207332aaa4283fcd8b9daa798b3bfbb5b9c26e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-part-2.27-3.fc37.x86_64.rpm"
+          },
+          "sha256:b1f48a911c68c5ed7afd8ccd83539b76a4e61b775efc19d5815a2a439f7852b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-hawkey-0.67.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm"
+          },
+          "sha256:b353a0995c13684076f30b900fa47ce16652145302f9670ebd3f7ca1397e46c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:b39adb12197f08a665204c5628eca9a8025b24f12a77d6c7b4e04a2e11532a03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/jq-1.6-14.fc37.x86_64.rpm"
+          },
+          "sha256:b4b88b5e76ec10eea9c09bdff3c1078cff3cd2d82481ffb4974fb595d22ad2e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gdisk-1.0.9-3.fc37.x86_64.rpm"
+          },
+          "sha256:b4d23a66a6afc27bd19b01eabb811b4ce00fe16faa027d702529e51f41dc0c99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:b57f465bbca8c4ee064a73e3fa044b4fac3a158e1d754611a63db7feb7ffeec2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/y/yum-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:b5ab4cbdd3a100451cb6f79b2b6dfa1ca47a0e797e9f6b7dfae393b56460bc93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-tools-minimal-2.06-48.fc38.x86_64.rpm"
+          },
+          "sha256:b7548d4dced9671ae77294541ce1c82c7db90e5e1634413bd49e0d4830452969": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nettle-3.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:b9e42a34622ef6f84da6e709a09da1ed4706540d9cb2d248a3d717e43a050946": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kernel-core-6.0.0-0.rc1.13.fc38.x86_64.rpm"
+          },
+          "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:bc29d08898d7d829cff570e29d32b7565800cee94358e5e53b314a2596343302": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sssd-kcm-2.7.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:bc3b99028b610bd236645eca33d75b98fa9f07eb82239cf6031385ceb825080f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm"
+          },
+          "sha256:bcf4603e22813dc3529f3e973711cbf5a785de78c2554da68c74b86391b4870e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/oniguruma-6.9.8-1.fc37.1.x86_64.rpm"
+          },
+          "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm"
+          },
+          "sha256:befee2bd06f9e9ebd716791c4613957049dc7c847a8ed9a841e6e2fb33e50026": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/NetworkManager-libnm-1.39.11-1.fc37.x86_64.rpm"
+          },
+          "sha256:bf6c10fd5b73cdfa52bc01e316242ae6c1d0712f43b05375d71ac2eb9ddc9231": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-sysinit-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:bf7f4d5badc8faaca874d2abd39202e4340e5e352998bad2da43af805a5fad26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:bf9cf9900f3ce7df167ec948605e36d3a616faa7293ca1daabaf0734e8447787": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcsc-lite-1.9.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:c0bc33ff5df85f2c9a1bf645a20c77b60a7c270b1dfd54305d5ae3b75e89f4a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm"
+          },
+          "sha256:c14525cf0bc24724c32b66015c4c82b27eefa76e65d3621e94be54936cf90708": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gobject-introspection-1.73.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:c19d2a133bb48c61325b9b6fe63f02aefad65ce200b67006bfbadd54b324a024": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grep-3.7-4.fc37.x86_64.rpm"
+          },
+          "sha256:c297a9d8223d4cd595d89d3e789b86e2558b902c9ba636af3f49587a17541dcd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm"
+          },
+          "sha256:c2bb600208d5a9cfb7f7df7e54bed27a8d3041b5657eddc74474edcb4e3ede12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm"
+          },
+          "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm"
+          },
+          "sha256:c3d14194ed32384f4050402e37484ca375a6a32df20d92e2e56e50141241cd1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-3.11.0~rc1-1.fc38.x86_64.rpm"
+          },
+          "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm"
+          },
+          "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:c4431de14bd2612dde9090d20e4727a0bf2deee21cb5eeb08d82c4196c367e0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcurl-7.84.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:c4901f13daa6c7c034e1c42031c50053a6a94b406ad23cb0dde0c37508a0df3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/NetworkManager-1.39.11-1.fc37.x86_64.rpm"
+          },
+          "sha256:c568f1d12548ff1f2a379c6d6892982a47b2d303f886f98b2924f8ac354e5cbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/amd-gpu-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:c59cc4671bd159d06c722bf40df0da69b7336980c320de6c24b6aaa1562d2170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-unbound-1.16.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:c665d09c1beb16de5cacea881aee87cf0aef7ff8a79de42595fe80256c9fa38f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/plymouth-core-libs-22.02.122-2.fc37.x86_64.rpm"
+          },
+          "sha256:c67f867a6bad6badc7c27ba481280b6116c6c1b18bb0935c28b843a83333f00c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm"
+          },
+          "sha256:c6d2a12382aa9c1de1a9867e6bf554aaf6a25b6e6fd08ba8eb04fdf177de82f3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-pc-modules-2.06-48.fc38.noarch.rpm"
+          },
+          "sha256:c6e1018e5327403c955cb766feaa112687b3210f06afc7702abae185de061506": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/duktape-2.6.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:c6f5750601aef9659831ba4e1effd28732bdf86e1f2cf4908d15f6b93b4c8596": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/npth-1.6-9.fc37.x86_64.rpm"
+          },
+          "sha256:c6fdb21908848e96e58d0ea2b495701eedad190b01f9df44c16e35f760cacae4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm"
+          },
+          "sha256:c74fd7795d471046edbd2ba1eb6a984025519aa076b2e856363ca8c2c4e26e6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:c78693b8c775011e52abb0719a4f643fc29d38b7a8c756bf20d7937ab4cd80a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:c7931f5dc4a593808c00346a9a452e24e79d5a70201da6ffbd3fc18d9a0e04a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm"
+          },
+          "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/file-5.42-4.fc37.x86_64.rpm"
+          },
+          "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm"
+          },
+          "sha256:ca34df9ec9bc66a150d308568c53e462a6f35b48a07354982a1773eb9cd0abe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-38-0.2.noarch.rpm"
+          },
+          "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm"
+          },
+          "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm"
+          },
+          "sha256:cd33ffe6445e9fa5aec6cce73d9a57eb52a2c819487ace6e96e63d51147618b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:cd47d802aaae00fb7498f98cfb3951a7dfe8f1cb412bd0cdac2aa37f0e6ad5d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kbd-2.5.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/json-c-0.16-2.fc37.x86_64.rpm"
+          },
+          "sha256:cd5ceea29405a70d0751933a5c3d6178b671c80ff97e04aec2614caf6156d238": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:cd8987f528bf3bd926c809d492f64374dcbf4a95252b569fd9cbf804848c319f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-2.48-5.fc37.x86_64.rpm"
+          },
+          "sha256:cfd13bf9a8723dc1d74d68155e59692e83707928c7f1366be13472da7612acb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm"
+          },
+          "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:d013334b24315ea9b3540cb035aabf117f793aa0f4e8a5a96067a348102265eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/audit-3.0.8-3.fc37.x86_64.rpm"
+          },
+          "sha256:d0be81593c6a700d883ff95b06a92afef5790a5fbcdb8d35d6cbfc9c4e87e5a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm"
+          },
+          "sha256:d0cb041ab0d613e62be3897fd8f0b3e02c2f720244efe83b3205efbc26eb065f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-resolved-251.4-51.fc37.x86_64.rpm"
+          },
+          "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm"
+          },
+          "sha256:d413c4373f19d35e6e743930b2ddb34f3d53ff0c33ed42826e0cdc08def5e994": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-libs-0.187-6.fc37.x86_64.rpm"
+          },
+          "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:d59f7a80a28be4afb428d6038a39a6a3741ed283e2fcbaae7a6ee7bec2c2bd55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-1.14.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:d655e5491ee4ced0bf5a9a374e5bd513ec0c82f1d606a534312824280c111fc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm"
+          },
+          "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm"
+          },
+          "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-unversioned-command-3.11.0~rc1-1.fc38.noarch.rpm"
+          },
+          "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:d7f3c8c057eb68b6b5838ff0738826b996c847f2452ee62fb5c1c344161f633e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm"
+          },
+          "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm"
+          },
+          "sha256:d96a131abbdbea273866174699f0c7c563fa35481fc8ea198064ad1857d5e979": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm"
+          },
+          "sha256:d9dc143ecd8d941b96d556a2dbad4fe03ca1897d8e6147a46c672e5f6498f2ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm"
+          },
+          "sha256:dc515828054d44f6b85901e83169e1a8e022a2774d7544b7161bb00f0c4c3071": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bluez-5.65-1.fc37.x86_64.rpm"
+          },
+          "sha256:dc7f0cd491fa100062e4901a2a30512dccc060b1cda2fb291cde05561e948794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/w/which-2.21-35.fc37.x86_64.rpm"
+          },
+          "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm"
+          },
+          "sha256:dd45fa047049031a58bfc4dec681ca81f3c031b61305826421423dfea5b2bd8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-libelf-0.187-6.fc37.x86_64.rpm"
+          },
+          "sha256:dd593e435ea68265fe742c4c6e3acc7240abaf9b9d75882205c4f434b727e1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm"
+          },
+          "sha256:ddd8d068c38efecd8a06ba1b0022cf6d59c9f7b6b54c0557bf792dadfa971c01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-common-2.36.9000-1.fc38.x86_64.rpm"
+          },
+          "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/selinux-policy-37.9-1.fc38.noarch.rpm"
+          },
+          "sha256:de1bf3531ca177b7bbc957c1447f86b545127d6a728b6dc55cd680af797e90ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nspr-4.34.0-3.fc37.x86_64.rpm"
+          },
+          "sha256:debc0be72012ae50ae10caa306ad14b7a4f61e6bc43161da7036e3091900297f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nano-6.4-1.fc37.x86_64.rpm"
+          },
+          "sha256:df65995dbfc5853caf3c3b81ee09334d4e7a7a8674d439ab2778b5047767c0d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm"
+          },
+          "sha256:dfcc4c16a94c401145dab64316d66cef8d2a579da55a46f4726cced30eb8b474": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.x86_64.rpm"
+          },
+          "sha256:e0c0c018d4123a23c789a078f73a0bc4e026b74281e5dbfe049c5f2b8266937f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm"
+          },
+          "sha256:e0d46120682f1f84d1cc960c8119a752a607a5f977b800c8886d663b3231373f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-softokn-3.81.0-1.fc37.x86_64.rpm"
+          },
+          "sha256:e3786cac439d6e4364fc636ab88113449a725b2b4600d291037980d9418e8385": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/popt-1.19~rc1-3.fc37.x86_64.rpm"
+          },
+          "sha256:e3a4e9b6e68360f24bb2b92bf23068c47e96d6d705f546648b2e10dd88e44e84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/less-590-5.fc37.x86_64.rpm"
+          },
+          "sha256:e43aa00d3d59e296bd2c46396d127b4c4622a5dc566462249669fcc560121e13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.x86_64.rpm"
+          },
+          "sha256:e5230b318ee68400f8ec1cb1438667d236e23a3d476228e943ee44b6df063036": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kernel-modules-6.0.0-0.rc1.13.fc38.x86_64.rpm"
+          },
+          "sha256:e66f6a75e909357289e07d9ce9801a0662527aebee680bc255637012b956e66c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm"
+          },
+          "sha256:e746f59d62344dcca7f14582affd2b2543e3204d3ecf6525513381057c7c2fbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm"
+          },
+          "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-identity-basic-38-0.2.noarch.rpm"
+          },
+          "sha256:e7d469f950778ff8adef1ca289cd186afcea961258f9548fbd41e4e75a723ab2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:e89d05bc19b065b78b97320f26bc442874279b8dd14ca77893ee4370497cb12c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-libs-0.21-17.fc38.0.20220203.x86_64.rpm"
+          },
+          "sha256:eaad7eb1db33cd9a7d75dc22f93fedf00d5cb5e58c4b91da4efc08394b6a3465": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm"
+          },
+          "sha256:eb053b7bfdbdc452cf439e3a067b157c950256bcc50b2fd57e0527564c924070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgomp-12.1.1-4.fc38.x86_64.rpm"
+          },
+          "sha256:eefadbe8b3e74f1b171269c86b218dd808d5cc5e3a39a1d6b24d8705cbaa0c25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/readline-8.1-7.fc37.x86_64.rpm"
+          },
+          "sha256:eff8922a8b9fcc415fd0b2b058a35b3a3adbf782d947355156b2bf4f97fe1f8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nvidia-gpu-firmware-20220708-137.fc38.noarch.rpm"
+          },
+          "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm"
+          },
+          "sha256:f0315d368bde2128992a58c09596af85d39ef7a37e097bfc94612f3dd7178dad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm"
+          },
+          "sha256:f0a922c318960ca36e6c4b398b2b5c8c8aecee3e86184830555cbc198f688b94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sssd-client-2.7.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:f0e526b1bd8a24ae49c2c408de73f32a54b1136fe6a404580e9e702aaa58f93c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-udev-251.4-51.fc37.x86_64.rpm"
+          },
+          "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm"
+          },
+          "sha256:f20fceba4f2c12cda1b77e788eb9f25b62cda9e31a70e29478703066e68db36b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssh-9.0p1-1.fc38.x86_64.rpm"
+          },
+          "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm"
+          },
+          "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm"
+          },
+          "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm"
+          },
+          "sha256:f74da1c044980e6bfcdfc8340fa91899f9a944800e3e6f71bd6e99e7693df5e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm"
+          },
+          "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm"
+          },
+          "sha256:f894b52e533562c47b9bbf8e00d1131b4c7dc2db7da0e40cad045ee49bbf5eec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cpio-2.13-13.fc37.x86_64.rpm"
+          },
+          "sha256:f97bf6f29d7554e4fb4da8db547d8d5cf9ffb6d608fd473b8c7224e71816892f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_nss_idmap-2.7.3-3.fc38.x86_64.rpm"
+          },
+          "sha256:fab563924947367fc91c4c5b3182d3ef8e526fc9a16b5b67c85da62e0a809084": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-runtime-0.21-17.fc38.0.20220203.x86_64.rpm"
+          },
+          "sha256:fc213083bf978b139113ad37c607b772b2ff621461e314b09fa21a3d1da1e842": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zlib-1.2.12-4.fc37.x86_64.rpm"
+          },
+          "sha256:fc6ebe507afadf828aaabf170689006435c8ab334b5e8289ee9eab9492cfcda0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-libs-251.4-51.fc37.x86_64.rpm"
+          },
+          "sha256:fd33e3c1b8730844a570f9e2cc1bc818d7ce4d71ed345d48e1db4c120db3e209": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm"
+          },
+          "sha256:fded0e1914333e957b98f7da4b80ff785e7b1122f611c48cd2e375dacd2bc07a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/unbound-libs-1.16.2-3.fc37.x86_64.rpm"
+          },
+          "sha256:feaf82298552968ed6b93fce62514a23ca6e387e60fd8d822d06b31b746d6580": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.x86_64.rpm"
+          },
+          "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm",
+        "checksum": "sha256:699c7614a02f23e068ef5cefee980ca70da47823610e27742e29fcfe979e5690",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/audit-libs-3.0.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9f017dacf544a17d271361f78924c29eda45f0f52fa77fb9514042336d68ef7f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bash-5.1.16-3.fc37.x86_64.rpm",
+        "checksum": "sha256:82b232d1dec388528421f451420a5e2111410113ca495a0b662a3bf0c7a82646",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:2571429544288cf7a61867a063e7d10d0f2c2709a9e5e802039aee454dbc9e41",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:7c94d4dee58512f7fcd79e55434025062da0cbf4c995ecbbce5a3f21efeb6a93",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:f894b52e533562c47b9bbf8e00d1131b4c7dc2db7da0e40cad045ee49bbf5eec",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:5e6b4a62d8cda8eb663df9365c93d3201bb1faaf1816adbc400d56262afdccbd",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/crypto-policies-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/curl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:54b4b997573536fc04bd6ce7aeaaade4d0a9ace438d804f9477198437ec78249",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cyrus-sasl-lib-2.1.28-7.fc37.x86_64.rpm",
+        "checksum": "sha256:011fd0372136954d6dd7523e327547b3dd718e7c6e34745d990fddfc52a29238",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-1.14.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d59f7a80a28be4afb428d6038a39a6a3741ed283e2fcbaae7a6ee7bec2c2bd55",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-common-1.14.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:aeb18fe98ed3d835cdba202e2c55112f9b7f57656c383e845abec682963b516c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c67f867a6bad6badc7c27ba481280b6116c6c1b18bb0935c28b843a83333f00c",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dracut-057-2.fc38.x86_64.rpm",
+        "checksum": "sha256:13077b608f650173e1fba77045bc6608c93e87f58d532cc9f408ac2cc35c86c5",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:11e9cd35f16ce7dc5765667a062276dc6cde1099b09f8d956adb1d58127db25c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-libelf-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:dd45fa047049031a58bfc4dec681ca81f3c031b61305826421423dfea5b2bd8f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-libs-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:d413c4373f19d35e6e743930b2ddb34f3d53ff0c33ed42826e0cdc08def5e994",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-gpg-keys-38-0.2.noarch.rpm",
+        "checksum": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-38-0.2.noarch.rpm",
+        "checksum": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-common-38-0.2.noarch.rpm",
+        "checksum": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-identity-basic-38-0.2.noarch.rpm",
+        "checksum": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-38-0.2.noarch.rpm",
+        "checksum": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-rawhide-38-0.2.noarch.rpm",
+        "checksum": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-0.21-17.fc38.0.20220203.x86_64.rpm",
+        "checksum": "sha256:4d2f5dd86aa96c1afbf32cc3d98a7f9c06c0685e15ffeafb12987e47c0e389ae",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-libs-0.21-17.fc38.0.20220203.x86_64.rpm",
+        "checksum": "sha256:e89d05bc19b065b78b97320f26bc442874279b8dd14ca77893ee4370497cb12c",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-runtime-0.21-17.fc38.0.20220203.x86_64.rpm",
+        "checksum": "sha256:fab563924947367fc91c4c5b3182d3ef8e526fc9a16b5b67c85da62e0a809084",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:09b995e278193e02bd80451ff807a5f4d3712b2346724567bed3729c2508bf1f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-common-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:ddd8d068c38efecd8a06ba1b0022cf6d59c9f7b6b54c0557bf792dadfa971c01",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-gconv-extra-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:44b7cb6f7ae43a99383954f49b273fc9c574cc6c47cfaf5b297549c35f5444c4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-minimal-langpack-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:22a9001f0c13eaad184ae9a019e7b14d737f8015fb50a157f06435c361cb7fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c19d2a133bb48c61325b9b6fe63f02aefad65ce200b67006bfbadd54b324a024",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-common-2.06-48.fc38.noarch.rpm",
+        "checksum": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-pc-2.06-48.fc38.x86_64.rpm",
+        "checksum": "sha256:aabd27aa8687b29d4334ac2e40ecbe14d7adc18df0f430505f0c8f1df3e9f55f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-pc-modules-2.06-48.fc38.noarch.rpm",
+        "checksum": "sha256:c6d2a12382aa9c1de1a9867e6bf554aaf6a25b6e6fd08ba8eb04fdf177de82f3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-tools-2.06-48.fc38.x86_64.rpm",
+        "checksum": "sha256:75447f4c68574c2504b27033da0e611b5fb09e0e7fd47c94c6a8a899501e9a33",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-tools-minimal-2.06-48.fc38.x86_64.rpm",
+        "checksum": "sha256:b5ab4cbdd3a100451cb6f79b2b6dfa1ca47a0e797e9f6b7dfae393b56460bc93",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "64.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grubby-8.40-64.fc37.x86_64.rpm",
+        "checksum": "sha256:5468fe904a1e33354ba552ba41e5a034cb97da57a78ae7c02ff163196a1f3e1f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kbd-2.5.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cd47d802aaae00fb7498f98cfb3951a7dfe8f1cb412bd0cdac2aa37f0e6ad5d5",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kpartx-0.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6959b36d7ef7afd316fa0c27e84ce21ee1c191c0b76ea50ae39cbde275d0606c",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:189f3a35a9e06c3a16454bad74b941dd2f15619b60bc6c2ed1468f4f38ee8108",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcurl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c4431de14bd2612dde9090d20e4727a0bf2deee21cb5eeb08d82c4196c367e0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b4d23a66a6afc27bd19b01eabb811b4ce00fe16faa027d702529e51f41dc0c99",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a71f4fcdbf0a1bb2468bab1fc2dc49a57a25aa9486afb02708990cc97249f0eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgcc-12.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:50b0dc3d33070a6cad724e373a473b2c7ce2127090adcf6dc175173f0ce5d1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgomp-12.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:eb053b7bfdbdc452cf439e3a067b157c950256bcc50b2fd57e0527564c924070",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:85d2fc0fb54bc8635d9ae51a2b692d592644fb4a39f34b70418ef1e241858ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libkcapi-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:d9dc143ecd8d941b96d556a2dbad4fe03ca1897d8e6147a46c672e5f6498f2ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnghttp2-1.48.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7ffa143b2cc5980b96e460a8e926a3211dc7b04613700f5810a5e957915bf8ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50bff8587480cca84236252ee99f2f306d21ea476bf4b9f2e85b6ddcd565f3d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libssh-0.9.6-5.fc37.x86_64.rpm",
+        "checksum": "sha256:75e438745d6d681c3de20f7f4b07deea33b964eac73fa3ab17e32df8e5d9ad79",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libstdc++-12.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:02f7656240a7a817fb9abe5a8de0d38b6f9e3c3e4d421624819e3af365830995",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:942d78a457a63542875bebe56dacd55dbdd19efa596e78e5f07fe2fa4a0aa959",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxcrypt-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxcrypt-compat-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bf7f4d5badc8faaca874d2abd39202e4340e5e352998bad2da43af805a5fad26",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:5766eb61aed8b117ba04b36715ef5fbf1b52792babb9f15471df59a68e1e65d8",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm",
+        "checksum": "sha256:53ec41e569ebca5a02dc2ae3148c05e6dd7127765a6fe4ddab0e26874f24389d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openldap-2.6.2-5.fc38.x86_64.rpm",
+        "checksum": "sha256:05d2f64fad5473ce1f46ae2f1e8d8be03cd32403fafa6cc8b3f27fc953895f96",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8e41c308c4cd335ce5a0e306977fbdec18abbcdcc8ed4811ec14784ae91f8905",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:fd33e3c1b8730844a570f9e2cc1bc818d7ce4d71ed345d48e1db4c120db3e209",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/popt-1.19~rc1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e3786cac439d6e4364fc636ab88113449a725b2b4600d291037980d9418e8385",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm",
+        "checksum": "sha256:783787153af3229bfc3214929ab49002df5b6454edfc7a25756a139457908a6c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-unversioned-command-3.11.0~rc1-1.fc38.noarch.rpm",
+        "checksum": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-3.11.0~rc1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:c3d14194ed32384f4050402e37484ca375a6a32df20d92e2e56e50141241cd1e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-libs-3.11.0~rc1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:9e797d933f72843c6807e432359ec97e1317a1116d7d0effa57265a5e0acdc97",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/readline-8.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eefadbe8b3e74f1b171269c86b218dd808d5cc5e3a39a1d6b24d8705cbaa0c25",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:6003cd293b27e79e5b0a2ce42d2de69e5fff97ed9f968ced438d15371e63d2f2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:e7d469f950778ff8adef1ca289cd186afcea961258f9548fbd41e4e75a723ab2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:feaf82298552968ed6b93fce62514a23ca6e387e60fd8d822d06b31b746d6580",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/selinux-policy-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/selinux-policy-targeted-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/shadow-utils-4.11.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:7ba6e32620cbf52fa6a2569c05c87012acbca0622c385ca79a2a3530e8b91ac1",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1824a7ff7e02feab54f1ddaaf0462efb842e6c68ee5646ae33c93cbd4855f917",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:14e228653909101710ce5e9b5ae448b1a92906f76b575d64339c6dce36462820",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-libs-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:fc6ebe507afadf828aaabf170689006435c8ab334b5e8289ee9eab9492cfcda0",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-networkd-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:8f43907f08625aefe9de6e3e33c18cb2d9835a1a26672994a951000ceb8557d6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-pam-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:0d29ce0147d6a1dc333b111baec1f0ab3e9079c8c4820ca2c2349e1576beb4b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-resolved-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:d0cb041ab0d613e62be3897fd8f0b3e02c2f720244efe83b3205efbc26eb065f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-udev-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:f0e526b1bd8a24ae49c2c408de73f32a54b1136fe6a404580e9e702aaa58f93c",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022b",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/t/tzdata-2022b-1.fc38.noarch.rpm",
+        "checksum": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:65f1521372f4e3edd032f7379cd6f4e021a1aa69199db6382e34ce7e7cea2413",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c78693b8c775011e52abb0719a4f643fc29d38b7a8c756bf20d7937ab4cd80a4",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "35.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/w/which-2.21-35.fc37.x86_64.rpm",
+        "checksum": "sha256:dc7f0cd491fa100062e4901a2a30512dccc060b1cda2fb291cde05561e948794",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:8571bf4b6c8648679ce401f7c9a619ee105eccacf6ccc731c75a60a449b80345",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:344ef345e55df5b4de878bab40afc3f2fc6d4362f6fe78d9cd2a6c19483b9e3d",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zlib-1.2.12-4.fc37.x86_64.rpm",
+        "checksum": "sha256:fc213083bf978b139113ad37c607b772b2ff621461e314b09fa21a3d1da1e842",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/ModemManager-glib-1.18.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:777f6e31853070aba2797e9332ef135032be2a40291da87e40795dfd0b7c6e07",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.39.11",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/NetworkManager-1.39.11-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c4901f13daa6c7c034e1c42031c50053a6a94b406ad23cb0dde0c37508a0df3f",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.39.11",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/NetworkManager-libnm-1.39.11-1.fc37.x86_64.rpm",
+        "checksum": "sha256:befee2bd06f9e9ebd716791c4613957049dc7c847a8ed9a841e6e2fb33e50026",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/alternatives-1.19-3.fc37.x86_64.rpm",
+        "checksum": "sha256:699c7614a02f23e068ef5cefee980ca70da47823610e27742e29fcfe979e5690",
+        "check_gpg": true
+      },
+      {
+        "name": "amd-gpu-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/amd-gpu-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:c568f1d12548ff1f2a379c6d6892982a47b2d303f886f98b2924f8ac354e5cbe",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/audit-3.0.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d013334b24315ea9b3540cb035aabf117f793aa0f4e8a5a96067a348102265eb",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/audit-libs-3.0.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9f017dacf544a17d271361f78924c29eda45f0f52fa77fb9514042336d68ef7f",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/authselect-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b02ca8808bb8cd14dfc9da4fac4d1a0e90a5cd9a41c801686c2c4b61dcc3de48",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/a/authselect-libs-1.4.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c420528bee4010117e5e5c5dedf1a30811136175e4d165f19162295066d224b0",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "14.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/basesystem-11-14.fc37.noarch.rpm",
+        "checksum": "sha256:a67e500497ee3177adca6e8eb5d1efd26e98cc76de1f532f5ef580bd6e995165",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bash-5.1.16-3.fc37.x86_64.rpm",
+        "checksum": "sha256:82b232d1dec388528421f451420a5e2111410113ca495a0b662a3bf0c7a82646",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.65",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bluez-5.65-1.fc37.x86_64.rpm",
+        "checksum": "sha256:dc515828054d44f6b85901e83169e1a8e022a2774d7544b7161bb00f0c4c3071",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bubblewrap-0.5.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1d1768c630ebaa6f90c6b80d15b58bd2c2304e1ce939335c3823273a33ffe253",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/b/bzip2-libs-1.0.8-12.fc37.x86_64.rpm",
+        "checksum": "sha256:f1379517e611bd4235f3fea36107cd095392d05bc7d5c6d9cb5aacf0a87946f4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/c-ares-1.17.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:627a4f6c12cfe958371ed4829de0eda73ab4fca3e696167f5780586d0dfef5c5",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2022.2.54",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/ca-certificates-2022.2.54-5.fc37.noarch.rpm",
+        "checksum": "sha256:ad615de631c0bc837a8555dcc027b9ffbf385cfa21366ea94d45fcf010c21a21",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/coreutils-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:2571429544288cf7a61867a063e7d10d0f2c2709a9e5e802039aee454dbc9e41",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/coreutils-common-9.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:7c94d4dee58512f7fcd79e55434025062da0cbf4c995ecbbce5a3f21efeb6a93",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cpio-2.13-13.fc37.x86_64.rpm",
+        "checksum": "sha256:f894b52e533562c47b9bbf8e00d1131b4c7dc2db7da0e40cad045ee49bbf5eec",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:5e6b4a62d8cda8eb663df9365c93d3201bb1faaf1816adbc400d56262afdccbd",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:1b6c32d4748460d2bd442c4b813593b9711507caa20c8cf9140beed414493cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/crypto-policies-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:981d7d1b855616fc631de98589b221d0802ed27041878778024d008e6c3336fb",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220815",
+        "release": "1.gite4ed860.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/crypto-policies-scripts-20220815-1.gite4ed860.fc38.noarch.rpm",
+        "checksum": "sha256:068994e7b1f31389286cd46f1981aabea804f64913d4e0b734f2c94dee574cf2",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.5.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cryptsetup-libs-2.5.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:ade1098a8b124d57f0f5154e6918819e2a6f63206a55e84326a5a79498c9f817",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/curl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:54b4b997573536fc04bd6ce7aeaaade4d0a9ace438d804f9477198437ec78249",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.28",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/c/cyrus-sasl-lib-2.1.28-7.fc37.x86_64.rpm",
+        "checksum": "sha256:011fd0372136954d6dd7523e327547b3dd718e7c6e34745d990fddfc52a29238",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-1.14.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d59f7a80a28be4afb428d6038a39a6a3741ed283e2fcbaae7a6ee7bec2c2bd55",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "32",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-broker-32-1.fc37.x86_64.rpm",
+        "checksum": "sha256:a069111178e08a8e414eb9a738f927cadbba2817b343142489f63e8c3e592100",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-common-1.14.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:36ebf7dac814a0726cd27be64ae549708458d53ba2e23550cff271908ef9aaa7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dbus-libs-1.14.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:8f615d35f78e1f51d61b46a95205a8e3433f46966ed5a140b53fc901b83a119b",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.3",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/deltarpm-3.6.3-4.fc37.x86_64.rpm",
+        "checksum": "sha256:39b86b1de69f52c26e72945d84c5767248a6ef3280289dc7c3fd5d55d251b504",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/device-mapper-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:aeb18fe98ed3d835cdba202e2c55112f9b7f57656c383e845abec682963b516c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/device-mapper-libs-1.02.175-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c67f867a6bad6badc7c27ba481280b6116c6c1b18bb0935c28b843a83333f00c",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dhcp-client-4.4.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:74f679016b4c124834a072830f7baab7c7e0193bb8f8a6024357f08e44101ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dhcp-common-4.4.3-3.fc37.noarch.rpm",
+        "checksum": "sha256:351b9f8911296b57b7f69f8b6f04bde3715648ed827aa6f5fa6b6ea44168341a",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/diffutils-3.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:22cceb6527dbd46ee35cf2d461003df43bc2637b48b86dd8a677ad50bb7e3f84",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dmidecode-3.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d96a131abbdbea273866174699f0c7c563fa35481fc8ea198064ad1857d5e979",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:3a630412a9094d1294745986fd77c6e99762a667e8265c9859feb67651996785",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dnf-data-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:b353a0995c13684076f30b900fa47ce16652145302f9670ebd3f7ca1397e46c7",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:828ccdf867dea1145e90a327a3556465d1076c5d749b1976c32f1cfb3f3468ab",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dosfstools-4.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:74026fb802867ad2d70544e1ebee0d6d699dfa01890a4044b385ba435803760f",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dracut-057-2.fc38.x86_64.rpm",
+        "checksum": "sha256:13077b608f650173e1fba77045bc6608c93e87f58d532cc9f408ac2cc35c86c5",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dracut-config-generic-057-2.fc38.x86_64.rpm",
+        "checksum": "sha256:2e29bf7ae154d7c5485c493652836dfc189b0d5a0323052ac0cda7d8509094e8",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "057",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/dracut-config-rescue-057-2.fc38.x86_64.rpm",
+        "checksum": "sha256:18f49193ba10e94d9d57ad445ee8c9a6ef454577274bf88e7da23c1482e87fe5",
+        "check_gpg": true
+      },
+      {
+        "name": "duktape",
+        "epoch": 0,
+        "version": "2.6.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/d/duktape-2.6.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c6e1018e5327403c955cb766feaa112687b3210f06afc7702abae185de061506",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/e2fsprogs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:be840ed4c79ce5eb22c1870864120d1280d723731b88504d175337506cb4d680",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/e2fsprogs-libs-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f02595d2c580ab3f0cd4048137140898e09f2b7092d3c26b8d7e7a234498d091",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/efivar-libs-38-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e0c0c018d4123a23c789a078f73a0bc4e026b74281e5dbfe049c5f2b8266937f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-debuginfod-client-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:11e9cd35f16ce7dc5765667a062276dc6cde1099b09f8d956adb1d58127db25c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-default-yama-scope-0.187-6.fc37.noarch.rpm",
+        "checksum": "sha256:5ab154e0241eeb642418d01a2f7f378437117b092ad8a3e8ac268a39d72b146e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-libelf-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:dd45fa047049031a58bfc4dec681ca81f3c031b61305826421423dfea5b2bd8f",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/elfutils-libs-0.187-6.fc37.x86_64.rpm",
+        "checksum": "sha256:d413c4373f19d35e6e743930b2ddb34f3d53ff0c33ed42826e0cdc08def5e994",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/e/expat-2.4.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a0c055b565c6514d2f8d7be063202e550357c6146b2c92cc17bac6cad59aab2d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-gpg-keys-38-0.2.noarch.rpm",
+        "checksum": "sha256:4234a86587cc9c50d473d6d1a30b73cdddff73a61cad721c59fb06dbd5a0e4e2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-38-0.2.noarch.rpm",
+        "checksum": "sha256:8ce26bf8803d624b403b73410288b14a9e620850b56c555bb10f490cec39281e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-common-38-0.2.noarch.rpm",
+        "checksum": "sha256:419e2166a3bbe59bd29755370d45eced06ea9a5ba30c33da2780592562e6d1ab",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-release-identity-basic-38-0.2.noarch.rpm",
+        "checksum": "sha256:e7af75b7758510a0ec9892c57f81de66179829e71a35e7b78217ea87bc37b125",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-38-0.2.noarch.rpm",
+        "checksum": "sha256:caef59db38a7cf870f0ed0761a5f8341557736aaea096619a8562d2bb0ea7f3b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-modular-38-0.2.noarch.rpm",
+        "checksum": "sha256:85a7acceec5dbd64452b50af82887038c103768790a8a9c666caa048263432f2",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-rawhide-38-0.2.noarch.rpm",
+        "checksum": "sha256:ac2c9c07ce3f8d14bccb33880f7a950926db04c5a4ddd1f2e62fe418d8d4824a",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-rawhide-modular",
+        "epoch": 0,
+        "version": "38",
+        "release": "0.2",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fedora-repos-rawhide-modular-38-0.2.noarch.rpm",
+        "checksum": "sha256:15b79ceb2f5777ee511f9bcb722c4affc72a5e994fc3dcb250fd4e49c25814b2",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/file-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c91dbcccb9f11de00029b63890d10d496f58e51731b5f4afb6700685a4bfa264",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.42",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/file-libs-5.42-4.fc37.x86_64.rpm",
+        "checksum": "sha256:bb7bb8b78456dbd0b94511b26becb472ada8a5482871ebe7e2f8a8a044fae3a7",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.18",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/filesystem-3.18-2.fc37.x86_64.rpm",
+        "checksum": "sha256:3598c5f780a4a3af6ec93a80183361d0339f7b94da25a09e6356d260fee96fdf",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/findutils-4.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7a0b7208d4fa48eff55578ad2e99d8d4a53888ede87df804c6bb89d125417c46",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/firewalld-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:7176e5bd8f6a7137a54684507a3eec12999fbf23607d87a0f59f165794a80da3",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/firewalld-filesystem-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:0121cf8885d2a35b98223ebb05ad2daf7ea2ed2856227297d556c93564defe7a",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/flashrom-1.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:2af369b0f500f875bf394b437524ba072cc317b0841cd62815691bc36d487ff1",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fuse-libs-2.9.9-15.fc37.x86_64.rpm",
+        "checksum": "sha256:cb8340f6d2151b97e54df3fe09c063ac8f820bfe096753cfe395e2516030c70c",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:cd33ffe6445e9fa5aec6cce73d9a57eb52a2c819487ace6e96e63d51147618b9",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-efi-1.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:cd8987f528bf3bd926c809d492f64374dcbf4a95252b569fd9cbf804848c319f",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-plugin-flashrom-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50ba63b1632e6c2de313206a9a0cc02aaf4bf6695fd3e5a4cc6132fb6e58d7df",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-plugin-modem-manager-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:9c74e1647f0c6288a1f4f268f16f8b7bebcd53cb5f8bc9b3cea32af1eb24b6c0",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.3",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.3-1.fc37.x86_64.rpm",
+        "checksum": "sha256:dfcc4c16a94c401145dab64316d66cef8d2a579da55a46f4726cced30eb8b474",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gawk-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:336b5d44b186dbfa29e8c4a2c387a6225671787812395bd49c05249d969008d7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gawk-all-langpacks-5.1.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:408b6c8214a6fbdc2b921d3d1acb056b3a8fba0e7d5f51ca7817b5e55c59270b",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.23",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gdbm-libs-1.23-2.fc37.x86_64.rpm",
+        "checksum": "sha256:58a55546644acbbf49ac082cd4855f475192caadc835722c38dd86ef9d285057",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gdisk-1.0.9-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b4b88b5e76ec10eea9c09bdff3c1078cff3cd2d82481ffb4974fb595d22ad2e3",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/geolite2-city-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:00054d4310ddebcfd966ebcbd42c072bfb69d0709f6165e2c0bc0ee1337efba2",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "7.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/geolite2-country-20191217-7.fc37.noarch.rpm",
+        "checksum": "sha256:4cfd593ae556df6f8e3ace44379261ab2d44044a2ab25c2fd4a4323b73cd17d8",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-0.21-17.fc38.0.20220203.x86_64.rpm",
+        "checksum": "sha256:4d2f5dd86aa96c1afbf32cc3d98a7f9c06c0685e15ffeafb12987e47c0e389ae",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-libs-0.21-17.fc38.0.20220203.x86_64.rpm",
+        "checksum": "sha256:e89d05bc19b065b78b97320f26bc442874279b8dd14ca77893ee4370497cb12c",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-runtime",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "17.fc38.0.20220203",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gettext-runtime-0.21-17.fc38.0.20220203.x86_64.rpm",
+        "checksum": "sha256:fab563924947367fc91c4c5b3182d3ef8e526fc9a16b5b67c85da62e0a809084",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.73.2",
+        "release": "8.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glib2-2.73.2-8.fc38.x86_64.rpm",
+        "checksum": "sha256:1e625693911f27f89ba5165242547d76893ed7bcea095580ecea5ac33c808c1e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:09b995e278193e02bd80451ff807a5f4d3712b2346724567bed3729c2508bf1f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-common-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:ddd8d068c38efecd8a06ba1b0022cf6d59c9f7b6b54c0557bf792dadfa971c01",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-gconv-extra-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:44b7cb6f7ae43a99383954f49b273fc9c574cc6c47cfaf5b297549c35f5444c4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.36.9000",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/glibc-minimal-langpack-2.36.9000-1.fc38.x86_64.rpm",
+        "checksum": "sha256:22a9001f0c13eaad184ae9a019e7b14d737f8015fb50a157f06435c361cb7fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gmp-6.2.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:718b9103f02d5aebee50918c1d324cda6e3c5aec8e63ed8daaed3b1b104acd7c",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gnupg2-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:273a3901469983516f69733d0e773cfac3f13c183d12dc1018ccfdde3e1b9455",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gnupg2-smime-2.3.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:843fa03aed0edaed163739cdeaf432398287e480b0fbe2b181b6b4a939e8c9f7",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.7",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gnutls-3.7.7-1.fc37.x86_64.rpm",
+        "checksum": "sha256:61dc36c13af2246b88f013ded040cb9e5e90377bd017be5a084c013280d5bdb2",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.73.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gobject-introspection-1.73.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c14525cf0bc24724c32b66015c4c82b27eefa76e65d3621e94be54936cf90708",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gpgme-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:368fb99245a0a78c0c229a9a53791b7ec0c4aaaf22d64451f36637d652a4aa55",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grep-3.7-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c19d2a133bb48c61325b9b6fe63f02aefad65ce200b67006bfbadd54b324a024",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/groff-base-1.22.4-10.fc37.x86_64.rpm",
+        "checksum": "sha256:648b73a8211d7b165c80bf366895cb39a3b86dbbf1d971258de653be0b6cb289",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-common-2.06-48.fc38.noarch.rpm",
+        "checksum": "sha256:18d1655a0eab4d3f6e3cc4f8d56b06eb1fe3a6419815c0363dc6e67914463eff",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-pc-2.06-48.fc38.x86_64.rpm",
+        "checksum": "sha256:aabd27aa8687b29d4334ac2e40ecbe14d7adc18df0f430505f0c8f1df3e9f55f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-pc-modules-2.06-48.fc38.noarch.rpm",
+        "checksum": "sha256:c6d2a12382aa9c1de1a9867e6bf554aaf6a25b6e6fd08ba8eb04fdf177de82f3",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-tools-2.06-48.fc38.x86_64.rpm",
+        "checksum": "sha256:75447f4c68574c2504b27033da0e611b5fb09e0e7fd47c94c6a8a899501e9a33",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "48.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grub2-tools-minimal-2.06-48.fc38.x86_64.rpm",
+        "checksum": "sha256:b5ab4cbdd3a100451cb6f79b2b6dfa1ca47a0e797e9f6b7dfae393b56460bc93",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "64.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/grubby-8.40-64.fc37.x86_64.rpm",
+        "checksum": "sha256:5468fe904a1e33354ba552ba41e5a034cb97da57a78ae7c02ff163196a1f3e1f",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/g/gzip-1.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:38b7d5c5f8aae3b697e3a9d21ca78465f66980acd0cfd8bcccf100c2cc6400f0",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/h/hostname-3.23-7.fc37.x86_64.rpm",
+        "checksum": "sha256:1cd7cb3a9dcb03e1a3322200060b02fea694400f5c58ca1143a78758c55b6304",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ima-evm-utils-1.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:18238fedd785dbfe55bed864c13635a9feee9f4b929ffbd258c58e61736e4236",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "56",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/inih-56-2.fc37.x86_64.rpm",
+        "checksum": "sha256:12cb09ac132e4945809adfa22d3edbdc7fb458361d37032d6300830c052490c0",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/initscripts-service-10.16-3.fc37.noarch.rpm",
+        "checksum": "sha256:c297a9d8223d4cd595d89d3e789b86e2558b902c9ba636af3f49587a17541dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "intel-gpu-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/intel-gpu-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:16a7a3f9d73ff11170a6f0fa686d03ef9a491089e8a3ddd492c93a865ed75aa3",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ipcalc-1.0.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:c7931f5dc4a593808c00346a9a452e24e79d5a70201da6ffbd3fc18d9a0e04a2",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.18.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iproute-5.18.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:021567d8ce7baa4198a67eaa4f5a07311b3a3f3697c35f79ac3604e2389611e5",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ipset-7.15-4.fc37.x86_64.rpm",
+        "checksum": "sha256:422d37180e8f7b3b2f7df2460c2697bd7c7c29241f809212947643351127eaf3",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/ipset-libs-7.15-4.fc37.x86_64.rpm",
+        "checksum": "sha256:afbefb63271c859ba3e8b38aa4d34d96dbf2c97c7faee77aa1929aa791a6b9a3",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iptables-libs-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6d3f733c72e0a227747d0c3319f35c197126a84cea362b4c32f34ea253d0e3b2",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.8",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iptables-nft-1.8.8-3.fc37.x86_64.rpm",
+        "checksum": "sha256:089e516a282a6611d8ccb37ed05870860c71d0fe0a00fcc75dfdc70e082d49cb",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/i/iputils-20211215-3.fc37.x86_64.rpm",
+        "checksum": "sha256:1dbb1fc38e0bac0925353d24aa78aeb2030f5eed9ef4b2637ccf5811d37fc807",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/jansson-2.13.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c0bc33ff5df85f2c9a1bf645a20c77b60a7c270b1dfd54305d5ae3b75e89f4a8",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/jq-1.6-14.fc37.x86_64.rpm",
+        "checksum": "sha256:b39adb12197f08a665204c5628eca9a8025b24f12a77d6c7b4e04a2e11532a03",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.16",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/json-c-0.16-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cd577dc1b6787341ec0d89a688a9e5c5450badbebe8abdc1049aca4f8553c3b5",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/j/json-glib-1.6.6-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f74da1c044980e6bfcdfc8340fa91899f9a944800e3e6f71bd6e99e7693df5e3",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kbd-2.5.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:cd47d802aaae00fb7498f98cfb3951a7dfe8f1cb412bd0cdac2aa37f0e6ad5d5",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kbd-misc-2.5.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:d6b6f0b6f2f83cbcb73edda54569f3679a8a35fd2eb210690b25cb889f9e14d9",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "0.rc1.13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kernel-6.0.0-0.rc1.13.fc38.x86_64.rpm",
+        "checksum": "sha256:7ec5068f909fbbe589275596543d4664a5b9790a6d0effa3145f1d8824e01a42",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "0.rc1.13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kernel-core-6.0.0-0.rc1.13.fc38.x86_64.rpm",
+        "checksum": "sha256:b9e42a34622ef6f84da6e709a09da1ed4706540d9cb2d248a3d717e43a050946",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "6.0.0",
+        "release": "0.rc1.13.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kernel-modules-6.0.0-0.rc1.13.fc38.x86_64.rpm",
+        "checksum": "sha256:e5230b318ee68400f8ec1cb1438667d236e23a3d476228e943ee44b6df063036",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/keyutils-libs-1.6.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8fcbd5077df15f8c8d3f3df2139087238868ef26ecdd68669364b4fb3e355c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kmod-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:a847f339173fd09197887df7f84218b2cba1020e80b78399fca3e084751b77df",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "30",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kmod-libs-30-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c3b4d41f2e0c05622a18888d356210282cc3309fb132a0e967edd8aa0fafc58c",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.9.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/kpartx-0.9.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6959b36d7ef7afd316fa0c27e84ce21ee1c191c0b76ea50ae39cbde275d0606c",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/k/krb5-libs-1.19.2-11.fc37.1.x86_64.rpm",
+        "checksum": "sha256:9fb93562eb8a553196dd8133a422161c0c54f396338e2467a6830cf79db37f38",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/less-590-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e3a4e9b6e68360f24bb2b92bf23068c47e96d6d705f546648b2e10dd88e44e84",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libacl-2.3.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:34fb99840e8800b5f105b18aed42c33371421e1cd6c4092727cd9a01587a072e",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.6.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libarchive-3.6.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:dc8a30844c2e5a519e69bc35e9a12571698a99c89dbe4e6e4febaaac623636d6",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20190702",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libargon2-20190702-1.fc37.x86_64.rpm",
+        "checksum": "sha256:36ce047183f8e73f9dc2e675f800001e9656dc31641360224c04a47a8f1437c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libassuan-2.5.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:e66f6a75e909357289e07d9ce9801a0662527aebee680bc255637012b956e66c",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "23.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libatasmart-0.19-23.fc37.x86_64.rpm",
+        "checksum": "sha256:6b79e53815bf9ccfdced5dc732b9d20ef47ab8dd20a5777e136adfc1740bf570",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libattr-2.5.1-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b52d63173a94b61eead79ec9146111a5877b2e9f5a21c947e385fdef8304969c",
+        "check_gpg": true
+      },
+      {
+        "name": "libb2",
+        "epoch": 0,
+        "version": "0.98.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libb2-0.98.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:25cd4bedd47325a47e47a27062fa6c139ee56a92ed119fe88eefd6263a2e09df",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbasicobjects-0.1.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:193f1fe42eef13e768d599bc89b07a2bfaab4223e66b35b1a6f89e3712fa73f5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblkid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:189f3a35a9e06c3a16454bad74b941dd2f15619b60bc6c2ed1468f4f38ee8108",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:29252f846cee0db551a9591bb0b9ccd1a67c79acefd4f5d034673bed15c082de",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-crypto-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0d8a26362c8177fe0b5244b4eca9ca46f2c566e36a22b100d03602e2c858d98f",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-fs-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:229016c32a77e76959f06a6f343388f6aa6079562b79d4ec38312348f96bc314",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-loop-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7d7a5f3f3bc6082dba0044531b4cbea7a50cd5731b3af6b87006f59fad9fecd9",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-mdraid-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0a47823036727b46b3661b41343b62ef0755cbffe48685c4af916537ead7aa33",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-part-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:b10cc93138634a64bff33bb14207332aaa4283fcd8b9daa798b3bfbb5b9c26e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-swap-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9ba626bdec4c251d6e39faaa5ed247fc26e459d255e50936fec468431b40b3f4",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libblockdev-utils-2.27-3.fc37.x86_64.rpm",
+        "checksum": "sha256:76163e9f4faf4017811e2d63491fce611db1dfd5a6e5de24c1c497cc84c1032d",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbpf-0.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d012a020c6e80fb827881e026d572022730cc86c16d0b6b3d3935c2860e49d10",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbrotli-1.0.9-9.fc37.x86_64.rpm",
+        "checksum": "sha256:aa9327946e86d20192948513e27b5314e565bd533f4e801215cf62190314056e",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libbytesize-2.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:9afc19fb507521ee32f35e2cad4b530d863b2cc3810cb9b8408eb61bbb50b6b1",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-2.48-5.fc37.x86_64.rpm",
+        "checksum": "sha256:cde5a2b8b2b57ca5986327f5aea5eda780e3fce2a38de4bc93d1098c94781d50",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-ng-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:66797ffb041aa8f8df7259c33063a328c641ca6a9b2c01b226877d7369d0ac91",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcap-ng-python3-0.8.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:633d70b8df9fbd3a9a66ac186e5827525a1d01adeed448147e40a2b7c2a30ba4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcbor-0.7.0-7.fc37.x86_64.rpm",
+        "checksum": "sha256:a51a769a3a49965980b3ddf74cc8dd8380265a14bb76fc3a78645dee87bc828e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcollection-0.7.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:115f36517e2b9c7cab9ee7b092f8bfff6c1d53b09d0d774969c3884ecec1b601",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcom_err-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d77164c603273f980bf9152290c2b507df0c6ea6b907c93f1de73c50eb489f76",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:6a0f03d9442843a9df7468a5a926a43c76d4c6437405db90598faea2f35434d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.84.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libcurl-7.84.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c4431de14bd2612dde9090d20e4727a0bf2deee21cb5eeb08d82c4196c367e0a",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "53.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libdb-5.3.28-53.fc37.x86_64.rpm",
+        "checksum": "sha256:3201b65c3a8178d52164089dfe5800314b803d1a88367fbe12c8906f1c05da02",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libdhash-0.5.0-52.fc37.x86_64.rpm",
+        "checksum": "sha256:453eec881996f5c80bec7ac779f7973ba8c2244e83d01e87daf4c3381b88a1ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libdnf-0.67.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:5f33c11f27b6953125ef43198459e256a0a75f222b5dfa2581b9dd7866a65b70",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libeconf-0.4.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:ff1cb7ddb5c0ebf0b4dbd9e307591dad5de749f9a8226ad5fe38ce1dd6fc9b39",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "42.20210910cvs.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libedit-3.1-42.20210910cvs.fc37.x86_64.rpm",
+        "checksum": "sha256:6e03bc1e73acbe36966bce6df587d60d4081960198225c1fb8f62584b4363d16",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libevent-2.1.12-7.fc37.x86_64.rpm",
+        "checksum": "sha256:8a66d6e4a4d83cb48ab7ca731da9c63c3e40d3f8fa2e9c1d4ea41cf3924c0415",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfdisk-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:b4d23a66a6afc27bd19b01eabb811b4ce00fe16faa027d702529e51f41dc0c99",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libffi-3.4.2-9.fc37.x86_64.rpm",
+        "checksum": "sha256:f216369a72a6f3cd932463e7d236c853b1bf2f63526b1637d0aa1269ac35ce57",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.11.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfido2-1.11.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:a71f4fcdbf0a1bb2468bab1fc2dc49a57a25aa9486afb02708990cc97249f0eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libfsverity-1.4-8.fc37.x86_64.rpm",
+        "checksum": "sha256:48c3829c4b7616d6985737c5c8552d49ac9d80e41780af6daa34963b8d5b9225",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libftdi-1.5-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8b79f85fa9266e4ed110f75e71125593d7de788a3f8242a69acfb4be56e92190",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgcab1-1.5-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c6fdb21908848e96e58d0ea2b495701eedad190b01f9df44c16e35f760cacae4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgcc-12.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:50b0dc3d33070a6cad724e373a473b2c7ce2127090adcf6dc175173f0ce5d1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgcrypt-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:8d599d9a7ce446f0c7e2040422fec9a241f6c45dc0371372e9704abdaa8bd21d",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgomp-12.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:eb053b7bfdbdc452cf439e3a067b157c950256bcc50b2fd57e0527564c924070",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgpg-error-1.45-2.fc37.x86_64.rpm",
+        "checksum": "sha256:df65995dbfc5853caf3c3b81ee09334d4e7a7a8674d439ab2778b5047767c0d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgudev-237-3.fc37.x86_64.rpm",
+        "checksum": "sha256:50a0828e3f1eba2ec053d15a3412b2ca62ae513c3899ac5a6e88e9d91a21041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libgusb-0.3.10-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aa33eade6ec12857c1d17d8b56d704e1718833de594f6a4115c9528f8465830b",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "41.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libibverbs-41.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:922d0eab6721af3757cb60b4c0b79abd47e32897ece35bf02f08bc4951c2fc65",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libidn2-2.3.3-2.fc37.x86_64.rpm",
+        "checksum": "sha256:85d2fc0fb54bc8635d9ae51a2b692d592644fb4a39f34b70418ef1e241858ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libini_config-1.3.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:cd5ceea29405a70d0751933a5c3d6178b671c80ff97e04aec2614caf6156d238",
+        "check_gpg": true
+      },
+      {
+        "name": "libjaylink",
+        "epoch": 0,
+        "version": "0.3.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libjaylink-0.3.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:09fc65ab51d47ada940766c145b96f738bf592e0359bb2a42ba2a398fdc7f6cc",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libjcat-0.1.10-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8d623c4ed5fae679121f36b97a7a47b857c6b69b6647fd42a9a03a2591cd074a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libkcapi-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:348b04d1e81b64dc688fff396798a364212e27cada55e87ed1eed7336782fccb",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "2.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libkcapi-hmaccalc-1.4.0-2.fc38.x86_64.rpm",
+        "checksum": "sha256:4aafc48fc095f171d20fd31e1a4a88784ca8017a75d167bf794dae3394661517",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libksba-1.6.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:5d623b3080b32144b709ed7cf11dae330607dfb65bb5ac27585ec83bd3d99429",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libldb-2.6.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c74fd7795d471046edbd2ba1eb6a984025519aa076b2e856363ca8c2c4e26e6f",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmaxminddb-1.6.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7b9be0289d003cca9fec06b13b62aa9eb35c58651ec28404ad6ac863244cb394",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmbim-1.26.4-2.fc37.x86_64.rpm",
+        "checksum": "sha256:65d61922e3a2b117b79e44ffd2945ee5c8ee53e6d3603dff792982c04eb13d9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "16.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmnl-1.0.4-16.fc37.x86_64.rpm",
+        "checksum": "sha256:3aa53c7eb54ad2acaeab5231a44387ffa3f03dcd99a9f75ff4c8c592dd1cfe90",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmodulemd-2.14.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:15358af44d005789cfda790606bd60c162b673167bbfe7153a97a043e1083768",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libmount-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:d9dc143ecd8d941b96d556a2dbad4fe03ca1897d8e6147a46c672e5f6498f2ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libndp-1.8-4.fc37.x86_64.rpm",
+        "checksum": "sha256:092a0396068edc5fbc4e77aa49aa5c312184ef4b0b7435c604107a52f712a19e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnetfilter_conntrack-1.0.8-5.fc37.x86_64.rpm",
+        "checksum": "sha256:995659e1f0c39fb758160120c68ece8446d14ab3e3b0527aeadb90b0547e5a7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnfnetlink-1.0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:1a056805ee78f023e3dcabda0c298c6dcc16515a86153459c01905ab2b43e9be",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.3",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnftnl-1.2.3-1.fc38.x86_64.rpm",
+        "checksum": "sha256:324c6e6d4a55b3ac12198e8c6a528be517d57cb38d27e3dd961bc0efd487b292",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.48.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnghttp2-1.48.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7ffa143b2cc5980b96e460a8e926a3211dc7b04613700f5810a5e957915bf8ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnl3-3.7.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:118b3e835f01f45feb29c6c1eea1a50925ada9d5ff2804d6d7de74453aba5fbd",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libnsl2-2.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:2dbcefd797e17c3e6b73bb43351003f8fdb5236bdd6f4e288301119b663a0c7a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpath_utils-0.2.1-52.fc37.x86_64.rpm",
+        "checksum": "sha256:dd593e435ea68265fe742c4c6e3acc7240abaf9b9d75882205c4f434b727e1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpcap-1.10.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:149011e66fc747517ea929ff80d4f88e72961b10e352a324a7ea4ec3d20503bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpipeline-1.5.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:ca34df9ec9bc66a150d308568c53e462a6f35b48a07354982a1773eb9cd0abe3",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpsl-0.21.1-6.fc37.x86_64.rpm",
+        "checksum": "sha256:20925047133a5303a51f4e376b537c3d14c2a4ab0c239c5b480327a948b948ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libpwquality-1.4.4-11.fc37.x86_64.rpm",
+        "checksum": "sha256:093d967abc65b0810e20724e9f8e446d4a3901ef0bbd0aed7756e7a1535644d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libqmi-1.30.6-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d7f3c8c057eb68b6b5838ff0738826b996c847f2452ee62fb5c1c344161f633e",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libqrtr-glib-1.0.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f0315d368bde2128992a58c09596af85d39ef7a37e097bfc94612f3dd7178dad",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "52.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libref_array-0.1.5-52.fc37.x86_64.rpm",
+        "checksum": "sha256:cfd13bf9a8723dc1d74d68155e59692e83707928c7f1366be13472da7612acb5",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/librepo-1.14.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:84b3ed0958b484d83a0c189d674357f1287a60125cac6bf34a6e87a54c1a5505",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libreport-filesystem-2.17.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:29c61e3a7856ed3e31ae8d42777b571ae7f08644bf27acb1f0a1c1856c308b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libseccomp-2.5.3-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aa1981728f4d99093e379a6cdf6815257afd48a940b3fcedeea53799234e662b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsecret-0.20.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:89fc69c405e600d7667df2cb98d4c7d62259c72545db6267f234b28761244224",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libselinux-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:b4d348f2385b36bdc1a818b36511e491ccff83cbb24040472303e8bc02a1ca7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libselinux-utils-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:c96af87a1d3aad0cb63953fb402ae37d14823288dd74e910686d0322172140d2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsemanage-3.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:83518b7a45109407fcac3427dad51a9f7f7d3668e0a0942ad2158da82b869476",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsepol-3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:aad543b786b8f870cd0a7a1d472199b5ac3f10a87e58133146470c3183d6862a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsigsegv-2.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:f5f0521c7a9e1cd8fbd0e1fe82f3f91de9ed38b4680bf2eb929cd592522c6652",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsmartcols-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:50bff8587480cca84236252ee99f2f306d21ea476bf4b9f2e85b6ddcd565f3d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsmbios-2.4.3-7.fc37.x86_64.rpm",
+        "checksum": "sha256:95aac8f490ae408be49651cba31d9ae7805157013629317cd5f13eaf6ce4696d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsolv-0.7.22-3.fc37.x86_64.rpm",
+        "checksum": "sha256:891ca4669541cb323a77e6d2224baeebccb8d0bb892670521f63ecf4a5d490d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libss-1.46.5-3.fc37.x86_64.rpm",
+        "checksum": "sha256:2d8cedf110833c4652b589953178498f3d6ec9218b3419f3e25da8f89fbd379c",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libssh-0.9.6-5.fc37.x86_64.rpm",
+        "checksum": "sha256:75e438745d6d681c3de20f7f4b07deea33b964eac73fa3ab17e32df8e5d9ad79",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libssh-config-0.9.6-5.fc37.noarch.rpm",
+        "checksum": "sha256:958507f166994210e1ad2026c4f1099016783ab8b86d5d4860839d53f564dd15",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_certmap-2.7.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:a8c89e22f49416efda631ada91d7b944667d331672f82d60a0a2cb89c5a876c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_idmap-2.7.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:536faf2906d98e64f4c712e59116f8281466a3e0f0d191a02a679f942a156fd2",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_nss_idmap-2.7.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:f97bf6f29d7554e4fb4da8db547d8d5cf9ffb6d608fd473b8c7224e71816892f",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libsss_sudo-2.7.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:5377663e146a6c0ea34ee7f025bbcb12e4c46e3599e2de20cc0b958761fd4bd0",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libstdc++-12.1.1-4.fc38.x86_64.rpm",
+        "checksum": "sha256:02f7656240a7a817fb9abe5a8de0d38b6f9e3c3e4d421624819e3af365830995",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtalloc-2.3.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:0f3e6504aef91fc641678229a4f9d8d5428dd7b837cc4b0fb57038583025cdbd",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtasn1-4.18.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6206e39671991eb0ee840e2daf92cd84ff72aa04b8d089e7dfe7ab29602c088b",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtdb-1.4.7-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4eb90ba78d6ebbc54758ec1787b3c1adf2608962d183a101da8de1013bcb7cef",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtevent-0.13.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:0eaddcdfd370876db1241bf7251c8f87e0565dc818887d2bc95d7a211c77b3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.3",
+        "release": "0.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libtirpc-1.3.3-0.fc37.x86_64.rpm",
+        "checksum": "sha256:beb040c019a273d6f8b189dbe5898fbcce953fc8ed82a44b038177b2d5e50e60",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libudisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:8afe733f094d886431d500e2c5aac11bf8bcef0a05314160a968684cb006d574",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libunistring-1.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:39f7b9690b91d195a45782d7aaf37e407eb553027bbed89e9a9a2abaca6c461e",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libusb1-1.0.25-9.fc37.x86_64.rpm",
+        "checksum": "sha256:5f4d9ea051cce5144c69ba8b8519a5c3ab8b4e3907b391378f96a4e03981681f",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "12.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libuser-0.63-12.fc37.x86_64.rpm",
+        "checksum": "sha256:ae8795f1364c3fc84324923c2b594bd8207006e684d43016c052dffb70825c8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libutempter-1.2.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:12a585c3a3636f88abcc9afb60d2a691006dc5b40879a8abd5e903a7a78a6a62",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libuuid-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:942d78a457a63542875bebe56dacd55dbdd19efa596e78e5f07fe2fa4a0aa959",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libverto-0.3.2-4.fc37.x86_64.rpm",
+        "checksum": "sha256:f7f29a0e81b5049ae1882f1e6656133818b46d3923be2fcea41ff5e0ef10c622",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxcrypt-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:76bbb5d3dacb6b5d086d4c425ca05a2b63b8ef6f17e905d523acf4659b71c865",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxcrypt-compat-4.4.28-3.fc38.x86_64.rpm",
+        "checksum": "sha256:98da69aa484ccd357cc76312774d53a64f552b21b594d74a2fd01be5e21f300b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.1",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxkbcommon-1.4.1-2.fc37.x86_64.rpm",
+        "checksum": "sha256:7552ec8b34844ba0cdc2f8c19dbac36b898e3d303e778888ff30193333d0a859",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxml2-2.9.14-3.fc37.x86_64.rpm",
+        "checksum": "sha256:bf7f4d5badc8faaca874d2abd39202e4340e5e352998bad2da43af805a5fad26",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libxmlb-0.3.9-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4fa17e852c5e17fb3caa668f5e8e04b517aa1a1985b76767ea7444f3343416e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "8.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libyaml-0.2.5-8.fc37.x86_64.rpm",
+        "checksum": "sha256:6183bae674287b17dd36e3f5c01f0abcb021875895959fa63fb5061f18ccc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/libzstd-1.5.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:4f0e83dae6f1df1074aed8bd8a072edb2fed894f734ab55f07f31dd214e6db25",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/linux-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:648e27449350f50b6fbed7bce4ecdb586976446ddafcfa100cd235e74d3a2c38",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/linux-firmware-whence-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:607d9c1a9c9f80a1bd21b1d3dfe9dad0b564c6a90d3359bd2d7e6594fc24f430",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lmdb-libs-0.9.29-4.fc37.x86_64.rpm",
+        "checksum": "sha256:7c28ce263b298c1f526718c1cb0f055bdbb455e1130a4bbcf7113fcc992b448e",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lua-libs-5.4.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:5766eb61aed8b117ba04b36715ef5fbf1b52792babb9f15471df59a68e1e65d8",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/l/lz4-libs-1.9.3-5.fc37.x86_64.rpm",
+        "checksum": "sha256:695c89729d68929af4096102abc3b40ae12ce8cf18f0a6c85703474ffaca5bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/man-db-2.10.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6d5c1e81de661038bbeb3f2a2e6c2f98db4e1a009915da1f5ab6910940215827",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mdadm-4.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:2022bb0fe9c17df96734f4667357ddb956fd82004e9297504649ac60081b5464",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/memstrack-0.2.4-3.fc37.x86_64.rpm",
+        "checksum": "sha256:7eae9fb9787d66887be6131718a6769fa6b963a6c3df9f9248ac0296aa7a6538",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mkpasswd-5.5.13-2.fc37.x86_64.rpm",
+        "checksum": "sha256:53ec41e569ebca5a02dc2ae3148c05e6dd7127765a6fe4ddab0e26874f24389d",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mpdecimal-2.5.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:0679744c52934c2f7285aa54209e7a3bc6db713f9570652894b8ebbc4a4b6fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/m/mpfr-4.1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:3e0e9ba133c66e1858baa05017c196c75c59fe4c9df6d7b3476470164a8f17f8",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nano-6.4-1.fc37.x86_64.rpm",
+        "checksum": "sha256:debc0be72012ae50ae10caa306ad14b7a4f61e6bc43161da7036e3091900297f",
+        "check_gpg": true
+      },
+      {
+        "name": "nano-default-editor",
+        "epoch": 0,
+        "version": "6.4",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nano-default-editor-6.4-1.fc37.noarch.rpm",
+        "checksum": "sha256:60040f8563239848aabd3a655c2bc185a7d7f47dcf59228353a6713eec036269",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:81b81aee93d47f3a869b2582a53a0b59871b04f7e7c0b84d5e12207a271b0fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-base-6.3-3.20220501.fc37.noarch.rpm",
+        "checksum": "sha256:8b0c12122f054ed4c6421d6adf82185ac4140c29f886402d3a00a7e859e03f93",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.3",
+        "release": "3.20220501.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ncurses-libs-6.3-3.20220501.fc37.x86_64.rpm",
+        "checksum": "sha256:ae3f201e386217e734ab85b1744505ed5346cb70c049ca8ee7f122b2550de38c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nettle-3.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:b7548d4dced9671ae77294541ce1c82c7db90e5e1634413bd49e0d4830452969",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nftables-1.0.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:80d01a8159d6c89b9e41b743a26a7148cb4ba043d2c8667c80738cf2e7efdd8f",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "9.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/npth-1.6-9.fc37.x86_64.rpm",
+        "checksum": "sha256:c6f5750601aef9659831ba4e1effd28732bdf86e1f2cf4908d15f6b93b4c8596",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nspr-4.34.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:de1bf3531ca177b7bbc957c1447f86b545127d6a728b6dc55cd680af797e90ca",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:1a5992a49dfd989b0d7e80507aef401a64a3e071d732a4ecd8780ac128f1f740",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-softokn-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:e0d46120682f1f84d1cc960c8119a752a607a5f977b800c8886d663b3231373f",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-softokn-freebl-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:6238635b31f4b9dae4879707d1e1cacef4513a98b735062c3e9330d7dbddb918",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-sysinit-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:bf6c10fd5b73cdfa52bc01e316242ae6c1d0712f43b05375d71ac2eb9ddc9231",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.81.0",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nss-util-3.81.0-1.fc37.x86_64.rpm",
+        "checksum": "sha256:935be10e2da04ce9cc96892f19fdcb53f3621bdf449fcd569ef930f5e5086a1c",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfs-3g-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:39e14c4ed790fe4d47bd984afc47f291cac78bdfc9cae7d220979ca52c7301d5",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfs-3g-libs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:6fc5af931ae4e106fac29e38db61b4ac4e86331088ab085cb2e9ff0c33dc55bf",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfs-3g-system-compression-1.0-10.fc37.x86_64.rpm",
+        "checksum": "sha256:7c6819de5a54218e8d69921d7e9cab759b794c4d65c5b9199e0da3e05fc31ec1",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/ntfsprogs-2022.5.17-2.fc37.x86_64.rpm",
+        "checksum": "sha256:d0be81593c6a700d883ff95b06a92afef5790a5fbcdb8d35d6cbfc9c4e87e5a9",
+        "check_gpg": true
+      },
+      {
+        "name": "nvidia-gpu-firmware",
+        "epoch": 0,
+        "version": "20220708",
+        "release": "137.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/n/nvidia-gpu-firmware-20220708-137.fc38.noarch.rpm",
+        "checksum": "sha256:eff8922a8b9fcc415fd0b2b058a35b3a3adbf782d947355156b2bf4f97fe1f8f",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/oniguruma-6.9.8-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:bcf4603e22813dc3529f3e973711cbf5a785de78c2554da68c74b86391b4870e",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "5.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openldap-2.6.2-5.fc38.x86_64.rpm",
+        "checksum": "sha256:05d2f64fad5473ce1f46ae2f1e8d8be03cd32403fafa6cc8b3f27fc953895f96",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssh-9.0p1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:f20fceba4f2c12cda1b77e788eb9f25b62cda9e31a70e29478703066e68db36b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssh-clients-9.0p1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:426e7f130bc6e13cdef872e9a5d77a0e1feedce7aee993216c1c1570987e7d29",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "9.0p1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssh-server-9.0p1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:6e3d330928099efbf01cffb1f29da318c15eda3feb8aa97a16e0e4978b5c0d85",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.5",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssl-libs-3.0.5-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8e41c308c4cd335ce5a0e306977fbdec18abbcdcc8ed4811ec14784ae91f8905",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.12",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/openssl-pkcs11-0.4.12-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c416cd702ce78583b177eb152e87424e4e65a706cad8966904d10f3b413ddc54",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.81",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/o/os-prober-1.81-1.fc37.x86_64.rpm",
+        "checksum": "sha256:79426b7b91b26682579cab6943516b32797f6c3028008e9c52d3299fb8299f1c",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/p11-kit-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d238b2e8d817b89bc0d1d22d716c3695185a96bf939b548e1143ff76c4d5def8",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/p11-kit-trust-0.24.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:05172ef8afc62632b5e7c395dc9ed2f801e84ace131d36b1df777109df138797",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pam-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:1cb235881ac5c89085fe28e6fde153920cde9f4bdcebc17fca86723f3cc19310",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "14.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pam-libs-1.5.2-14.fc37.x86_64.rpm",
+        "checksum": "sha256:043bbdc6ac7341dd00c1857c68d50f8fc91e2d589e1020c5c4678ef6327fd03c",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.5",
+        "release": "6.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/parted-3.5-6.fc38.x86_64.rpm",
+        "checksum": "sha256:003ce0d20116e00e8b521e5b7451ea0606950387352596c066fa983d3b709d9f",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "13.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/passwd-0.80-13.fc37.x86_64.rpm",
+        "checksum": "sha256:873a81a4fe3a7364f2b93cfc72f6a0153e26051cf4937604fd9394e405600753",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.8.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pciutils-libs-3.8.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:9b4e2edcab2b0876625a00d939f8e415e1ba52c70bc5e21d6ed0713fe7c44a8c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc37.2",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre-8.45-1.fc37.2.x86_64.rpm",
+        "checksum": "sha256:fd33e3c1b8730844a570f9e2cc1bc818d7ce4d71ed345d48e1db4c120db3e209",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre2-10.40-1.fc37.1.x86_64.rpm",
+        "checksum": "sha256:6d2bb2cef78697952123b3a7a6a21dcd244d3fbfea20f577f75fd09b9d52fd74",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc37.1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcre2-syntax-10.40-1.fc37.1.noarch.rpm",
+        "checksum": "sha256:f671b18b67b0818e7195f22dd24afb1904fac9e0b4c4dee32f6a7aaea59ffe14",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcsc-lite-1.9.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:bf9cf9900f3ce7df167ec948605e36d3a616faa7293ca1daabaf0734e8447787",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcsc-lite-ccid-1.5.0-2.fc37.x86_64.rpm",
+        "checksum": "sha256:eaad7eb1db33cd9a7d75dc22f93fedf00d5cb5e58c4b91da4efc08394b6a3465",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pcsc-lite-libs-1.9.8-2.fc37.x86_64.rpm",
+        "checksum": "sha256:e43aa00d3d59e296bd2c46396d127b4c4622a5dc566462249669fcc560121e13",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pigz-2.7-2.fc37.x86_64.rpm",
+        "checksum": "sha256:5b03af8ac2ea38b815d942ec3acd99ecc6628c2047395f5c9667c044972fa114",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/pinentry-1.2.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:105e81dea42d33867b290d41a8b5b7ed615ba05ade804c3b04a7ed01fb6b7cfa",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/plymouth-22.02.122-2.fc37.x86_64.rpm",
+        "checksum": "sha256:4f12201baaf7ada83796e6327ac381de4a5fb761c1455c69f9b7f80054531841",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/plymouth-core-libs-22.02.122-2.fc37.x86_64.rpm",
+        "checksum": "sha256:c665d09c1beb16de5cacea881aee87cf0aef7ff8a79de42595fe80256c9fa38f",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/plymouth-scripts-22.02.122-2.fc37.x86_64.rpm",
+        "checksum": "sha256:8f78812b1fe8d73e5cae7d5bf750943f50ddee775f735dbb508f91395400725e",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/policycoreutils-3.4-6.fc37.x86_64.rpm",
+        "checksum": "sha256:05b63669a849d7cfac20c627dc0bfaaab33ed479f7be9623154adaccceb68476",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/polkit-121-4.fc38.x86_64.rpm",
+        "checksum": "sha256:151d21077d158b81f0b444fe3c819179f235db61e889245610f2474494781055",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "121",
+        "release": "4.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/polkit-libs-121-4.fc38.x86_64.rpm",
+        "checksum": "sha256:84933208c4c2cd87bfdf08817f28fd8b2ea2f4920d63739cea1b937d63c5d0bc",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "22.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/polkit-pkla-compat-0.1-22.fc37.x86_64.rpm",
+        "checksum": "sha256:d655e5491ee4ced0bf5a9a374e5bd513ec0c82f1d606a534312824280c111fc7",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.19~rc1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/popt-1.19~rc1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:e3786cac439d6e4364fc636ab88113449a725b2b4600d291037980d9418e8385",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/procps-ng-3.3.17-6.fc37.x86_64.rpm",
+        "checksum": "sha256:783787153af3229bfc3214929ab49002df5b6454edfc7a25756a139457908a6c",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "6.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/protobuf-c-1.4.0-6.fc37.x86_64.rpm",
+        "checksum": "sha256:a34e7ee2f04f7fd376899ea78e1161101ba264cd9875a2d398b6e6adab38cd2e",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/psmisc-23.4-4.fc37.x86_64.rpm",
+        "checksum": "sha256:692a5ce3d939ef1069eb54cdd3c67ca814f604199ae10dd40e1d1a6305d368d9",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "5.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/publicsuffix-list-dafsa-20210518-5.fc37.noarch.rpm",
+        "checksum": "sha256:0797a07a47c3a119cb7f34a35bc1fc83cda59d4241f1bd999c07babdf8ddb571",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "22.2",
+        "release": "1.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-pip-wheel-22.2-1.fc37.noarch.rpm",
+        "checksum": "sha256:7243691c3cf8581988fdb05bbfc8ab3a8fe7e4d10c0a6916f984447a67f1e1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "62.6.0",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-setuptools-wheel-62.6.0-2.fc37.noarch.rpm",
+        "checksum": "sha256:054771e1610401a2d3dfefff7f5fe3936e188d43e863b519dbf0e3aad507e53b",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python-unversioned-command-3.11.0~rc1-1.fc38.noarch.rpm",
+        "checksum": "sha256:d73dd7b831c9a04512fa6add549dff49f16b53d02b7fbdeafc49319aa5ca75f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-3.11.0~rc1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:c3d14194ed32384f4050402e37484ca375a6a32df20d92e2e56e50141241cd1e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.2",
+        "release": "4.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dateutil-2.8.2-4.fc37.noarch.rpm",
+        "checksum": "sha256:d9572a1494fa167b5073b7a8633eb278b40d85d9d57426e2fec190cef713551b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dbus-1.2.18-5.fc37.x86_64.rpm",
+        "checksum": "sha256:2927ca7c2dcea19963acc971bdf3e02a2e5e8a327520c04d34cfce51f978f828",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.7.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-distro-1.7.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:c2bb600208d5a9cfb7f7df7e54bed27a8d3041b5657eddc74474edcb4e3ede12",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dnf-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:bc3b99028b610bd236645eca33d75b98fa9f07eb82239cf6031385ceb825080f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-dnf-plugins-core-4.2.1-3.fc37.noarch.rpm",
+        "checksum": "sha256:3e62bca2c90ace2b9e000d02bc3538cfc3dd5bb25b0c9740f47b4fbf1e6b6a00",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-firewall-1.2.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:e746f59d62344dcca7f14582affd2b2543e3204d3ecf6525513381057c7c2fbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-gobject-base-3.42.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:23de5abc3a9620f7f8c5917cfd452892cfcab34fcae502de4d04f83964ca716f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-gobject-base-noarch-3.42.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:358de9892f2947ad5ae159ae918e9a568e1ae5f8e8ee56d875e21bc758230914",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.17.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-gpg-1.17.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:3ae53041ff5534b34434f74420fe2726ee16da7807058475993c1035c729d477",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-hawkey-0.67.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:b1f48a911c68c5ed7afd8ccd83539b76a4e61b775efc19d5815a2a439f7852b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-libcomps-0.1.18-4.fc37.x86_64.rpm",
+        "checksum": "sha256:4e62e029027cfae50e42f483e2e275cf33f6e24e4bfd8dd0b88b9be7ed719ef6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-libdnf-0.67.0-4.fc37.x86_64.rpm",
+        "checksum": "sha256:65a1852efc0080df33c92fbc1a80c18e6facad743094e5a778063150ba1581ff",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.11.0~rc1",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-libs-3.11.0~rc1-1.fc38.x86_64.rpm",
+        "checksum": "sha256:9e797d933f72843c6807e432359ec97e1317a1116d7d0effa57265a5e0acdc97",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.5",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-nftables-1.0.5-1.fc38.x86_64.rpm",
+        "checksum": "sha256:729c2e05903cc91e4bfa594265d346440e1dc72d52ae17b80edd998223660743",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:a47a3377d709b85abdb7ee644cc4d97b13176ea9ed92da72627b80465eeda5cd",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "8.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-six-1.16.0-8.fc37.noarch.rpm",
+        "checksum": "sha256:47a875f1e20f6981847217e875699f645665dc968dd77149289ddff4de1fd76a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/p/python3-unbound-1.16.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:c59cc4671bd159d06c722bf40df0da69b7336980c320de6c24b6aaa1562d2170",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/q/qrencode-libs-4.1.1-3.fc37.x86_64.rpm",
+        "checksum": "sha256:13566999e878517b6dbf677531479657a79db99f58b5789b3c4219293fa4be1f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "7.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/readline-8.1-7.fc37.x86_64.rpm",
+        "checksum": "sha256:eefadbe8b3e74f1b171269c86b218dd808d5cc5e3a39a1d6b24d8705cbaa0c25",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "32.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rootfiles-8.1-32.fc37.noarch.rpm",
+        "checksum": "sha256:b2d2472284b2f589e360c7c49705812112322e53110b98faee4088f94933e9ad",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:6003cd293b27e79e5b0a2ce42d2de69e5fff97ed9f968ced438d15371e63d2f2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-build-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:9714ed4acee2bba058776da3250ab8e7b0ea18268bc091abd98ded1df0aa14e5",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:e7d469f950778ff8adef1ca289cd186afcea961258f9548fbd41e4e75a723ab2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-plugin-selinux-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:feaf82298552968ed6b93fce62514a23ca6e387e60fd8d822d06b31b746d6580",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-plugin-systemd-inhibit-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:ab148da694432365ab80452a1ebc7a9cc9cd76243874551b4759552a21028b41",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "0.beta1.4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/r/rpm-sign-libs-4.18.0-0.beta1.4.fc37.x86_64.rpm",
+        "checksum": "sha256:2f03293f178737efb4d4e044d1d4059fbedaba49978c3dc56bd8a0e6edfc83e4",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "11.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sed-4.8-11.fc37.x86_64.rpm",
+        "checksum": "sha256:8cd7312e2810f706aeec6985c277f1500be87f0e58f4311f1fd2d9ee00f5eb3f",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/selinux-policy-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:dde47318851ffe9bb3f04d1520f2da27eb4aee0965bba9fab4297a475baa1407",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "37.9",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/selinux-policy-targeted-37.9-1.fc38.noarch.rpm",
+        "checksum": "sha256:12158c6560d1c1a47cfb4c98817cb3452021345a6b2ee1f2e4ad65f92d30d8c8",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.14.1",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/setup-2.14.1-2.fc37.noarch.rpm",
+        "checksum": "sha256:4dec1040e07368f786b29a82e78b91efc492b2c866f356b5bff959fc51fb27c8",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/shadow-utils-4.11.1-4.fc37.x86_64.rpm",
+        "checksum": "sha256:7ba6e32620cbf52fa6a2569c05c87012acbca0622c385ca79a2a3530e8b91ac1",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/shared-mime-info-2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:972aa39dadfa549706a4e5b1e021495060aad322663960d273f06ec093a1c009",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.39.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sqlite-libs-3.39.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1824a7ff7e02feab54f1ddaaf0462efb842e6c68ee5646ae33c93cbd4855f917",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sssd-client-2.7.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:f0a922c318960ca36e6c4b398b2b5c8c8aecee3e86184830555cbc198f688b94",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sssd-common-2.7.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:67eee198120158693730192cfe76e8c9632e3b00e8550e573aef07bbcc2ee771",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.3",
+        "release": "3.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sssd-kcm-2.7.3-3.fc38.x86_64.rpm",
+        "checksum": "sha256:bc29d08898d7d829cff570e29d32b7565800cee94358e5e53b314a2596343302",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sudo-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:59613aa4a26e2b338742edee7dc99d5fb1b2c7c81d500b5977a7a69a7174886e",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.11",
+        "release": "4.p3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/sudo-python-plugin-1.9.11-4.p3.fc37.x86_64.rpm",
+        "checksum": "sha256:2b750d60543a4c45b5d663859d1372a041b2eb1c5d808c460cf536079e64ae02",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:14e228653909101710ce5e9b5ae448b1a92906f76b575d64339c6dce36462820",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-libs-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:fc6ebe507afadf828aaabf170689006435c8ab334b5e8289ee9eab9492cfcda0",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-networkd-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:8f43907f08625aefe9de6e3e33c18cb2d9835a1a26672994a951000ceb8557d6",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-pam-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:0d29ce0147d6a1dc333b111baec1f0ab3e9079c8c4820ca2c2349e1576beb4b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-resolved-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:d0cb041ab0d613e62be3897fd8f0b3e02c2f720244efe83b3205efbc26eb065f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "251.4",
+        "release": "51.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/s/systemd-udev-251.4-51.fc37.x86_64.rpm",
+        "checksum": "sha256:f0e526b1bd8a24ae49c2c408de73f32a54b1136fe6a404580e9e702aaa58f93c",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/t/tpm2-tss-3.2.0-3.fc37.x86_64.rpm",
+        "checksum": "sha256:d52620cf80bde19169fca7ce66fa7cff416b04b7a0cf2bd7dae8446578dc999b",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022b",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/t/tzdata-2022b-1.fc38.noarch.rpm",
+        "checksum": "sha256:6f714b6522d58ce7ececfd6a8edd9fcae53164f13d7b758dcca0b3421e93f4bc",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/udisks2-2.9.4-5.fc37.x86_64.rpm",
+        "checksum": "sha256:86b85375ee031abc705f8cf1af528f761a5a5ef73418cb52ae58f44d1405f793",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-anchor",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/unbound-anchor-1.16.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:6b6187adc0b8facf93e4bd9e64490695517e47b4d67d04e5c592efcb8b89c8f6",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.2",
+        "release": "3.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/unbound-libs-1.16.2-3.fc37.x86_64.rpm",
+        "checksum": "sha256:fded0e1914333e957b98f7da4b80ff785e7b1122f611c48cd2e375dacd2bc07a",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "5.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/userspace-rcu-0.13.0-5.fc37.x86_64.rpm",
+        "checksum": "sha256:7e674c68dc9d3b7b254b677696c12743e1fd79e31c9b315bc700d9f545d145fc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/util-linux-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:65f1521372f4e3edd032f7379cd6f4e021a1aa69199db6382e34ce7e7cea2413",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38.1",
+        "release": "1.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/u/util-linux-core-2.38.1-1.fc37.x86_64.rpm",
+        "checksum": "sha256:c78693b8c775011e52abb0719a4f643fc29d38b7a8c756bf20d7937ab4cd80a4",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc38",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/v/vim-data-9.0.213-1.fc38.noarch.rpm",
+        "checksum": "sha256:0687cbfe5b9e9a63521b4a2f1e913ecffb35bff038211fc8bfc4dc277c193d0a",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "9.0.213",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/v/vim-minimal-9.0.213-1.fc38.x86_64.rpm",
+        "checksum": "sha256:a5bc403cdd722d6adaa0a7bab0b28fa8737a6f2e2b5a537e2b25ab759f3e6b0b",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "17.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/v/volume_key-libs-0.3.12-17.fc37.x86_64.rpm",
+        "checksum": "sha256:0088c48b167cc56fde621d2ced4addc70c1097f0ea57f91939ccba67a2b22f28",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "35.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/w/which-2.21-35.fc37.x86_64.rpm",
+        "checksum": "sha256:dc7f0cd491fa100062e4901a2a30512dccc060b1cda2fb291cde05561e948794",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/w/whois-nls-5.5.13-2.fc37.noarch.rpm",
+        "checksum": "sha256:159e9b82f1a1502a3e34a5f77505e276619121bffac395ea80e604832ebd0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.19.0",
+        "release": "1.fc38",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xfsprogs-5.19.0-1.fc38.x86_64.rpm",
+        "checksum": "sha256:7998e07ae6dc75167fbb10dc3ee39e3cff89c129aa84166ee38449b01ac3e877",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.36",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xkeyboard-config-2.36-2.fc37.noarch.rpm",
+        "checksum": "sha256:cd18043df6a9e97f6690ca1a459070da4ad046c4881b1f9688acd2f70f0a391d",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xz-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:8571bf4b6c8648679ce401f7c9a619ee105eccacf6ccc731c75a60a449b80345",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "10.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/x/xz-libs-5.2.5-10.fc37.x86_64.rpm",
+        "checksum": "sha256:344ef345e55df5b4de878bab40afc3f2fc6d4362f6fe78d9cd2a6c19483b9e3d",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "3.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/y/yum-4.13.0-3.fc37.noarch.rpm",
+        "checksum": "sha256:b57f465bbca8c4ee064a73e3fa044b4fac3a158e1d754611a63db7feb7ffeec2",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zchunk-libs-1.2.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:1145e44089cf728566285ecd6419fd1a8f78e47f38dda1c998ac6d38d24843ce",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.12",
+        "release": "4.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zlib-1.2.12-4.fc37.x86_64.rpm",
+        "checksum": "sha256:fc213083bf978b139113ad37c607b772b2ff621461e314b09fa21a3d1da1e842",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zram-generator-1.1.2-2.fc37.x86_64.rpm",
+        "checksum": "sha256:26a3e46f75e0213db137674dbaadabb14e2164a6146236e1f8bc3f7a6b56780e",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "2.fc37",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f38/f38-x86_64-rawhide-20220817/Packages/z/zram-generator-defaults-1.1.2-2.fc37.noarch.rpm",
+        "checksum": "sha256:ae6ef1c1cfb61f9940bb23f79d271e8b6e4ca7cec9825dfe992cb8ef7a2b1aa5",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_35-aarch64-armsysready-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-armsysready-boot.json
@@ -1,0 +1,10297 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "aarch64",
+    "image-type": "armsysready",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-modular-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "armsysready.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora35",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:93ef166ef633109718d61c580210a47a65a21eb8a178a11dd7bc577706595e27",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:097de2cb18e9011f37bf4fb4f093346ef1d786cdda1663b5ba9a66a977ac4ffe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.15.13-200.fc35.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "armsysready.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm"
+          },
+          "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm"
+          },
+          "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm"
+          },
+          "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm"
+          },
+          "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm"
+          },
+          "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:097de2cb18e9011f37bf4fb4f093346ef1d786cdda1663b5ba9a66a977ac4ffe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.aarch64.rpm"
+          },
+          "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm"
+          },
+          "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm"
+          },
+          "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm"
+          },
+          "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm"
+          },
+          "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm"
+          },
+          "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm"
+          },
+          "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm"
+          },
+          "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm"
+          },
+          "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm"
+          },
+          "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm"
+          },
+          "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm"
+          },
+          "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm"
+          },
+          "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm"
+          },
+          "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm"
+          },
+          "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm"
+          },
+          "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm"
+          },
+          "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm"
+          },
+          "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm"
+          },
+          "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm"
+          },
+          "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm"
+          },
+          "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm"
+          },
+          "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm"
+          },
+          "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm"
+          },
+          "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm"
+          },
+          "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm"
+          },
+          "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm"
+          },
+          "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm"
+          },
+          "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm"
+          },
+          "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm"
+          },
+          "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm"
+          },
+          "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm"
+          },
+          "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm"
+          },
+          "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm"
+          },
+          "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm"
+          },
+          "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:93ef166ef633109718d61c580210a47a65a21eb8a178a11dd7bc577706595e27": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm"
+          },
+          "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm"
+          },
+          "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm"
+          },
+          "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm"
+          },
+          "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm"
+          },
+          "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm"
+          },
+          "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm"
+          },
+          "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm"
+          },
+          "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm"
+          },
+          "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm"
+          },
+          "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm"
+          },
+          "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm"
+          },
+          "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm"
+          },
+          "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm"
+          },
+          "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm"
+          },
+          "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm"
+          },
+          "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm"
+          },
+          "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm"
+          },
+          "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm"
+          },
+          "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm"
+          },
+          "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm"
+          },
+          "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm"
+          },
+          "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm"
+          },
+          "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm"
+          },
+          "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm"
+          },
+          "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm"
+          },
+          "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm"
+          },
+          "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm"
+          },
+          "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm"
+          },
+          "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm"
+          },
+          "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm"
+          },
+          "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm"
+          },
+          "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm"
+          },
+          "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm"
+          },
+          "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm"
+          },
+          "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm"
+          },
+          "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm"
+          },
+          "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm"
+          },
+          "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm"
+          },
+          "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm"
+          },
+          "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm"
+          },
+          "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm"
+          },
+          "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm"
+          },
+          "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm"
+          },
+          "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm"
+          },
+          "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm"
+          },
+          "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm"
+          },
+          "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm"
+          },
+          "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm"
+          },
+          "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm"
+          },
+          "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm"
+          },
+          "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm"
+          },
+          "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm"
+          },
+          "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm"
+          },
+          "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm"
+          },
+          "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm"
+          },
+          "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm"
+          },
+          "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm"
+          },
+          "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm"
+          },
+          "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm"
+          },
+          "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm"
+          },
+          "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm"
+          },
+          "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          },
+          "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm"
+          },
+          "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f6149724bb7159dfeef67108e12e9b854b97f9aa4d074c93677c3db05f6dd9fc",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bc74646a7cad5fd02685b1e8ca591e10e9303b7310e3b94b33bdb35c1b944f31",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f8d1a5f9243a462c2a57de28f615e430b42cf601708ceda6ad1bf394d560de2d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ff884863d91863eb8e04bd9ab69caa06b25032e222e947b6377845a82075f80b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c21f11b9d6e22af4626ed8f12397695e55993b3393095c94a0b44986cd76cc94",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.aarch64.rpm",
+        "checksum": "sha256:571fcfcf5a1fe6e21c3568856d310758f38ea71d5c3a1a302a14f9f899ddeabf",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:423e6ed55e1e33c861da433a8928fb3b7bac14b7c7592648a057439d0b2f4d65",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.aarch64.rpm",
+        "checksum": "sha256:54159a60bf3bdc15d9453ca2cda710c94f8c53b50d97914faa6ff1d02be82d75",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:0e5e13c8c5abb8e694eb1331fc2f5732124856d342221e7b8aa986735d4cefe8",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.aarch64.rpm",
+        "checksum": "sha256:d5e19f222b87bf50d32f0fe5491bb0c20dced53250617abd5446f45589c0c943",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.aarch64.rpm",
+        "checksum": "sha256:d53052fb75a4293cc82fe322b53ced8102b7ffafff2d5ca6222b333679caf3bf",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:3f8212d036f0641d8d623892737a9030394e24a141271f2f35468b13ad016284",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.aarch64.rpm",
+        "checksum": "sha256:a71c28319df3e3bb8867e6b70a320b53775aa475b8638723d7bce82d4d667b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.aarch64.rpm",
+        "checksum": "sha256:f25026442fd87ff20cd7545b2ef8522afc686251c78cc35d3519f0b51b2c37c8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a7b4f4c638b821067ce94a5efe0fb6b0d32f776efb2e208fa13a70c450c742a6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:117dd4f23733a0b9e86e88cb8a4598f66f39c6e8950bd2c353b6a27018216558",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.aarch64.rpm",
+        "checksum": "sha256:7fce3f36167b5f8cb25cf56d7922cc6a2e4d78f435a0bfa405202a14ac6f395a",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.aarch64.rpm",
+        "checksum": "sha256:a33325072279ee7131730119799c8a64d2daacd98eba419223a3e2685db19e04",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:1249b3779ebd462fb1bc894bb345baf637c7c9befb56f1fd1e7cda3480289126",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f63f129516e3289f210487fa9c91bcfc8a08c6e636867666ea8cbffce56b1d7e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.aarch64.rpm",
+        "checksum": "sha256:c24de5196f685e18736fe3ee8d1b35ed34b19b5e277a17baaca30777e59fe070",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.aarch64.rpm",
+        "checksum": "sha256:940f3380ec9b743c188cd310320cb1315763d246b4c1c26d78721d3a7ca521b0",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c15429541bf1984e507f991adb9c9daf6f9ba7e7ef5d5db34704a072773c994d",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e08085458034dc7dac6708c92ce37e1dc7e6f18b88024216d823ede8bd40ce7b",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30aab0b7bafefdb4c9b6946f5d949c3815311566a38328cfd873249716ca2da2",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efi-filesystem-5-4.fc35.noarch.rpm",
+        "checksum": "sha256:2de92f6f278bf7801b580fcd1ed8e36b18311db493511e2ca038596f458c02d9",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efibootmgr-16-11.fc35.aarch64.rpm",
+        "checksum": "sha256:263feed0527658e659b38909e24ab318fd9855606ccd5cf5ee901eaf9b3fd697",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "37",
+        "release": "17.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/efivar-libs-37-17.fc35.aarch64.rpm",
+        "checksum": "sha256:6cdd19819db86be3e98fd20c48402100f6341d8b50b16b2850bd94198f0b3072",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3d51b4873e763244a38ad508d7e3fa37dc1e9957d6534d0402a2e436c8621c39",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:3232daf8e3cdd58c2f0c45db691ff477a71aef2645c961e6878e9e712115b396",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.aarch64.rpm",
+        "checksum": "sha256:fea177029aed4a44a04df669e94c241a6cc2f5d3ffe744bd9c0f8a7ca9eb8c28",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.aarch64.rpm",
+        "checksum": "sha256:1fe9256424e4aa279e4041ef68456cd7c9bfb38777adf53ff0504c11681eef6d",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:bab0d343ebbe51b3abf8ed26d1096f5b33031dea0da5cec18712fbb409b80544",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.aarch64.rpm",
+        "checksum": "sha256:c672c83511ff9b15125e3bd36c324cc84e01c4a8befc67a933702ab9549b02c9",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6959b9ad5d0b0e8b89d202e0299d739ba8765227acbb4a9af3aedf0745e2a63f",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:56bfcaee03150ab7e37ad1eebf391b5708c19897208cee883f301c0f746df565",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:bdd379f15b0ea86b802d0c8c87c4dd956fe60c89a64254468534ec48d89f1d1a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.aarch64.rpm",
+        "checksum": "sha256:c7bce725f16f4f27f225210a310f9dfd5696ad6c40557474bfd45d50a8610f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5378600a5abc95933c2a4ed4c76fc21f1f4a0c64d82938b49e77eca50b398bcf",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:88e31bb9248f1564b56b61aed171ece501d576dfe0f91f0cd66c1712dfc86454",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.70.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:30c4143715cbe6d44c23039777276fe7b900130ea6193d75512f5d4651e52e13",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grep-3.6-4.fc35.aarch64.rpm",
+        "checksum": "sha256:7d48cc14535ae1e3f2903c1d86b3335794d5d83e6d74ae62b5b560183fe7086b",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.aarch64.rpm",
+        "checksum": "sha256:631b94206cc2db85e25d8aba128506d68a4df9f4974bb9b95960fb794f28ea21",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.aarch64.rpm",
+        "checksum": "sha256:9fd5e4c1a5ec8e3eb77f0c8a6d55657156aba3ddc1f745381638dfd05154d711",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.aarch64.rpm",
+        "checksum": "sha256:a5d92839c5b336545f98f3c90b51961c69d49f2d55d13b93d90ea6e95229029c",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.aarch64.rpm",
+        "checksum": "sha256:05da09b181ece80a8f5890a257d51c9ce2eb274f358865c6fecb73cb5d73a5be",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:920ae9025e1e56868fb4a0c5fa7f3e6e76597393cbeb9c3d5d0faca489afa93e",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fbe40901b7fe60e3399e1bd1e9bf412dc8b99699e25cb6a5800f9ba156d911a2",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a517ec614d39a7b285fd3333806b1d863dc31120c504668cdef9199207b251ce",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:cf075521733c84f4c80af0d130dc7448fef3750a473adcd5056a91438c38240e",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a313d9bf609188c4c2add95eef063aa9fbf89812d8a04db211f6df285d45aa4c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1f81a2122f9b9482a6b41b2bd98ec47a9f06697a4f3d08ed81dfaca7ee7b1c6c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f62c37836b177bbaff44da7e94c70bd9badddbd873cc0b470f14c56257eee5",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:7398bc214f0a036d52fe84e54096784c9aaaee0939212ead1570697e3b375676",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:bc477a63a3f763b2b95c2b6e3ab71e70a737dff956075173ed8f3711290579a9",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.aarch64.rpm",
+        "checksum": "sha256:8a93cb5f7a78270157d8bc5272478d64104a7d89dccfea2dd227d8692fc510c3",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4eb53d0f3aaa1dc3d974556a6138459e14460bb65e506442400b4eeae61866eb",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:972e63fdf149b8fa4cc48d07c77a5b2a8d630b2a71deee28d78c8eb260df65b0",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:24393abb5d48136286d571b9c1ec8c9b8e0c2e9117419c350695efffb7fd371f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:51c58377114d5197c717b9f375f96bc0b8562053dece8d6d8be64ad9134ff9f6",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6f9e9670b78921bd121d086aea93a052793e50409c75d8e91f63c7ff0b3cd5a0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b33ec7be77f37c20d86b9abda435dd8a27a1bd18a1270b556446362fa14495f4",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.aarch64.rpm",
+        "checksum": "sha256:64cf8c6501ad535c1e20a1a403d5cd781bacbcd07f0f5d82955549323b9773cd",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.aarch64.rpm",
+        "checksum": "sha256:8401255848d9b9795f8df5967e2fd19c24f857cabaa54484cc152ead13cc8df1",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e8cfbe82cbbdc4e46a25648d2d0d7fdfca963d3339924adca6c4bb89b93afaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:59b7fd0bf5e658384fa445e1d776573c1cc97f80317304eabba56c45d6a75c77",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:76f8d7d914f5341402d3d049565c02f9e890dea2143be8f72c1f63bfbb5195da",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.aarch64.rpm",
+        "checksum": "sha256:f3e03d461d5ff06bef6a77adb115ecfde7f68bb9a8c00a463c270863f438a8c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.aarch64.rpm",
+        "checksum": "sha256:75781c63c84fe070d10703b47e9fa8c2a4cb5a58222d768715846c4661c392e0",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6de1615b300767268d494be624d5230bbea36ab2acdf64dabcf11c6f8f7e8838",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:39ea1be463aa022b97bebec6be82102229a6ecbdaf706e0260199700c7297094",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:df97c3628b82d79634071c06d4ffd1f233b4ab7aa9bc87e753b6c2f5221c0a74",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.aarch64.rpm",
+        "checksum": "sha256:808626b08f0cfb6612028b8996dc1504b659548715b567a47ea5a2bf24ab4fa4",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3d50ca8e744c233f4629a6fee02387975db10789af0a1709bf30c68c2c96ce7e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:016685437aaae0dfa2006c74f3559227f378915327bb100bd5017c981fa27bba",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d2ee9f93a162b90bf2abc1422826c30d85ecf0cdd16ad1b5ab2c343cc98dca36",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a8715a6e95f77f368e1c085ffbb755c28627f53c15072b3c80f35e0cfd9a7cdf",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2c3c12fba39b3e6dcc93e3f8f36bc49589361bc7b80c894123a81908ecdf6a3f",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.aarch64.rpm",
+        "checksum": "sha256:6ed5d73ffb4114c77aa5c3ac34db75c3823be572c3c18666e9772ee3168df5a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.aarch64.rpm",
+        "checksum": "sha256:3cdc380d3deaeb22b0ca12f53100d22d00a14322d43f1b361d63f2e494e5a6c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b089742fa5a02813f6813a6a547bac0a4f7cac8f85af56af3b3263a93446041f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37859d0b2f0973a7e7e44faecaa2aa94f8bc46de8fbed6f8a31cf01532bb231f",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.aarch64.rpm",
+        "checksum": "sha256:b76b5ec57886b032d05b76b0a73cd9dd2b9b99ddaf4c264bed90b2b2a3c18f52",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.aarch64.rpm",
+        "checksum": "sha256:8e07a596e497687c56fef75b8b18b89fde94adc37b9e1c0323e26c8e5c83683d",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fe4e779ec1310b73dd140a5849fd36e936e90ad80c0b7feae71c5488d8332bfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.aarch64.rpm",
+        "checksum": "sha256:426f6072fa967808c3705d7c2601d36d8f1e3e96c854f898235624e0a0195593",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d076fdbff4d2a8c31e9d9cfa57ed7cd14333ebdf1b76df61b262aafde5509a6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a7519cef5c1ac6c0d3ed5acb7a20749da78baa0930d59c01ebaeae0dc18c706f",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.aarch64.rpm",
+        "checksum": "sha256:1f0021b8f5b3f080ac32761bb49b6621e3255204df09343eef6f16281b555202",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:d482a04dd2f0f2a27c6f53fdc5a1d6d1015b245feac831eb0ce4d83cda6de22a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:4083ebbd837767eded1168121d6b4ba37f05fb739243a1af473cd543d4869ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:cc15ac6df02f0242ff91f9af981960934c95b192d0ebac5b79075a48f937d502",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:557ad1d597488de22d8f1b70b546730a9ec58810689abda6144f7f4762b03cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a6af653b17d373a84301cc89ef9d815cc7af7b07d3b0fc9a9858f189b3e45a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fa1c75225948ef78b084ae0108d6db8f48625bcd68462f9b3db07f52ce60711c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9281b560827f943e2d79d047b29a63877218834259bcfa0da464d88b3309d9a2",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.aarch64.rpm",
+        "checksum": "sha256:92ce5e56e6a986c910a1656c054ae13bcbbc0e82f8dc14f0e5a2bf67aab3e223",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.aarch64.rpm",
+        "checksum": "sha256:a979b53677808e3805a1a94d763468a011fc64acf8fcbb2373391f0c35649a63",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:8a18dfb2f79808c73b8c66b060efbbf20173b24b6c32f65d6ef889f061496dc3",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.aarch64.rpm",
+        "checksum": "sha256:aeed7f38d4c85edaefd322fe78bbe1b1fe00969823903bc652cc3f9f5a268831",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7bc35d9fda6ebfe33a63cf1093a2c64b03da111461fce2b213f4fc5e91519eaa",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5d23912532e4d20bff983c59a62da6c46451bbaefa98802febf414a8803c6c2f",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:75722fb072ed0fd917e4e6e46e7c7b5f9f5cd72aa28cc062dfaeba65f3defe19",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.aarch64.rpm",
+        "checksum": "sha256:e08c71aef887d7ae02f9f2e907971ea03da627339962d4f58cdab144acede0d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.aarch64.rpm",
+        "checksum": "sha256:b417812d002c332b2e70a2f00dd9b90674d7f202408f69fe8b83db9f31559032",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:db8eea424816afc05b9ca8b2002f457ad678c1385b13f84fb00d7e115846129a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:824e776b32c1b9e05e10a8e1c53de70ffee28f4b1ebcbe38e23b2746c7d040ad",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:19a3ee105315e792ff4bc3d000fa0d0ed108d677ec17e612a96f9f2890d11f4a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:b88f0a47d87f91347e395eb950cf19f0f63b8cbc7a04afe2f233262e21631507",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.aarch64.rpm",
+        "checksum": "sha256:7070b40d929f07da16b440c85c26d210eddf0d4820639a54d9a02ea8bbbfa5d1",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:1421e9ea91f43ccf9ab915ebcb3c88dec30cf8e393c03eba716015d5f74f21d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:e4248a96037c3459f7392c03e52dcb9ef450aeebcb071b82be070f13cd2f5cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.aarch64.rpm",
+        "checksum": "sha256:9ea361651019d6dce0b04b7c670612bbacf910df723c6c98d583fd64640b0a50",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:963af64a8c2a1baa3c28651f736b1a6fdbb705d23a4c461aacf79f76619b1bec",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.aarch64.rpm",
+        "checksum": "sha256:fb1498d9bb41a1cefc06766895e7c976cd00b7a96a8762428c40b5128a15c8da",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:d87223943cddfcaf962661eb6a1ea6bdbe38fdea1f61909f34a6ca421ace61bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.aarch64.rpm",
+        "checksum": "sha256:caaebf4b51cf7791ef4b38e10d27115a6d56422695bdd0c15dd80ce3977486d8",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e09432e1bb993236ae138fdcd8ed2b95790046dde763b6d60a6d430f62978180",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.aarch64.rpm",
+        "checksum": "sha256:2439e2ecacf5a1c31464a84f8a58c252850b1f250f45ecdecbf5403203ba1a9e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.aarch64.rpm",
+        "checksum": "sha256:ee513c0a565ea3f2678466996dbc0f1ccc3cd443d8adef8f383e3c221e3936c6",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ae799bca349c5dbe2ce5395590b21d1146bc0dc904b359552688af2fd69198a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2a5a0fd68ada233eadc7fef2aabffcd4ab6bd03a76d62de9b28727b11d5e6369",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.aarch64.rpm",
+        "checksum": "sha256:a49ed8c677e57c76ed9196eb629ae4dec2b50089114bf3694aa25c585a6e99cf",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.aarch64.rpm",
+        "checksum": "sha256:02df6bb4450348ad6b49106fd7a76dce3c00de8bf3566fb98ce1de9d74514698",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.aarch64.rpm",
+        "checksum": "sha256:acd634a7dc3792ed74a1601893a46f19f58a59660e708e360737605a575c5d8f",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.aarch64.rpm",
+        "checksum": "sha256:07bedeaa6d8151ede08990c41a0d8f1bf7b0d09ab51f4a6ab0e9d7916812f715",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a068319e368d257c407c2290becee57f0140fa4b93212da4b6e88004d82dc4d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:b8c12369c4dc364ef0070049787c916b38ac452c7699a8818a60ea28e14bb2d9",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:a12c09e4e5444f5f9be93b5021976baaa60a251c096e6e3deac2cf52efa7c3c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.aarch64.rpm",
+        "checksum": "sha256:aa44bbc06523947ec8257d5b46b03f4f3f79d590b5d93953a9199055ad8efb9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.aarch64.rpm",
+        "checksum": "sha256:74c1a7f0ca08004104c5e2025ce9dde2aae9a5f0356e7059efb8a40d26d4d715",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.aarch64.rpm",
+        "checksum": "sha256:9197fde110914580f58ef0d82d3e25feb7cae54a89b170918229c0078ca57fd7",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:692874610a3df98c1a9a6fb07eccf1724362c4c251ccca8a0732bd8ecbd3306f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.aarch64.rpm",
+        "checksum": "sha256:21d4cbbb1bb136f73fbfd299ccfd52ece986b9b9195cb80995366cdeedb81a2b",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:58dbceff7a2405a8034cd7baf0c041eadd07e0cb75c107626438ecff1c5fd9a9",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.aarch64.rpm",
+        "checksum": "sha256:bfb5ab20252ccd24774f72797aa120d17f0ac26819c52f427cf3d1ce5e9beb20",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0427a2067995038fb4fe45f6a2da4e820c0eb5c03b89bd416bf24b05386617bc",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:239b8ce52856b0da088e3cd1ef7f158e8445f964593b0790e7029f2d440c0ef8",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.aarch64.rpm",
+        "checksum": "sha256:d4996b9d9c60603ad04bc3a55ca17d6a6b414baa7b36140f2a509919a3f0636c",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:cba570790333f009110e6df66c4d86d730adacfbc3a975f6dc102df68191bea7",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.aarch64.rpm",
+        "checksum": "sha256:e7849d46d2c36958591eb826d6e853b0bae9154d270e05eadcdcd38dcf32f217",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:7aecbc13c9c581be6f47674b4ff12ba453a42e669eb21678e3b88341cf1c60ae",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:717d52dab884a42e0c346dd8d2b6f5bcb80b85703c7a208df04ff96ec4114f6f",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/n/npth-1.6-7.fc35.aarch64.rpm",
+        "checksum": "sha256:5b149eca706e4e38e1f66bc1d95e7938b23a355f2b8fafb667b55c19245e5453",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3a3336a4131cc7bffacba171c9fcbe72da873e4bf6c872a026a3c63c09fc804b",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d901ed13f67566c96988beac1b8fb66c874b9da383d0afbfb802bcf47bc25559",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.aarch64.rpm",
+        "checksum": "sha256:5c5237f1c6d6c6063f8b91194b5a7f3f52eee5e83fb267445b7a10f32aea802c",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.aarch64.rpm",
+        "checksum": "sha256:2946733fcf55e18ad7892e420c297006fd3c07fed7955deacb2a8f3d3e5b8893",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:4689184be02f5b0294a4b5c416761fdcb5ae0ed5d743f53a94e8e19337d58ccd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.aarch64.rpm",
+        "checksum": "sha256:25bdf7d234d338d590925563ce7197b2d3be3966e5fa64e3c56d40cff73338c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.aarch64.rpm",
+        "checksum": "sha256:c2d7e19729aaf214daabe35bdb6b756401ad3dd2cc8366c6e415ca4e310e7c5e",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/parted-3.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:4acee2ec5d3e97b4c133f87f908a3083acb508959162ce71b148b780dd0c28fd",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.aarch64.rpm",
+        "checksum": "sha256:004095ef6516dea7751c05caa02ab288bba7fd8a42551bb7f64030d82ac1899a",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e031556a46cc1a1157f28d566ab4072772a1fe62830eaf58b085efc33509bf15",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.aarch64.rpm",
+        "checksum": "sha256:b534577816b775d016db472fd372983d6058af05c1241bed94be4a5d7898befe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d0be85fa4bbe17218b233ea4803f964ae58a6f59ef360c4b77e782dd488c5fab",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:66d9ef6e2523b94dca3f51d94675224b973016f32388e8eaee8298427b5dcf0b",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:07fd0548f64b358ffd9ce32e885b7b91dc7e6208171d7efb9874923aead0fa5c",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:6c5f9498b18f3634aff99c8c07148876906a35357a86d473ff62f1073059a7aa",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.aarch64.rpm",
+        "checksum": "sha256:97c959173adc41a960200043e95347cb2ef9035dd7eec79d5489b11e3332a23d",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.aarch64.rpm",
+        "checksum": "sha256:6cd3fafa4f6512e3f0d317d5515d018a4ac21f0f3d50dc00651041bfe4344d84",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/popt-1.18-6.fc35.aarch64.rpm",
+        "checksum": "sha256:9faf8ecc986690f619c1180a055c964af5de6f11aecd136abea947978c2064be",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.aarch64.rpm",
+        "checksum": "sha256:3b312b89fc1d28bc4e4dd37193934e89dba98bd69908960a81c2f2c8d0c9333b",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:78ebb6ee4e81a7d4dcdeb7661eca2fcfaa0356f3d556f9414f7ffbe4b8888658",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.aarch64.rpm",
+        "checksum": "sha256:e5c152a0e0bc554550e31e6617a9f465fd7985ff163d187e18f8561d705f11cf",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.aarch64.rpm",
+        "checksum": "sha256:598bc8fb5472b531b2bdbc514110472d8d302edf7a13cbb01c4e3cd363fd67b9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:501d1c9a812d927bc37ec65f11d818fef9f0647d711f132c91c1718124c32dc4",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:69a7416ec93298b039a3f39c8b962347b78bcf70f9a16149aa288a4febc9b156",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.aarch64.rpm",
+        "checksum": "sha256:faa3c79ce573bd0eb34eed44badc961e62bc9f6967fc7d50260f8a69aeddaf3a",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:97d4da29302965059b162077189a6fb8ac54cacb09af9663dc081c984ab3ba58",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:31e3038cdc752f890970d60653b510eb815e56be7854ba627ef7843b4c760ec9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ad9c3de81c03202058ceda3038610a1f41b125cd865d2edf751d850e3ad5ffc6",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:547d25c3d92b1f5eb142ef15b96b915f2c5cae3383d260fcb8cfaeab9ec67cf6",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/readline-8.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:6e1649a57f60b421890ed42beb7a249153e3d83614d526f9b716e40364bbc625",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b2b021abebbd79fefe971f8b7082c2adc68039919ffa5022174c8501f9667859",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:976c20433f106817c253fc507a3b78065c9dd7f799007a1d020ee734dba9585c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4d607a71b40b92e26a1c2c1159b525d4ae015ed2560827e23916348a0747fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed78c4f941bf082571097d025ffa7a6c37fa99f83d4230d306f7958652bfd24f",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ec5ac10221fc169b221102debbc5573402a6c3bacfe4639d3d079602e701b31b",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:db3f70dd8aef6f93152e66c61fa0881e54e6069735da1b161800e1bfc0750816",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sed-4.8-8.fc35.aarch64.rpm",
+        "checksum": "sha256:90d662497f94084f535c50ef683fe2297dc42b4af47d078d90ebe989d1c46049",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.4",
+        "release": "5",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/shim-aa64-15.4-5.aarch64.rpm",
+        "checksum": "sha256:e7fb54bd48748b0fedf7e3f5160ac68d8d1c2d00b78eccfbc4bdc33349f75280",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:43cbfaacd7e6b3040022988d71517b6dd409466e1a7eaeeea62555069aeb25b9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:c1528292610b5ba3cb299bbdfd3cc5a7272cca8a9cf2920d651530e3b4852a88",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.aarch64.rpm",
+        "checksum": "sha256:5e427a32c68646a648d5891e486b28044e67768bc0c3429efb10ab7ba2960f66",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.aarch64.rpm",
+        "checksum": "sha256:275b8126bceb4195df605904dbb5ba02806ae112c4c3ceacdc22d2879f455f07",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:6c0a82fab048bc32a0de04512458ad268b11dc184857fd027e75e98eac2923a1",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.aarch64.rpm",
+        "checksum": "sha256:9b4791e619b22fd597c4b6ff99d9baf7a13f9d4ee808838f5517b32b5a4fc1c9",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ac0672e9d9539e34e5f6e2e6d9cfeb372f00204c5e38a3c132aaff31effde541",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:55aef5a0e2bb5ab271f48b3a655ad044e6368864531a2d07f5c9d345d322d6ee",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9dd8674e7f7a04b8bfc73bb61041730d535694bae2eaf60fb34addfebcfda126",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/which-2.21-27.fc35.aarch64.rpm",
+        "checksum": "sha256:729e7e662448d335680668ce7b8589e0daebd1bf915fe5a8a14ba676d92812dd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:d96eb3eab79c75682945adb17bae7771b402b7aef85afd9be8ff55ef636cbd2b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.aarch64.rpm",
+        "checksum": "sha256:20201e1d53164068ea9d4d24e715a8599669bdbfc4eb7abd76c63c29c364315a",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f4188ea8b876d9f7dddd8afa286b38ec70763ef99aaae54216ba5912a0e5ef0b",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.aarch64.rpm",
+        "checksum": "sha256:bfc31baa978daa7de870528c35cab5cd859d66338551ff617ffc4f7444d731fd",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:123459d742f5343cb23b007c090828982bb965e849dcba248c9d3c04204488a8",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4392b159222783a493e748bcf893eef130c82f0d5f26d00f21f949f923e1d66f",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0618493f5f46192445bb81f3ad07ed804c92aa4fe19d41b851be6a0138423e85",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:2ca9bef2d48b3ca4abd2c998d36f9b4e5b93997ac222a77fbf34852e914cf366",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:806fd542fc627df2c9dd0c2975e5a69f415986859e3f1585e91f2addf0ae6d0c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:f5e1f5983cdb59008647a4134e36d7c4b3d7f592cb8ea0402e1efea97bc47ad6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.aarch64.rpm",
+        "checksum": "sha256:93ef166ef633109718d61c580210a47a65a21eb8a178a11dd7bc577706595e27",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bf57a50119e2894e2dced373388c07bc7d763c96f73636232a5487831c226b65",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:5e278a4763f2b324d6b198cb04aa274cd8a6e6db10ac318290f369698540a1de",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fcd30d838e6922a11ca9a93fa3c926af765c0b13792c2057d34906b486d61df4",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6e6fea83855790e832bf37e3a28b7a337eaca8b95f16abf6f954a980dbf51d91",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.aarch64.rpm",
+        "checksum": "sha256:9280826c888d52a8b332bb5c57684db612f93a804370aa38b2c4026b83989973",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:b2ad7d4287eb6d485864724884128b6aa15710216aefdbb1215a1a4377bfb1b5",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:4fb9e08ae6ad77ed4a210e6b98a512d40c02fe0ef7a1af551911568a3c790abf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:f9954eee9049c60d915c5c3cf34ca83770af7b0d433f12e9773d434e70391028",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.aarch64.rpm",
+        "checksum": "sha256:92a7d484c50d9e5a4201433219a9427bd0dccb006bd6d06628b5b104c2a86d74",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d5376af71be6916bf2c2fec42611bcdb83d7c085074946a583846b5f6bb84f9",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:fb75dd64266d16bd622c8a764c3f327f1a03c665f21d23eabb390ef2fe81be97",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:cf476abc761d662d3d6ade6511dbdb244e793bc725c762297a704cd0720a42b6",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-efi-aa64-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:9d31bbde3f8a512ac32be4e26a5563252c4b609601b476754f89880c1cbfa5e4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:dc18ce2bc247e72e158d295f8a7edd7cbe7ecacdfcf4583a48a2c2bfd5930014",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.aarch64.rpm",
+        "checksum": "sha256:0e4fa725403ebbba28413e25712bf6f359e6ae2073cc2b422d5b351cec81e07d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:7544992457deba7879032a76119e9d274e5709145a3e942677268f017d86a94a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:1312be3ee5c11972af6405a951f70fdbfdd86a022d67227ca4c20d7d4e32f25f",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.aarch64.rpm",
+        "checksum": "sha256:271ac1a74698c8d1d66c0d1965b7282ed097deda63ad3410a14d77536348d6bd",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/less-590-2.fc35.aarch64.rpm",
+        "checksum": "sha256:37f696cfe38d94fda21598acbef6cef5b48ddfb464b60c9a2e59752028a77a97",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:b94a1a763db7e2cf02587ad25ef72eac736544461ed2f22014ff313d2bb9675b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.aarch64.rpm",
+        "checksum": "sha256:01c4eedbedec34f5413a98f2dae6a84466270a71aceb647206e84e64b452ed96",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:52c81050d29a38a78a2bf63dead7eea7ca2c842460b7d7a578d17902eae13b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.aarch64.rpm",
+        "checksum": "sha256:d139c9ee675f39aaac868502a21d923ea4505299d89354380a8c17f3bc8c67fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7736b3090875b4051737244506872d85744f1a3382a1280777701193e9c79a29",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:06fdbea513b43796d5178d3898dceeee85d6dade9e7d39f10a02a859d9c9b1eb",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c81703b4e8290b80833260448e75a86f9db5a1b86d014995c58213cdbbbb464c",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:f3dffbe0794bbcb59ce0765a7c9befae47090b2dae3aca07a68b4cb01ff6ac54",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f9a59772da3fd797b4a6bfcc901b4f7a223a0c024c35200a604e9ad749f5d70",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:19d9fffc34128931f9ed675882c0077265610baae9a55e27c87f8d23ad60a99c",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:772fb61aaafed609656743b3f61f44b339388840a6683fba6e1faf327cce7853",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ae73dc8a1cf3dfa34beda5f3fabbebb5e3f6c00b1c51504fa3616d2c10a7c48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4125de6dc120f32cc50d4179097dceab7c953aadf1c87bc25d53e815b41fb05a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8e317a964dbda3c7869f11a9edb2795de809c68bd501886a5ea00720a8e9663d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.aarch64.rpm",
+        "checksum": "sha256:3c88aa4ab16afbbf386b97946c7cf90b0c709fcf1ee9c0558b062ccfe882beff",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:3a25a14f5e1497712781b1077c6802177a21bf17ae37e61eacf248973d4915a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:95f7175eef2c9e253e956556cf53c2beb3b68819e257cfab23b830a609184478",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:191ae76897f1f7ca61aaf2b36eb40e39b23ff0422716b6c347e7ec1f8ca39207",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4f3f91278bc44c4ccc67914df53bc7e8f0446ef485829ebadbde6980279a1e3b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7793551566ff4e9da00b57186a23c575d6e1619f594811dd387c142c371f0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.aarch64.rpm",
+        "checksum": "sha256:7aa7e422671982db63e03d2cf269896cbef8d1099234c407d33574470b3d493c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.aarch64.rpm",
+        "checksum": "sha256:bebed1edf9e0e70d528b8e75c8a1491d7a6f106f74778f15dbb192031b792cd1",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.aarch64.rpm",
+        "checksum": "sha256:f33aba03b4f2dbd4a98dd8614f2671f502611b0f93f90d475fd53c5e22d76d51",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.aarch64.rpm",
+        "checksum": "sha256:990744fc632c8d45420e2ccc900e497cfbbec26ce7649c19b2c89979655815ff",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.aarch64.rpm",
+        "checksum": "sha256:6b701fef01c2570fb0be53aa7c3a0fec224b2592b72799161a6204315900dc73",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.5.0",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/m/mokutil-0.5.0-1.fc35.aarch64.rpm",
+        "checksum": "sha256:c3e027a522363aa11accce1dac0a3043e0c968e2c457928cc6fbf8dcb3db0b34",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:06a4b4ed547ece5914288c8cb4f3a833069b8f8e8b3c78039fdd534c5f865b14",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:c6adf6fa6bb0e146d3d8632fbf7f277106184f057501aaa23fd7e85c177aecc5",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:09d42a79c265c1a794e89e98ca1aa1c92269501024f7f487f338579869f48c06",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:eed56e545c1e97c0429072f110150359713b8800c8a07646da2376936b811773",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.aarch64.rpm",
+        "checksum": "sha256:02a906e19374adcbd135a50828615cacdbd42e10f75cffa3a9441474690f7273",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.aarch64.rpm",
+        "checksum": "sha256:ed904ac491e7fc6d7ae6ee4990dea6d6e78401d1fc5f00cdf011204d8e9eb169",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.aarch64.rpm",
+        "checksum": "sha256:e9b13012f585963cb952187ae60f3540fbb3ece5ca49ba06b566cbffa93a5299",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:4bb583772441ca1a6a391b99f896f0ca5eb803c3e641eb49f0eb85680f7acdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.aarch64.rpm",
+        "checksum": "sha256:0e1a4f7b2061028918a39814e2b19e62979be2e247c26611db6733b53d0200f4",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:4d7649158fcd18f0b6cbaea54cf335886b705f674c01929e1a0ed1780adecbe3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.aarch64.rpm",
+        "checksum": "sha256:6be831a868d50842bf5aa654d4efd0f25b16e5361697c78fcadd0832736be4f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.aarch64.rpm",
+        "checksum": "sha256:f9942c3160fd9dbc9a7aac40d8497013c44a866b13d1ce3092a4ad916fa3dcbb",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:11fa92a91e4e359a2ecd450f6e362e28bfe9056a6cc6bf7efb448a66e785c858",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.aarch64.rpm",
+        "checksum": "sha256:307e69f3024cf95970f93fb94ebc6943f0e6de7cbaee0330f928906a88b19804",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:24ae2cc8d5b72698ff3f7644a651ac5c9ed12baab18efff6539ec2acfb46fe95",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:8ddc27244c565717c790c1af52221d69ce46272b3086c88f77168af0b89075ac",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:782e972353d12b14633a61562fb590488c1787eb2622c0fa2dd7166935a7c68d",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.aarch64.rpm",
+        "checksum": "sha256:94b2153747d3cd7b6450a0e22d7ed33ddba60957dc8f832ff34309249fcf42ad",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8677a1d7a1dc1ce429c2806da4f35e240a9dffe56fe911005c36afd0db5f78bf",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:8317ac46b69a8d3ed0184197a9e32878df985cf69a25613a2169a67421e105b7",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:d3df3d924aab1952e4246541841bdd6a89470ed142154fd005e355856a77b4fa",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:2536061f95e8adca628e0cc96eb45d95aed32c141eeb7993fc39bdf2493a05e5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:a7276e1adb193eb372af4b843ff3d8b9a9793a97b5d238b73cc8943541cacffb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.aarch64.rpm",
+        "checksum": "sha256:917840022e753cd6a7163a8764ec3bd61e5fbf613cb4936a4b63e6a6959886e2",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.aarch64.rpm",
+        "checksum": "sha256:b9801b26410bac86e0258413b49dd74b7088d8e5d05ee728bd0c2d392f85464f",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:097de2cb18e9011f37bf4fb4f093346ef1d786cdda1663b5ba9a66a977ac4ffe",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-aarch64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm",
+        "checksum": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_35-x86_64-armsysready-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-armsysready-boot.json
@@ -1,0 +1,10311 @@
+{
+  "compose-request": {
+    "distro": "fedora-35",
+    "arch": "x86_64",
+    "image-type": "armsysready",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-modular-20220106/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-modular-20220113/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "armsysready.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora35",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d85a31b893836536f151d1697cb4c693ff1c0445df84c3471d3d721f25c04d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d17182f998b2e5b2c11c97b03ac5c0a1924b7d66c6ee3a539357d8a923fdfc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8266ce704418cde8abe89215dc55aee64a37b4a273aa639ceb8d07c7f7e1c67d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f140ad437bba386c948ac0a37cd6c1119383fba4a42eb78214927a79e4e0d535",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d477896ce7c50c8ab915a4e0a95b462fbadb4a05a1dad5597899005f33b5315",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:086e4f8ca49ea270b2e8b12ef81b7b33815e614e5ad9a99cd28fecae864904ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:011444abd567c69e6fc589e7d74c883ae0749df41b6c3c460b97292bc5fe69ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90b4501a932693c1bed585b809ab15dca10edf4ecd0eadb34663ddba04ce89af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2bf24657611e4f1e988e55b24904d60abff918981e7cd1772bce29b116ab274",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:022cf3dbbd9dd9d3362c0bc6a42ea219c29abe1b22bcaf0972943b73abfa0550",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f693a388244b30744d1c219b26e00f5044c8f5e396a2a2dd3ce35864e646fe30",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6271b15b3b82e339216dec104060b6aac4a635c71ecc2517897684f021af3115",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1163282c68d42bed61523230431dc06e97c630f6f1e694e2f39bd1b53de5b00",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70d7f22b24741ce3a874646f46e111fc6f450433da2e50a4721a686891c2c36b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c318ea2de3bcf9f76bb541eb62fdd38640906d4691f87f3d6a6cc6452e1b973c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "legacy": "i386-pc",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.15.13-200.fc35.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "armsysready.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "armsysready.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "ext4"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm"
+          },
+          "sha256:011444abd567c69e6fc589e7d74c883ae0749df41b6c3c460b97292bc5fe69ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm"
+          },
+          "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.x86_64.rpm"
+          },
+          "sha256:022cf3dbbd9dd9d3362c0bc6a42ea219c29abe1b22bcaf0972943b73abfa0550": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm"
+          },
+          "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm"
+          },
+          "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm"
+          },
+          "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:086e4f8ca49ea270b2e8b12ef81b7b33815e614e5ad9a99cd28fecae864904ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm"
+          },
+          "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm"
+          },
+          "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm"
+          },
+          "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm"
+          },
+          "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm"
+          },
+          "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm"
+          },
+          "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.x86_64.rpm"
+          },
+          "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.x86_64.rpm"
+          },
+          "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm"
+          },
+          "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm"
+          },
+          "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.x86_64.rpm"
+          },
+          "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm"
+          },
+          "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm"
+          },
+          "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm"
+          },
+          "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm"
+          },
+          "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm"
+          },
+          "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.x86_64.rpm"
+          },
+          "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm"
+          },
+          "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.x86_64.rpm"
+          },
+          "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm"
+          },
+          "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm"
+          },
+          "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm"
+          },
+          "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm"
+          },
+          "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm"
+          },
+          "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm"
+          },
+          "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.x86_64.rpm"
+          },
+          "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.x86_64.rpm"
+          },
+          "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm"
+          },
+          "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm"
+          },
+          "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.x86_64.rpm"
+          },
+          "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.x86_64.rpm"
+          },
+          "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.x86_64.rpm"
+          },
+          "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm"
+          },
+          "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm"
+          },
+          "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm"
+          },
+          "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm"
+          },
+          "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm"
+          },
+          "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm"
+          },
+          "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm"
+          },
+          "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm"
+          },
+          "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/less-590-2.fc35.x86_64.rpm"
+          },
+          "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm"
+          },
+          "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm"
+          },
+          "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.x86_64.rpm"
+          },
+          "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm"
+          },
+          "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm"
+          },
+          "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm"
+          },
+          "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm"
+          },
+          "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.x86_64.rpm"
+          },
+          "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm"
+          },
+          "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm"
+          },
+          "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm"
+          },
+          "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm"
+          },
+          "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.x86_64.rpm"
+          },
+          "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm"
+          },
+          "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm"
+          },
+          "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm"
+          },
+          "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm"
+          },
+          "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm"
+          },
+          "sha256:6271b15b3b82e339216dec104060b6aac4a635c71ecc2517897684f021af3115": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm"
+          },
+          "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm"
+          },
+          "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm"
+          },
+          "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm"
+          },
+          "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm"
+          },
+          "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm"
+          },
+          "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm"
+          },
+          "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm"
+          },
+          "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:70d7f22b24741ce3a874646f46e111fc6f450433da2e50a4721a686891c2c36b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.x86_64.rpm"
+          },
+          "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.x86_64.rpm"
+          },
+          "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm"
+          },
+          "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.x86_64.rpm"
+          },
+          "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:7d17182f998b2e5b2c11c97b03ac5c0a1924b7d66c6ee3a539357d8a923fdfc7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.x86_64.rpm"
+          },
+          "sha256:7d477896ce7c50c8ab915a4e0a95b462fbadb4a05a1dad5597899005f33b5315": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:7d85a31b893836536f151d1697cb4c693ff1c0445df84c3471d3d721f25c04d8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm"
+          },
+          "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm"
+          },
+          "sha256:8266ce704418cde8abe89215dc55aee64a37b4a273aa639ceb8d07c7f7e1c67d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.x86_64.rpm"
+          },
+          "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm"
+          },
+          "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm"
+          },
+          "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm"
+          },
+          "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm"
+          },
+          "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.x86_64.rpm"
+          },
+          "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm"
+          },
+          "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm"
+          },
+          "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm"
+          },
+          "sha256:90b4501a932693c1bed585b809ab15dca10edf4ecd0eadb34663ddba04ce89af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm"
+          },
+          "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/parted-3.4-6.fc35.x86_64.rpm"
+          },
+          "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm"
+          },
+          "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.x86_64.rpm"
+          },
+          "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm"
+          },
+          "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm"
+          },
+          "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm"
+          },
+          "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm"
+          },
+          "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm"
+          },
+          "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm"
+          },
+          "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.x86_64.rpm"
+          },
+          "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm"
+          },
+          "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm"
+          },
+          "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm"
+          },
+          "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm"
+          },
+          "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.x86_64.rpm"
+          },
+          "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm"
+          },
+          "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm"
+          },
+          "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm"
+          },
+          "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm"
+          },
+          "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm"
+          },
+          "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm"
+          },
+          "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm"
+          },
+          "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.x86_64.rpm"
+          },
+          "sha256:b1163282c68d42bed61523230431dc06e97c630f6f1e694e2f39bd1b53de5b00": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.x86_64.rpm"
+          },
+          "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm"
+          },
+          "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm"
+          },
+          "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm"
+          },
+          "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm"
+          },
+          "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm"
+          },
+          "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm"
+          },
+          "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm"
+          },
+          "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm"
+          },
+          "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.x86_64.rpm"
+          },
+          "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm"
+          },
+          "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.x86_64.rpm"
+          },
+          "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm"
+          },
+          "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm"
+          },
+          "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm"
+          },
+          "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.x86_64.rpm"
+          },
+          "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm"
+          },
+          "sha256:c2bf24657611e4f1e988e55b24904d60abff918981e7cd1772bce29b116ab274": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm"
+          },
+          "sha256:c318ea2de3bcf9f76bb541eb62fdd38640906d4691f87f3d6a6cc6452e1b973c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm"
+          },
+          "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm"
+          },
+          "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm"
+          },
+          "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm"
+          },
+          "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm"
+          },
+          "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm"
+          },
+          "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm"
+          },
+          "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm"
+          },
+          "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm"
+          },
+          "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.x86_64.rpm"
+          },
+          "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.x86_64.rpm"
+          },
+          "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm"
+          },
+          "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm"
+          },
+          "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm"
+          },
+          "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm"
+          },
+          "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm"
+          },
+          "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm"
+          },
+          "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm"
+          },
+          "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm"
+          },
+          "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm"
+          },
+          "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm"
+          },
+          "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm"
+          },
+          "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm"
+          },
+          "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm"
+          },
+          "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm"
+          },
+          "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.x86_64.rpm"
+          },
+          "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm"
+          },
+          "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm"
+          },
+          "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm"
+          },
+          "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm"
+          },
+          "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm"
+          },
+          "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm"
+          },
+          "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm"
+          },
+          "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm"
+          },
+          "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm"
+          },
+          "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm"
+          },
+          "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm"
+          },
+          "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm"
+          },
+          "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm"
+          },
+          "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.x86_64.rpm"
+          },
+          "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm"
+          },
+          "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm"
+          },
+          "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm"
+          },
+          "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.x86_64.rpm"
+          },
+          "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm"
+          },
+          "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm"
+          },
+          "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm"
+          },
+          "sha256:f140ad437bba386c948ac0a37cd6c1119383fba4a42eb78214927a79e4e0d535": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm"
+          },
+          "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.x86_64.rpm"
+          },
+          "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm"
+          },
+          "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.x86_64.rpm"
+          },
+          "sha256:f693a388244b30744d1c219b26e00f5044c8f5e396a2a2dd3ce35864e646fe30": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.x86_64.rpm"
+          },
+          "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm"
+          },
+          "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm"
+          },
+          "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm"
+          },
+          "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.x86_64.rpm"
+          },
+          "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm"
+          },
+          "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "acl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/acl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07a1a82a73780fcf0ccba17e3aa8f7f3b7e014a6366bc9b5f5f4cecbb1ce0f71",
+        "check_gpg": true
+      },
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/alternatives-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:34bd270c903f503eb79b4cd30a5f68e9299458b43209479aafe5b229eb87da1b",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:537bbb4888324722c268e61e55507c49cdf332562b6106599aa62993c395cbda",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/a/audit-libs-3.0.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:45d4fceb8d135aeecc100c376d97f35382dc06347bf9a675a179174d4b06f38b",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "12.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/basesystem-11-12.fc35.noarch.rpm",
+        "checksum": "sha256:8e16674a8f308d03f9e1cd606bbfa392026cdb0f53b96da82a062d735e16feb1",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bash-5.1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:4b835e88a180c6fcc7f86d4b36695e4cfbf39f811c478588efdf07ec1fcaf271",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/b/bzip2-libs-1.0.8-9.fc35.x86_64.rpm",
+        "checksum": "sha256:94fbb4fe736ac33ed3fca9cc390436513ea4e25c4418c8fef71dd0841e08fed1",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/c-ares-1.17.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:42510fc2fc78334ce4ff5e01c1776ae19d8ff856ab532b52596bd1fedd488f5b",
+        "check_gpg": true
+      },
+      {
+        "name": "chkconfig",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/chkconfig-1.19-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2fdb91587fb70d5835cec683d1033a5c59069d6dc8f1ac462d1cd1c388174a04",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:8d9b1e4345d1e2671b92bffa0793a0bf1fa974a11b573ac237ac58f988eaf63d",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "8.32",
+        "release": "31.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/coreutils-common-8.32-31.fc35.x86_64.rpm",
+        "checksum": "sha256:50d4a29b455607e31575beb7d6606964253f249c6567d382e03d9876cebbd694",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cpio-2.13-11.fc35.x86_64.rpm",
+        "checksum": "sha256:85b1803bf167f76f9f12f2cc99ebb0715dfd4e80d867de351897f3969e5da92d",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:aa77d91834fdc0df69977e7662b315edb44a9dd5694a103e1aae773c41dfb038",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cracklib-dicts-2.9.6-27.fc35.x86_64.rpm",
+        "checksum": "sha256:dff5837ed139df9d8f468045a6992d644ed5209ab64c3ba68154b581a87e73b4",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:aca3c419c09018bc287cd054490fbc600d1d59ac48f247f9c63744bdf8ef5e3a",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20210819",
+        "release": "1.gitd0fdcfb.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/crypto-policies-scripts-20210819-1.gitd0fdcfb.fc35.noarch.rpm",
+        "checksum": "sha256:adffb27a1b8f618fc8c84ae984e571384eb7aa3630c722e5720a42244b33943a",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/c/cyrus-sasl-lib-2.1.27-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e5e796389161f7c49e81c5fd661d547861689fe63ca98088e09d6970e6c8660c",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:ae77e4a5d01e9e4d33b4a9f27cdeece9cba2d3e765bb4f92482ff1f20ea26d96",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-broker-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:773981783941ae374eafe1d2b3d7dd37c9e5c1857b13b37958d6e2f93f9cc5d6",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-common-1.12.20-5.fc35.noarch.rpm",
+        "checksum": "sha256:f4f60e9a17e89b849177af818573557f7767d92d9167a7e56107789185d763c0",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.12.20",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dbus-libs-1.12.20-5.fc35.x86_64.rpm",
+        "checksum": "sha256:e40c9d60943ad38157a3b49dead686edff41e14644c75d73ad2dbc0ac54fdffe",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/deltarpm-3.6.2-10.fc35.x86_64.rpm",
+        "checksum": "sha256:b6bd98d2c8e9477651052f738d741abe2c6220eee0ecbda9a39b971eddbeae7f",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:3c333cd6f38ecba5c443cb736371b377574c82906d4c7bf3af510e2ee517d77c",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/device-mapper-libs-1.02.175-6.fc35.x86_64.rpm",
+        "checksum": "sha256:62109e2dece864e85051c1c63d9eeceba946339a7949b5328300b4dcaf6b67f2",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-client-4.4.2-16.b1.fc35.x86_64.rpm",
+        "checksum": "sha256:3681a2bfa9526b157a63bf8876db3b7e7bdf77158f8045fb073c5987aa4ef860",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.2",
+        "release": "16.b1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dhcp-common-4.4.2-16.b1.fc35.noarch.rpm",
+        "checksum": "sha256:6a891516c367d27ad41cf3ab8fa0482de4a0276fa50fc77de6104abf45165e60",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/diffutils-3.8-1.fc35.x86_64.rpm",
+        "checksum": "sha256:52598fdd27be8d3ca7587b81ce86f03d1f17c66c0c8fd81ca3274cb7712a400e",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:bdd8ac8d916149edaaa5790d444e9b18f9679854e06add58f3693e5500adbb56",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dnf-data-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:a206d0ea77ae99368f6230f0337ffa0b5f4e4549f0d362f55abbae3aaf7e3adc",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/d/dosfstools-4.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ecd02f2a2fb547997c394c73642da7322670d4b64f51156f5e31661d61ed16a9",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e99f5ce0f6d485bb5f8de26507df2a3b93fb5d5f863848f2291b230379a7652c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/e2fsprogs-libs-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:24be2086b7d8f76b2c1793fe2852a3b93a58223510f454bb44f078e59c1ab8ce",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/e/expat-2.4.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:07044e883bcacedfa436448ce35dcbd67ff16aa1508a60395b59a3e37b71b946",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-gpg-keys-35-1.noarch.rpm",
+        "checksum": "sha256:52040f71864e67b462d278d040cdae3caba482526fe9b609a70ef4d0af2b7fd0",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-35-1.noarch.rpm",
+        "checksum": "sha256:b5f2885bc25152bbc93c229098850aa59fe37e431926bfd95be47952f6f3daa5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "35",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fedora-repos-modular-35-1.noarch.rpm",
+        "checksum": "sha256:5ececfb7e3ce5b2d7b888031f862cf920d0623de504746d78bdfebb6cb74e9ea",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:ba396eb1e69f816edf3ba9242f00952c76b6310a40ee5686bff97724fdc52dea",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.40",
+        "release": "9.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/file-libs-5.40-9.fc35.x86_64.rpm",
+        "checksum": "sha256:67ae1e904186c117e620be046ab982b7365627ef8442653c9f082d6a49354ede",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.14",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/filesystem-3.14-7.fc35.x86_64.rpm",
+        "checksum": "sha256:2c0246c154bbbc677cddf23f4cb24d4dfb4b664bad8505caac4d62a21ed19482",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.8.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/findutils-4.8.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:6f3ba23f7a356302ed0b1fd907d7a7528a22173e0a243cb84c0c8e26fa742b59",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:38e27cb16046f697cc5900913f62112b91d2656514642b3594ee0c99cceb7bfc",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/firewalld-filesystem-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:4d3bbd647f56bd0bd8f44cf473b9034e2c682d5c095f88f78cd29699d5e82a65",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/f/fuse-libs-2.9.9-13.fc35.x86_64.rpm",
+        "checksum": "sha256:e2d431a5c88e4728cb10ce9e327e3b16f24241eebce173f9bfdfde65a730df18",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d3b8c4e20ea36a5f86e861924424802269e9e920cdedd52648228965ac27c390",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gawk-all-langpacks-5.1.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e04fd1384f900dfc5e8422348e590c57cf18fef0e8339b22312826f8014bb3db",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-city-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:47073336fc560a28cd2b11f6c8f3fead340a4f443494d2178afcce534b28c7a3",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "5.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/geolite2-country-20191217-5.fc35.noarch.rpm",
+        "checksum": "sha256:824f0a1ef06204d74a8a3c5a72f31a0bb1a0bf117fe6a0e043305f8cfade634a",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:834213c4c6cfaba97cd605a0d70c0758ea90f463ee1399843d7094a91423b22d",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gettext-libs-0.21-8.fc35.x86_64.rpm",
+        "checksum": "sha256:fc9dfd184ac10ad2051df15ee51925a95e7144004214389e79d9abc6c1dc034e",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.0",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gmp-6.2.0-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b611c0c9d88af94c23de20547434ffed7b36f06f16aa265dd09b41e0b325d88b",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gnutls-3.7.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2bf547e003189b46efe384c47809bae23a86838103e29e872ebff698f5ff2ab9",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.70.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gobject-introspection-1.70.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7d85a31b893836536f151d1697cb4c693ff1c0445df84c3471d3d721f25c04d8",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.6",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grep-3.6-4.fc35.x86_64.rpm",
+        "checksum": "sha256:df829e7ce9de4183cf1750e3d305d901daa1b39975fbf797699b58bcd7c46824",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/groff-base-1.22.4-8.fc35.x86_64.rpm",
+        "checksum": "sha256:95c00ff3e832f2f89925eff9007fecfdcb5a85d22cd81aeb2897575c58d7b464",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "55.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/grubby-8.40-55.fc35.x86_64.rpm",
+        "checksum": "sha256:c1447e6ba83c7ea1faad6370f831c9b0adaa85d912727d165dfec32735f6fff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.10",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/g/gzip-1.10-5.fc35.x86_64.rpm",
+        "checksum": "sha256:cbdcf7c925da2e9a6eda1ec4ca4d478afa7fb6ef45bc852b2b822e09e12ea242",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/h/hostname-3.23-5.fc35.x86_64.rpm",
+        "checksum": "sha256:154cb55953505aee6e0546b7b1496a742ad1d01ae59262e1bd3dd473040903ff",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ima-evm-utils-1.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3080cbabcb524774e1382b0f9a9c9c77ee0ef596548e9c84106b3d2427edfb83",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-10.11-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1543cae4d98b7e701c42218004ead3680f01b403a3694dcd56ab504e715690a8",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.11",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/initscripts-service-10.11-1.fc35.noarch.rpm",
+        "checksum": "sha256:403ee2f247d7465ba65e61565b0d0642bb25d24eddc52b19c2314631754a303e",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipcalc-1.0.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f9583368a339e13987f4cd287883661c5c08c4ddf29734cd84b7434d2959321",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:6d714a00ad0f50d11149f199390440caed8765dd417b480816f21724bb9ad76f",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute-tc",
+        "epoch": 0,
+        "version": "5.13.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iproute-tc-5.13.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:3e342a4cf63be7ea0fde629a074e71b1caa29c0cfb387b14aaf39451cb7e1cb1",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-7.15-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7d17182f998b2e5b2c11c97b03ac5c0a1924b7d66c6ee3a539357d8a923fdfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/ipset-libs-7.15-1.fc35.x86_64.rpm",
+        "checksum": "sha256:8266ce704418cde8abe89215dc55aee64a37b4a273aa639ceb8d07c7f7e1c67d",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-legacy-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-legacy-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ba3fbb5e9b38246912ce8d95b477d56d120b9f4a01f8d841cda965f6d30988",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-libs-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f2ec557ec85dcaebfbe1e464c68cd5dd826190e3d9a1456c028e2bd1ea7f1c53",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "13.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iptables-nft-1.8.7-13.fc35.x86_64.rpm",
+        "checksum": "sha256:f140ad437bba386c948ac0a37cd6c1119383fba4a42eb78214927a79e4e0d535",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20210722",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/i/iputils-20210722-1.fc35.x86_64.rpm",
+        "checksum": "sha256:257cfc8c56a77471d8cff02ef7f7c4709676a49a564c0e7538d4eef02532634a",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/jansson-2.13.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:7d477896ce7c50c8ab915a4e0a95b462fbadb4a05a1dad5597899005f33b5315",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/j/json-c-0.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:e16c5692328637471d3a27dd6e57fe6d329b5028be22db6b8abaffedc75a1898",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-2.4.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:ac07468ece00f068f03c935a0453283c55e47dfc73be89f47a3dea903b7ab22d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "8.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kbd-misc-2.4.0-8.fc35.noarch.rpm",
+        "checksum": "sha256:9d003094761dd276481509e29e08198d3f04f58f9baa1fa566bc6085903313e3",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/keyutils-libs-1.6.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:36256910d28df38bff83b76e65fdc040fcc1c5cb26c051826bc98a7b65b48f8c",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:96440b7c2af6e0279acb417de9f83ddcb39d6e58ad6f81732d2c22ac814401ee",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kmod-libs-29-4.fc35.x86_64.rpm",
+        "checksum": "sha256:05b07c7bc2db206aba6f081e9f62f71e7829bda62f947d5c5bac949c1563fa5a",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.6",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/kpartx-0.8.6-5.fc35.x86_64.rpm",
+        "checksum": "sha256:427389e52a53ad0703940b8f11e5cd7088a7f17b03add22c01a07c150f7dc6dd",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/k/krb5-libs-1.19.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06c540d359929d9e75bab498a203e754d10c5669469a3b74e38e22106932656e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libacl-2.3.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:61b871106c1835138c4731fcc1ac17aa08074395b2e93339311e554908b774a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libarchive-3.5.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f18f95bb02e8c23e1d2bf16b377c44171f46d0418501ad07d90d0457a2090655",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libargon2-20171227-7.fc35.x86_64.rpm",
+        "checksum": "sha256:b80753249f4c81f711718327fd19e01daa84ff6455ddabcc5d5465a2b2976b67",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libassuan-2.5.5-3.fc35.x86_64.rpm",
+        "checksum": "sha256:16209f762462b8e819d804b0468aa66377b49d654917c13cb0808b2ef390e9d5",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libattr-2.5.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:43fc0f9e9ef9d8b4df077c41d740726b9c151a294b32330a4f19b98c2416e36e",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbasicobjects-0.1.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:361c435856f76b6e2e112534c0592ba1021490e38ff37ef93926f95733dc3da5",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libblkid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee0cb8b7ec1491aacc7940e1d7ced1e274682a283cc63ea4de1ef0ff8acd3f11",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libbrotli-1.0.9-6.fc35.x86_64.rpm",
+        "checksum": "sha256:4b5230e2c9c7e9665539181914e5978e535130f2c5616f686baa2ae5844dfca5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcap-2.48-3.fc35.x86_64.rpm",
+        "checksum": "sha256:d4e68847d7ba9b387abdbba60fbb0e7c15e4e5389e0b1d80021a89430e18cf45",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcbor-0.7.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d833e17b640e9c8e2c77faa38cb19fed867874754f8998e55b04f0615a221a1e",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcollection-0.7.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:ecc39f8297bdbe5d797d8c02a530d576ab1c39448c2c6e2c278f3458489d22e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcom_err-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d36c8398c78beb70f91b08774d309645e658e91caa8a425c4aa28b58919a2414",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:29b6829bf0aca7f8e618c4273f31b997ad9a5adfda37e51fe1db979c78f2e73e",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "50.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdb-5.3.28-50.fc35.x86_64.rpm",
+        "checksum": "sha256:63fe7aeec28feb0411fc2b0bc6ebb791ea5a372b96974a7fdb75b95666993eab",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdhash-0.5.0-48.fc35.x86_64.rpm",
+        "checksum": "sha256:b86188f018b8ee782fa4df439c15bf8dc78443a0f95c7a144871c6ed5904d9ae",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:372cb9bd8cb4a5de6fdc25022131b273be0596898bde8c2a3f52b14709705b76",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libeconf-0.4.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ee010fd337ef64907285c3cefb87df50b8bd092e3be6006327b4fa232b9a8fea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "40.20210910cvs.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libedit-3.1-40.20210910cvs.fc35.x86_64.rpm",
+        "checksum": "sha256:492a776ef88d62abcc7ade5a4998d44663981d72af87bc30f8cc866ffbc4d4c1",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libevent-2.1.12-4.fc35.x86_64.rpm",
+        "checksum": "sha256:d289cbd74ec66e80b23058ab4adb60349371eea2645f5194e1f27f11f61e6a8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfdisk-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:72302207c823e27d93b9cf6eddef76ae0d73b71922d02c92578308c430a9ae03",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "29.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libffi-3.1-29.fc35.x86_64.rpm",
+        "checksum": "sha256:24197bbef00869336592ca4a672c99e31c1ba589b4c6f32f7c329d1430ac16f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.8.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libfido2-1.8.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2706fac0d312be173d045cf8ae230791f77f7fed69f08242183d45ff0f679280",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.9.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libgcrypt-1.9.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:10913f9517c7d232190081d6a70b2bc2cd3416726029d3e90b6b3fea7462c7e6",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libidn2-2.3.2-3.fc35.x86_64.rpm",
+        "checksum": "sha256:ef459db382fdcbe854b6facb0c8398125b6c60a7e77a7c45c521599bf4db120a",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libini_config-1.3.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:1f4684fd8720319d2baa1bdad8a5ee6cf2484acb1368fd5e0bc6be8c5126bb79",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9955e23035ba6369d602cd8a7c2b0d19e41cedcb898e2b047e6ca5ecf69b2fc4",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libkcapi-hmaccalc-1.3.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:b7d994e1ff59c38ffd752f2c2f1797516a6e14823f12609f30f3e9b87a3bdc1c",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libksba-1.6.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ce976a2b18cf4096e711201429e826b38fb69cbfbc7f7fd7f2e1addc2f7c2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmnl-1.0.4-14.fc35.x86_64.rpm",
+        "checksum": "sha256:eefb89e40edd33bdce33983423e40682b4672e0ede42da3a33be17b6d57e4067",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.13.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmodulemd-2.13.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:f858519a1c1fd8f02ef9ac631d3f5096f996f71a6315fbf48a4124ca01de001e",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libmount-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6c22d0835b6259a02f23c3bd46cee7c042b96c2d8a231be5287fc2335ca7432a",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libndp-1.8-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9ffcca99e2ca01870a82cda02fa484c7ff85d054b277e02910df05ab292cda83",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnetfilter_conntrack-1.0.8-3.fc35.x86_64.rpm",
+        "checksum": "sha256:2324289e2fa73baaa2d28b12b6a7f523ef5ef6c956bfa84ef8c0b4da866d3592",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfnetlink-1.0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:8a510e37acc96dc2462243ea530ba77ed2e6b16964b0737c4f9fa883ff36aa07",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfsidmap",
+        "epoch": 1,
+        "version": "2.5.4",
+        "release": "2.rc3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnfsidmap-2.5.4-2.rc3.fc35.x86_64.rpm",
+        "checksum": "sha256:2e76f51592fe919f3583063e9548c665d2cd0688f5abe3e3d9eb2711271d5d6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnftnl-1.2.0-2.fc35.x86_64.rpm",
+        "checksum": "sha256:086e4f8ca49ea270b2e8b12ef81b7b33815e614e5ad9a99cd28fecae864904ec",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.45.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnghttp2-1.45.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5d6c319fc68cfbde5fbccbe6ae745d0679c4f45d893fdeb02fca88a0095658e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.5.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnl3-3.5.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:0de9b5a894058168824d8c4f593d1eee9d964b21de6c9a8e3ff5e90ab87600e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "1.3.0",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libnsl2-1.3.0-4.fc35.x86_64.rpm",
+        "checksum": "sha256:7f7b6a2a701e6fb488060c8b371a4efcf82fb8d7dbbbef43303cfaf154d3ccb0",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpath_utils-0.2.1-48.fc35.x86_64.rpm",
+        "checksum": "sha256:2a1a1b20558b7fabf55512347ee7404a48c90562bbce8375ecaacc2bc4562e56",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpcap-1.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2f3e8e6c23be82ab11d6ee82684567c464694d6a3c6a8745f20e270b7d9e2123",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpipeline-1.5.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:38be4bfe2b3d381d0253cdd39e163ad02f17735b25dd78bf4cc6c48d0b3f4a1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpsl-0.21.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:e095734ec8a8711dcb8bed2c370d5307c5fe795f2c31410630f94f24cbcad553",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libpwquality-1.4.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:65dec425b549db07bf854cb7412c180d7a103f40027e49c2ee9706fe427476cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "48.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libref_array-0.1.5-48.fc35.x86_64.rpm",
+        "checksum": "sha256:596cc0621aeca6e0432894236d28fb2685b9fb01edb6a3369dcea06a02440f10",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/librepo-1.14.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7cc688bb23318667c1821bedd610365ebef74b284a8001e99dac2b975a337f88",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.15.2",
+        "release": "6.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libreport-filesystem-2.15.2-6.fc35.noarch.rpm",
+        "checksum": "sha256:da65eca5dd6b39c10bcf9d4acc13b0ad756784f70aa9ac98a62a059194a24442",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsecret-0.20.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:4cdcad858cccbe01f29b72ec05693c83bfb84d03dcc5e37ca9ac7b886324ef82",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsigsegv-2.13-3.fc35.x86_64.rpm",
+        "checksum": "sha256:fa55c5201f7a2b52dd34ee0558da6c90ed880efed4f01f44561479fa6d157ab6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsmartcols-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:798d8b7c767daaf09b1c0f3c4b84957296cb25efa0ffc8ec2c59c6efb6e30c0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.19",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libsolv-0.7.19-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6ed74e42fbcfbf516467251fd4601f1a98e1456a14eb801610fb08655aa844dd",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libss-1.46.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c4d99cc259b4df4b49466075dc9e53e7ab9838696a37150ac523f6024d04143f",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-0.9.6-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6cd1ae92248cf0cb8ade79665ef931dbfb720a63bb99af2440e810f40641cc82",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libssh-config-0.9.6-1.fc35.noarch.rpm",
+        "checksum": "sha256:fe70d057223e4f93fe86c31f064b20f097c38393c9659b72a347022dc9bc3af2",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtalloc-2.3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:c04936fcd9ceb64a2ebc037d476b2d713f563d03bb6e1017e3f72bf5e983fecb",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.16.0",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtasn1-4.16.0-6.fc35.x86_64.rpm",
+        "checksum": "sha256:e94e8a9e04c65ebd3a881d872bcecce37d4777c7fac19d22272f4bd9ffcf172e",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtdb-1.4.4-3.fc35.x86_64.rpm",
+        "checksum": "sha256:1a57f5ae44250b9eb783efe030fb1b9b4907bb4344badef62a6a461ceeb6f8e5",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.11.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtevent-0.11.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:7ac6af3c01c31e098d4a0bc786bb9b0ae6c854a5d37f32b2b5b4de442b4f4fe0",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libtirpc-1.3.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2eddfe552e138d65dde5e42ec04df977dae86e36969b8d0ccfb4afd7fed87130",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "0.9.10",
+        "release": "14.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libunistring-0.9.10-14.fc35.x86_64.rpm",
+        "checksum": "sha256:9a13f3e823eb216d7d886ab2aea201424617abf1769fa42f4546271c6572c30b",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.24",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libusb1-1.0.24-4.fc35.x86_64.rpm",
+        "checksum": "sha256:056633ce04b2279728684ac4b3f2864cd840468aee9aaa045cc80bea5f86cfc7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuser-0.63-7.fc35.x86_64.rpm",
+        "checksum": "sha256:50c54584c8a1a34ff2d5f8edda843c5344dff6ad179e5392bd2efafc95cd4b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libutempter-1.2.1-5.fc35.x86_64.rpm",
+        "checksum": "sha256:b3c606cd7ef5ba1eda01fea558d6609ad29de2586a85f1f70f5f5491c39ad81b",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libuuid-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c929680a86cf4cf0558f585b08c65c7cd5573aac5b2154e7936782d84aed7978",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libverto-0.3.2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:59d8bf9aefb00d5ec8317c30561e05b9bd50d946ad3c9d5beaa4ec7c7d9a478d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxkbcommon-1.3.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4b0fe91407b997fcc72553af4e368b9272e37860e3a1f829005d55cf5e427dfd",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.12",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libxml2-2.9.12-6.fc35.x86_64.rpm",
+        "checksum": "sha256:15340e191f2099e51ca7f13f4352f0590ac2ce0f7b4c3aaadd9fb222e90148c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/libyaml-0.2.5-6.fc35.x86_64.rpm",
+        "checksum": "sha256:00a735aedc6b4f94eddef995c4727050da4d9a5d706d89bd0036b23d19c0aeab",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lmdb-libs-0.9.29-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7219d267c71b81586418726d9a8b395b29c4051f48b99b2d4c425788ce6f0e73",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lua-libs-5.4.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9c73ef53f05d371b472e5cc9bfd3b8d63e21518eeca90efb023cde4849e7c68b",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/l/lz4-libs-1.9.3-3.fc35.x86_64.rpm",
+        "checksum": "sha256:8551741a66c96386a4a62a5f26d176a2a6410dce46afab5351e42c159ae1834d",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/man-db-2.9.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d187b43a783c72bb0f6b9c9372d4ed8f9555a70476a5bc5bb1cb0e0c3f75eb98",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mkpasswd-5.5.10-2.fc35.x86_64.rpm",
+        "checksum": "sha256:75c38e7b22434dcf427a6c7a59d5267f6fffb932fa1a3bd3f105f686b41a3831",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs78",
+        "epoch": 0,
+        "version": "78.15.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mozjs78-78.15.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:20c027a4afeeed3ecac4bdb86cedf3b1ce4a9cdf437fe46f5b0edeb426ce4264",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpdecimal-2.5.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:35e95aeb874d46b2cf1c3a9c6fc1c1b8cf71093a7ff1f8dffde8abd07a6632b4",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/m/mpfr-4.1.0-8.fc35.x86_64.rpm",
+        "checksum": "sha256:9af6d0f320cae1a040c1da58b72a33170656bb7eeb6f35bbc8376854f08abdf2",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:d16f8f8e8bcddba1941542ba7c54cb166028fc262ad349289d31ebba188a2e9f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-base-6.2-8.20210508.fc35.noarch.rpm",
+        "checksum": "sha256:25a6a0c4e03e862b5092d0937bf3cd886a5768c5517c4e82e9a132260a631b1f",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/ncurses-libs-6.2-8.20210508.fc35.x86_64.rpm",
+        "checksum": "sha256:fa828fba06c3d070ead7325abc6c8c491d85efaf34e6714682dc031f071fd60c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nettle-3.7.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:8849213eb94969242c84dcfe8cd600af2ecd13e67b5fef845fd0d71ae13ccde1",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/nftables-1.0.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:011444abd567c69e6fc589e7d74c883ae0749df41b6c3c460b97292bc5fe69ad",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/n/npth-1.6-7.fc35.x86_64.rpm",
+        "checksum": "sha256:1d0c451d75a505cc71974ac284d3a8150e27c34465af403cb79346f27f15777d",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.4.59",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openldap-2.4.59-3.fc35.x86_64.rpm",
+        "checksum": "sha256:603075c9a8c4651fc8f1bd619655ec512894b6f84cf21deb1293de58743300f4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "1.1.1l",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-libs-1.1.1l-2.fc35.x86_64.rpm",
+        "checksum": "sha256:a8a4b9fc2dcf1a2a6ec895dc31ef278016b2417dd94193853180a7ebdbf787bd",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/openssl-pkcs11-0.4.11-4.fc35.x86_64.rpm",
+        "checksum": "sha256:edff24a466d28c5f54966c5a42f9b1d643bcb2227e74c9d72e4d8d9dcdac27dd",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/o/os-prober-1.77-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6bdfd2dcc1c5692d00cff763a59726e67d4835725a3b6ad4775cd34eadee3bd",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:8b92e662dc45efe3c5687a5c6a5030db9149f0a328318367669e0bdd07c82360",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.23.22",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/p11-kit-trust-0.23.22-4.fc35.x86_64.rpm",
+        "checksum": "sha256:b2183e767697a67ab691494ca54896435beabbd6efcdb9a116fde1cc3d882853",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "5.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pam-1.5.2-5.fc35.x86_64.rpm",
+        "checksum": "sha256:287621b919c2eef9b15684dc343ee0edda5b24ecae7b2fb8d1198077e1e7db1b",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/parted-3.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:94b669b65c5a7ac7c4957ad7c9efb982e65ee0b22f1ae844f78837ab823ca69c",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/passwd-0.80-11.fc35.x86_64.rpm",
+        "checksum": "sha256:a8fc6c3a5bce70d7f68e328a69533da48f80e4df1587ffdfac58cf7f60563c66",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre-8.45-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1b1439d260f208a4383bf6dfb7dccda083500dee55589684b2185b3c0720c3ae",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-10.37-4.fc35.x86_64.rpm",
+        "checksum": "sha256:a52cef649628889e83b5f37e30ad18e369e95667f8d7b92f562691966fd294d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.37",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pcre2-syntax-10.37-4.fc35.noarch.rpm",
+        "checksum": "sha256:ef802ac453e7b4d969d2e68c3344a101e4156201c4181221adc1618264da72b2",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.5",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pigz-2.5-2.fc35.x86_64.rpm",
+        "checksum": "sha256:29ae277d1f87f5f894b1c04be8a811971d36059dd14a453150079c067fb768da",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/pinentry-1.2.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1aff2fb69c2dceebf708b457f21081f5f48051895bedde21065f45d989d7e0a8",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:90b4501a932693c1bed585b809ab15dca10edf4ecd0eadb34663ddba04ce89af",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-core-libs-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:c2bf24657611e4f1e988e55b24904d60abff918981e7cd1772bce29b116ab274",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "0.9.5",
+        "release": "3.20210331git1ea1020.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/plymouth-scripts-0.9.5-3.20210331git1ea1020.fc35.x86_64.rpm",
+        "checksum": "sha256:022cf3dbbd9dd9d3362c0bc6a42ea219c29abe1b22bcaf0972943b73abfa0550",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "20.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/polkit-pkla-compat-0.1-20.fc35.x86_64.rpm",
+        "checksum": "sha256:46d0eabb124f4043ac302fe1d5991310b329dd34b5db62404c1db97f045660bb",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/popt-1.18-6.fc35.x86_64.rpm",
+        "checksum": "sha256:61b674e2fcd99782e099468f27c865a2dbc392ace441fd0b91aba038b5b107ad",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/procps-ng-3.3.17-3.fc35.x86_64.rpm",
+        "checksum": "sha256:214174bf4c5caec9cd5c8124ba52d4d55c401b074db45c13dd64c82c9fc743c5",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/protobuf-c-1.4.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:684422fd89017ffbdb69c7cefeda903cb5567106006f620644107dd77e14b80c",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/psmisc-23.4-2.fc35.x86_64.rpm",
+        "checksum": "sha256:9fe58a0ba8b3b641d0d568a00ddc9ffd6a3ea18deaa80a65762f845bb888513c",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/publicsuffix-list-dafsa-20210518-2.fc35.noarch.rpm",
+        "checksum": "sha256:7dfd0afdf3edd6a8d910df4be068237f1c62d10a74ea289764b0574dff3369af",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "57.4.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python-setuptools-wheel-57.4.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:1dc0b6862f4fe9eff8e29f28b9e9b8192c5b8f64653d538c8006fe16c26bc4b1",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "7.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dateutil-2.8.1-7.fc35.noarch.rpm",
+        "checksum": "sha256:cee395af8ff79e8fd4b8ea8896a929e692962ddb2988b027c5ebe54d78e60085",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dbus-1.2.18-2.fc35.x86_64.rpm",
+        "checksum": "sha256:f639f8c74dea5304f5afa5ca359c3935e8ba93165d342b52327960d98b912633",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-distro-1.6.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:0cfce1232a5ad6045cbb462fe71cd44744ce2c1df0c78c1bf7ddf2168366d99e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-dnf-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:d207f252bfd8bbf06f88ac3287cdde494f781781ad4f5c13d40443b8ab2e445e",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-firewall-1.0.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:cece9add6278dba4aa09817d459d76dca96e0bfde03421aa8ed257d12b07cb04",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-gobject-base-3.42.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:f693a388244b30744d1c219b26e00f5044c8f5e396a2a2dd3ce35864e646fe30",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-hawkey-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:75c4318d15bc07b7c66984865713ff99d2426b5e08f1d6cfe92cff958cdb63d9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libcomps-0.1.18-1.fc35.x86_64.rpm",
+        "checksum": "sha256:abd430aad90a47860d0167465bd8a97210c02cdfa29bddb41ae55c612722d826",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.64.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-libdnf-0.64.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4c2ec5153e0be05d8e3516beab0f881b526b0316de1e6e71b964ab75b9e37569",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-nftables-1.0.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:6271b15b3b82e339216dec104060b6aac4a635c71ecc2517897684f021af3115",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:cda4157dd8bb07f64eeb39cc7c8cde10318c6d62a3e9300901945666e8980480",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-six-1.16.0-4.fc35.noarch.rpm",
+        "checksum": "sha256:0edc090b5787c8dcd8df6bc09f0bc22aced4c83421b82bcde4f23dde47405ddf",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/p/python3-unbound-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3ff491b0cd8e4fb503688e39ed9b3103823cbfda0b5b82642cbb27f74975d8bf",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/readline-8.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:3195565a4fecafe311e48adfaeaf1ee6bdf7bc91a8da498fda046c07b38e544c",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "30.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rootfiles-8.1-30.fc35.noarch.rpm",
+        "checksum": "sha256:68ae8581a47df4ae4f620321a16935632394d37c044445d520f36afa65b28adc",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ee7fe077f66d98ec3f3ce326d3b60a9dbfd817edbbf4b51ab107f7e59cdf29c6",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-build-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:bffa951cb3c45d63a55795ac263cbf79fab0562eb2b808c5d240a6d71c62e750",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e37c7c50eb8ae0517a9fce31733d96dc5312616741cb2290e79d8557e6f45193",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-selinux-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:df40da25b77246474d39f71f32a6ab9bf4126153fc684d865788a91ca0e310ea",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:276994197e5bc295a609c2a58ea1ea407f9a967a65d83bbb43c7407cec1b9163",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/r/rpm-sign-libs-4.17.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a5776e77b969a3e7cbdec5ee6b30cec3b254090a0ae7c4ecdaf571c2a1a2a901",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sed-4.8-8.fc35.x86_64.rpm",
+        "checksum": "sha256:84a3821748a12e0cd75bf0cdfb8d5ce6eb1f37bca1b7cd22dc8861db9ac98ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.9.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/setup-2.13.9.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:e5c8df29ea474dc741bcefb0d6bd46cf498f302e73286250c0aa0bfd9cacf3c4",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sqlite-libs-3.36.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:bcc4edb810df0371fa4a1ca69b143386542505009eff4a1a0a806d13093e5c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:b5a1fe4789e8fde6873b432cd3a6dfb1e3025245beaf89e62e37fd23e169639a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.7p2",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/s/sudo-python-plugin-1.9.7p2-2.fc35.x86_64.rpm",
+        "checksum": "sha256:ba47f541e53846685c1033028452e4ba9da122ffa10e0765e5576c667e99ab21",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.1.0",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/tpm2-tss-3.1.0-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6777217f13c1297e07f62e61fc6d50d21f27f624218981a6e726128448cb67fc",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c8630885fbe4fd0c1b3f379cb892f01e16ea06ec7baf91b0105f3730d4f8507",
+        "check_gpg": true
+      },
+      {
+        "name": "trousers-lib",
+        "epoch": 0,
+        "version": "0.3.15",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/t/trousers-lib-0.3.15-4.fc35.x86_64.rpm",
+        "checksum": "sha256:3c3297e3edc67aab06079d9103c67ef9e56548a1811e4539ea73501718bef7d1",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.13.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/unbound-libs-1.13.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b569c18714661deb7a92c9633da4750a9a14399b26fd9332ffc48155b06e5340",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:41e1ac12c28a6dd233bbe56a00e946ccdc143858e82111fa4036a9fe458112e7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.37.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/u/util-linux-core-2.37.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:810fc2ef18bb7756608363bdbbb1d8bbc4eb39b898c4fc69c8edc737aaa960ae",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "27.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/which-2.21-27.fc35.x86_64.rpm",
+        "checksum": "sha256:96189479e6eca8129223703dfc26c5ebeab2882f49ee3840ea9ebc51e5e6dc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.10",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/w/whois-nls-5.5.10-2.fc35.noarch.rpm",
+        "checksum": "sha256:0c005878781dace51156c95627233a77b801f0aacf5e9547a27185ae25ecae1c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.33",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xkeyboard-config-2.33-2.fc35.noarch.rpm",
+        "checksum": "sha256:5ed80d0648e9daf6ca104a9bf0d1c1ce28bc0480bbaaea9a893eaaf263480fe7",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:015702447ba2c722045c4938ca4dad72fb74812a36f6b4465ac6f4607b03df5c",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/x/xz-libs-5.2.5-7.fc35.x86_64.rpm",
+        "checksum": "sha256:d9f563387670da48f64508eda2120911d6d10498e38042119362de45a0652e67",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.9.0",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/y/yum-4.9.0-1.fc35.noarch.rpm",
+        "checksum": "sha256:67df6090cef04291c301a1c390dd43d11ce3037bfdb91b686044abd8d2924266",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.1.15",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zchunk-libs-1.1.15-2.fc35.x86_64.rpm",
+        "checksum": "sha256:47936f70dbe657f574d02f176694082de5265bfb2174970a7c6ac83b52977f4c",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-fedora-20220106/Packages/z/zlib-1.2.11-30.fc35.x86_64.rpm",
+        "checksum": "sha256:c8ca54b8e132360acb465b412c7ecde13429e752fe74a5d85fe550769afd55de",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:01feeac42a5067e0d93d26be4fdfbb9e6b98a0199308e5c6fcca3190ad3083ab",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.32.12",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/n/NetworkManager-libnm-1.32.12-2.fc35.x86_64.rpm",
+        "checksum": "sha256:7ba84d10050c41fa26eb2602057e234cd7554dafa68529bedc5c51ce15d93182",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "1.0.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/ca-certificates-2021.2.52-1.0.fc35.noarch.rpm",
+        "checksum": "sha256:3d259a3da3561d489a2a829afeeaaf92e652491909c9dfeb1bfa4a275031df0b",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/cryptsetup-libs-2.4.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:734e5727cb268b6021f1aa6d447a9b348a3bd3c79e9ab4a4dd7342b2163cd547",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/c/curl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9135cd5877d3d03432834e747adf4833a189d1e691ee991569e063d069a890ad",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:5d6758e75d53429c9c6a799ebaeb3ac63c88ec4d57083b8be80e2154800b9fe6",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:35e10393072c1635b25c4536ab4bd5cadacb29e8b63133f6701244aff9f9fe07",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-generic-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:571ad1c79fa5dc94318169a18b5b395458580c74d7492215b5b0efc5aa07d29d",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "055",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/d/dracut-config-rescue-055-6.fc35.x86_64.rpm",
+        "checksum": "sha256:b1163282c68d42bed61523230431dc06e97c630f6f1e694e2f39bd1b53de5b00",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-debuginfod-client-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:0ad1ee7e95ed96eafc8b96a40a978ccc9f6da099e39293297676a2a9c154e2bb",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-default-yama-scope-0.186-1.fc35.noarch.rpm",
+        "checksum": "sha256:1e8929b9ceae5d4c3d89c2838e3e1c24c82c91f629ffac3f910fa0441691aebd",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libelf-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ea6d64581491e22f5e5db4ed7b5f655b722719c0d11b423202b29249460dce66",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.186",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/e/elfutils-libs-0.186-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4e38478a15a93da7f835d7cf503fb28981812c1eb18a39be2a6885dab7427c6b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-35-36.noarch.rpm",
+        "checksum": "sha256:c53fdade18d58360854bf7129371b5e97819514977159ad9d05d3d861ecc5cc5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-common-35-36.noarch.rpm",
+        "checksum": "sha256:ac4b769464ccbbfed9c887287b0410c0517f1d3b918fa1d4324067b94ed2ccb5",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "35",
+        "release": "36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/f/fedora-release-identity-basic-35-36.noarch.rpm",
+        "checksum": "sha256:bc094caaaacb96880fb4a98f6aac8c56064e7a957a76ce8096da445b73803fad",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gdbm-libs-1.22-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b78f7ce7880dbfcb68ce9c0da4dc6da1c3d9e95b70a725d7c975fbdd424dcabf",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.70.2",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glib2-2.70.2-1.fc35.x86_64.rpm",
+        "checksum": "sha256:3527a0a6349dd42551b08da5574c4dd993f593b1f2ad8253240aa82834004680",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:e198f1dfa9ee2ae2b20246895a664f985d1526778500e5ef75c4214dd1654b89",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-common-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:4b08824696b6164cf45c314ef9ec49bfd81dbbe21b963045b38b484ae288994b",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-gconv-extra-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:bbdaf5dfdfd669bb6282350591131fab000640ee33a3a1dac49a7f64304aeaf1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.34",
+        "release": "11.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/glibc-minimal-langpack-2.34-11.fc35.x86_64.rpm",
+        "checksum": "sha256:496e4eb656ef9ebaa4542f37ab915caaa7ef7a3d996c6e7d608fea5562eb1227",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:168398746c0c3d7a4f0f4d9245de29a768f5a45274cbbfb228e5e6f2c1e9941f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gnupg2-smime-2.3.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:49e4d2c8e792d490d72b964e8e714b5df4e70e0ba999b4536ab87ff43f219b1b",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/gpgme-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6919acf046586a84549edd7b1ec131b2b814529d96a4f1f65301dfe2d8c17dce",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-common-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:2a3580b96d36668085e21a9d6e11cc2a7d254bfba9855c66fbfc663ea1f211c8",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:bd422838b08aee333b919798924814148118cd1d2ec7051a3d01f0161eec4184",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-pc-modules-2.06-10.fc35.noarch.rpm",
+        "checksum": "sha256:59525eff25d7e8c661f3d2a5308d431234cbd5e4a70c4150c3a71639d0e0e136",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:94104f196a74be27358ac696a3f6063d45f7c33df2785a42454b988141760564",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "10.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/g/grub2-tools-minimal-2.06-10.fc35.x86_64.rpm",
+        "checksum": "sha256:4a6688d08116cbf7b75f51ec2b56fb82776ca7b0d8853286e4585596348abb2d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:9ecb8e5c854c5627dab136cb5731ef6c073400d6deb81dfd24a6a44bd0b9ad4a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-core-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:8ce8dfdbfce7c27275408198827f17889b22f3c0597e3b64548542cf8af4327d",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.15.13",
+        "release": "200.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/k/kernel-modules-5.15.13-200.fc35.x86_64.rpm",
+        "checksum": "sha256:18c9bc1629e34ba5328184a29314c7e751177731fdcbc98371f4587f97fe399b",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/less-590-2.fc35.x86_64.rpm",
+        "checksum": "sha256:460008c60bfe5ef76c671949906ec6028ad3e883f829ee071215baaf4505935d",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:05c3d47d0276b2ad318fa6810dc040e33e065c2400f3ff506393d514b6a2e6c5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.2",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcap-ng-python3-0.8.2-8.fc35.x86_64.rpm",
+        "checksum": "sha256:70d7f22b24741ce3a874646f46e111fc6f450433da2e50a4721a686891c2c36b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.79.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libcurl-7.79.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e6b865487f450e66373e267e924cb2b73680423e2d420246e275a65d6d5f4dd6",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libfsverity-1.4-6.fc35.x86_64.rpm",
+        "checksum": "sha256:6686a1f8fafbb1f7cf8abdb1a2b7a49e4278798b3d0bff8e648a53280e28ed1b",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgcc-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:c72fe2f4a82a752524cfbfa043c1cc5a44f34a54e134c654d921a7c86f691429",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgomp-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:30b97324409beb7a81199cd38cfc39c95476a91215521b27860223e664f9cd50",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libgpg-error-1.43-1.fc35.x86_64.rpm",
+        "checksum": "sha256:16ccfc043e3e964acea39e7858b23fe6e1719738c10596f97f03ef9c48db2503",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "38.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libibverbs-38.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:ae25cbec4ed8d0f942b9933af8b7b5c3348cabc61335afc2507d8bb2ef288bf4",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.4.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libldb-2.4.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2816abc40eb06525f3e48664243708e4fd648bc40a22d04d3c3fc4653a05beb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libmaxminddb-1.6.0-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b1914e9500f619aa12834d3018d5c53556b15f8fa801948850ad38f8ec9b223d",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libseccomp-2.5.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9418621ef2604f6e4186c7d93a3d22ea52f515e7d7adc944f93261f5fbad6ea5",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:784cd4dc502dc9fdb5645087d97ca0051e8d112c0c9a9376fa2469224a8d4145",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libselinux-utils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1c0981c43460e63693f80bb15559d5016ce11d3d445e4fc69c61ab61a61deae8",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsemanage-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:1a9a9f23373cac85fc2085dc604de39cb73f6c4a32ee5b9ef13d6aff088652b6",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsepol-3.3-2.fc35.x86_64.rpm",
+        "checksum": "sha256:449e351310fa9ddd539ecab0f43d21f12d15b714b69fdc6697dc5b7e7ab8d4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_autofs",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_autofs-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b99b28317bf01d270af6da14b5cb755e492708e034f10d46fa872c82113e1659",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_certmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:2382a1df3dc5a598eb3b2dd09995ca1964010af291265c965b7fc2906a98084b",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fb08e2d2a145964c84ada417b579b7deb8bf917fb15d4d69df33755a7e7b5ac1",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_nss_idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:b492545e958e49bb04288536508b249396e691d7d47c1f322c31af050f57f367",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libsss_sudo-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:97caa631cd7385314bc217c2a910faeb3b1ccf89cee700ae62671a6a12e2a107",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "7.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libstdc++-11.2.1-7.fc35.x86_64.rpm",
+        "checksum": "sha256:3de00c35730d8e60e5e44ff52f09d5b9b9ef2f0600bac5efdfad47bab9cf58ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:11f86346f64399eb50a0da763f549dce1be8b7dffc24824b41a51733bce9185c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.27",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libxcrypt-compat-4.4.27-1.fc35.x86_64.rpm",
+        "checksum": "sha256:e985781c487e2146b50b23c54bdc8c0d4afb78a636191682b985074d70d9409d",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.1",
+        "release": "4.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/libzstd-1.5.1-4.fc35.x86_64.rpm",
+        "checksum": "sha256:42fd0c03cc04e16f5c35ac4863807630cfc5c00be20242b3f333580e5497bbc7",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-atm-libs",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "30.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-atm-libs-2.5.1-30.fc35.x86_64.rpm",
+        "checksum": "sha256:b07af17dcbf638dc969aa55572e0fb300583a87b4c2ef755f359e4d7c1a91f4f",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:ab90c2821b8bb5b5b567f4df37e648fb1918b70a56e6c6be4c96b680d22765c3",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20211216",
+        "release": "127.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/l/linux-firmware-whence-20211216-127.fc35.noarch.rpm",
+        "checksum": "sha256:e04e8b9bece95a86b61ae3af34c5b50a4b342f59d4a61a55a7e8b720762af938",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/m/memstrack-0.2.4-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a905a0e199e419b31c40e15202e18b7ec7d384ae04f4c0d32118cc8c4747c614",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c8a4fc5b29a5f55805fd9b0d51817ab39ca26a5a12b25e7fd2a1b670a33048c4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-clients-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:7f95f92e23d855ce83b3740e5a7888bb0a4b35cf70b68b3e66ce847f09e0a131",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.7p1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/o/openssh-server-8.7p1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:9b3871c88738f18840741a1654a164574e72ed1c9cbf405fa6da5a84cb6a4abe",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:98c178ddb6699205772df4854952a881357f6d6fbc0dcd1df802474fb4d45e05",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.4.36",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-ccid-1.4.36-2.fc35.x86_64.rpm",
+        "checksum": "sha256:2d68d8a6653bd0ab6bc191a60a3ba435240d27681f91a974a4b964a2c6e36176",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.5",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/pcsc-lite-libs-1.9.5-1.fc35.x86_64.rpm",
+        "checksum": "sha256:4f4e8dda6475f9a0c4dfd519e9354c7e3ed3aae58193d3488fe2323b5564e5d8",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/policycoreutils-3.3-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c9d850b025ea8327eebbb35a5ce850851faf0ec6c9597e56c4f49ed3c6cdc090",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d5ca9fda5b1b8061be4e83429fe2344c5cc88f8dac5664e16899f4ae2d93cbe9",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/polkit-libs-0.120-1.fc35.x86_64.rpm",
+        "checksum": "sha256:d18f3db063991e9de1c63c6680bab248757906b008b0bdfcfc0b07624bb8867a",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.2.3",
+        "release": "4.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-pip-wheel-21.2.3-4.fc35.noarch.rpm",
+        "checksum": "sha256:13570a9cca99b7e14eaaf9d722f88598db1b859f01b920c5adfa65f4adbf7228",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python-unversioned-command-3.10.1-2.fc35.noarch.rpm",
+        "checksum": "sha256:c7a8e2099976b010721de5dd351c881f108748fb43c3e63bf188fb5049f45baa",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0871993ec7c876b0ecb0de4c5060c7f97f4a5f98a18f901a5b315e1c1c148034",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.0.24",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-dnf-plugins-core-4.0.24-1.fc35.noarch.rpm",
+        "checksum": "sha256:f07183fb8aeebc24e9ac1d9e0e737ec977e15a3066eb5fa3eba5ebab2355b6f9",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-gpg-1.15.1-6.fc35.x86_64.rpm",
+        "checksum": "sha256:a4caee0b42af8314f60d8e9a52c5fc1d315dc5a5bd4c23491ae5c2f331d456e2",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.1",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/p/python3-libs-3.10.1-2.fc35.x86_64.rpm",
+        "checksum": "sha256:d9b157ac7acc9749a3f1aa084ef90a37d914b1360ecaba7f7f976fe326400513",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/q/qrencode-libs-4.1.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:9e928229e1614dcdcae0796ca0e084e7c5aeb00be237f30b9d31207886cf5b50",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:db4f152d636472476f3d6134e595c15e52e3cd107e5b362b4a85a4660825db70",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "35.8",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/selinux-policy-targeted-35.8-1.fc35.noarch.rpm",
+        "checksum": "sha256:4368cc948c65e01de40dde7fe41c7960077215999e99cce887feadafc85b3a9b",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.9",
+        "release": "8.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/shadow-utils-4.9-8.fc35.x86_64.rpm",
+        "checksum": "sha256:d6c8bcc95fe6b1795ae5b819b9ffe4c2a5b3bb83d043831964fafd184b9f5b9e",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-client-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:a2ebffa755a9962dd761fb7984d48f5240e9e9cfcf9c22e913c4487b8dffdfdb",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-common-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:fa8c4d43af9adcb7230cc38180381bb01ebc97fb8ce31834c3fde3cb34849bae",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-kcm-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:874779944e2f10107b64356e3797733051d043bc683bf79cda3425e106bd8ea1",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-nfs-idmap",
+        "epoch": 0,
+        "version": "2.6.1",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/sssd-nfs-idmap-2.6.1-1.fc35.x86_64.rpm",
+        "checksum": "sha256:f28b0afa37f734b359f898180566e82ce63bd508b153bb28fb47f179f6b1338c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:5f10e7c1f5edb10933fcb83b6054393c8c90b7830dc3efdd435544023215b48c",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-libs-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:06087f1e4d27e8ed6f55a284d337a51d908791502c7dc1ae2d8aefce8e813b09",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-networkd-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:1c3ef96bfbc06f275f8eeff194ab39f53d0a18e0bbb2bcb2475ea020281cd699",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-oomd-defaults-249.7-2.fc35.noarch.rpm",
+        "checksum": "sha256:d2d490db9797f180fb3a42335898abc456c907cf4e7ff529e506516b3829f5c3",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-pam-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:786b271cf86aafe5cec4c2a2586ef85e1e1ce1f331657714cebcc158b99ee9fb",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-resolved-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:bc5e2ff785dd704da00ab3aca42e82566ef2736a8373ae985b8d4557761c0af8",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "249.7",
+        "release": "2.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/s/systemd-udev-249.7-2.fc35.x86_64.rpm",
+        "checksum": "sha256:0ddedfc13414f0a9f208fc7616e645e947496a2577460c62221c25a8d66ad577",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2021e",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/t/tzdata-2021e-1.fc35.noarch.rpm",
+        "checksum": "sha256:de07042241f195b815f8a32b0244eb9a43f7ac8fa5ef936ab28b10af18ebede2",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-data-8.2.4006-1.fc35.noarch.rpm",
+        "checksum": "sha256:40ebc78055a35e68c376c6a90e3dac91664ccc83287194f062cb52c0cb2936a6",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.4006",
+        "release": "1.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/v/vim-minimal-8.2.4006-1.fc35.x86_64.rpm",
+        "checksum": "sha256:c34b4c7349367ad9ec44d4858eb989b916fb118acdec4f07ae1506b257918bd2",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-1.1.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:c318ea2de3bcf9f76bb541eb62fdd38640906d4691f87f3d6a6cc6452e1b973c",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.1",
+        "release": "3.fc35",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f35/f35-x86_64-updates-released-20220113/Packages/z/zram-generator-defaults-1.1.1-3.fc35.noarch.rpm",
+        "checksum": "sha256:6acdd7238cecc7a50fa0a4c334550a1ff1d2b4984ae25be711322bef8f773a0d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_36-aarch64-armsysready-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-armsysready-boot.json
@@ -1,0 +1,11248 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "aarch64",
+    "image-type": "armsysready",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "armsysready.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "uefi": {
+                "vendor": "fedora",
+                "unified": true
+              },
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.9-200.fc36.aarch64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "armsysready.img",
+              "size": "3957325824"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "size": 409600,
+                  "start": 2048,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 411648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1435648,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 2048,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 411648,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1435648,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 411648,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 2048,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1435648,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm"
+          },
+          "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.aarch64.rpm"
+          },
+          "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm"
+          },
+          "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm"
+          },
+          "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.aarch64.rpm"
+          },
+          "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.aarch64.rpm"
+          },
+          "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.aarch64.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm"
+          },
+          "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.aarch64.rpm"
+          },
+          "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm"
+          },
+          "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm"
+          },
+          "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm"
+          },
+          "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm"
+          },
+          "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.aarch64.rpm"
+          },
+          "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.aarch64.rpm"
+          },
+          "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.aarch64.rpm"
+          },
+          "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm"
+          },
+          "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm"
+          },
+          "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm"
+          },
+          "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm"
+          },
+          "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm"
+          },
+          "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm"
+          },
+          "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm"
+          },
+          "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm"
+          },
+          "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm"
+          },
+          "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm"
+          },
+          "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm"
+          },
+          "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm"
+          },
+          "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.aarch64.rpm"
+          },
+          "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm"
+          },
+          "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm"
+          },
+          "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm"
+          },
+          "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm"
+          },
+          "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.aarch64.rpm"
+          },
+          "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm"
+          },
+          "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm"
+          },
+          "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm"
+          },
+          "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm"
+          },
+          "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm"
+          },
+          "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm"
+          },
+          "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm"
+          },
+          "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.aarch64.rpm"
+          },
+          "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.aarch64.rpm"
+          },
+          "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.aarch64.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.aarch64.rpm"
+          },
+          "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm"
+          },
+          "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm"
+          },
+          "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm"
+          },
+          "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.aarch64.rpm"
+          },
+          "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm"
+          },
+          "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm"
+          },
+          "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm"
+          },
+          "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.aarch64.rpm"
+          },
+          "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm"
+          },
+          "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/less-590-3.fc36.aarch64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.aarch64.rpm"
+          },
+          "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jq-1.6-13.fc36.aarch64.rpm"
+          },
+          "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm"
+          },
+          "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm"
+          },
+          "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm"
+          },
+          "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.aarch64.rpm"
+          },
+          "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm"
+          },
+          "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.aarch64.rpm"
+          },
+          "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.aarch64.rpm"
+          },
+          "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.aarch64.rpm"
+          },
+          "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm"
+          },
+          "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm"
+          },
+          "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm"
+          },
+          "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.aarch64.rpm"
+          },
+          "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.aarch64.rpm"
+          },
+          "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm"
+          },
+          "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm"
+          },
+          "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm"
+          },
+          "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm"
+          },
+          "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.aarch64.rpm"
+          },
+          "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm"
+          },
+          "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/parted-3.4-12.fc36.aarch64.rpm"
+          },
+          "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm"
+          },
+          "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm"
+          },
+          "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm"
+          },
+          "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm"
+          },
+          "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm"
+          },
+          "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm"
+          },
+          "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm"
+          },
+          "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.aarch64.rpm"
+          },
+          "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.aarch64.rpm"
+          },
+          "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm"
+          },
+          "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.aarch64.rpm"
+          },
+          "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
+          },
+          "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.aarch64.rpm"
+          },
+          "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nano-6.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm"
+          },
+          "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm"
+          },
+          "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgudev-237-2.fc36.aarch64.rpm"
+          },
+          "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.aarch64.rpm"
+          },
+          "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm"
+          },
+          "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm"
+          },
+          "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm"
+          },
+          "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm"
+          },
+          "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.aarch64.rpm"
+          },
+          "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/i/inih-55-1.fc36.aarch64.rpm"
+          },
+          "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.aarch64.rpm"
+          },
+          "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm"
+          },
+          "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.aarch64.rpm"
+          },
+          "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm"
+          },
+          "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm"
+          },
+          "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm"
+          },
+          "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm"
+          },
+          "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm"
+          },
+          "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.aarch64.rpm"
+          },
+          "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm"
+          },
+          "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm"
+          },
+          "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.aarch64.rpm"
+          },
+          "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.aarch64.rpm"
+          },
+          "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.aarch64.rpm"
+          },
+          "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm"
+          },
+          "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm"
+          },
+          "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm"
+          },
+          "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm"
+          },
+          "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm"
+          },
+          "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.aarch64.rpm"
+          },
+          "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.aarch64.rpm"
+          },
+          "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.aarch64.rpm"
+          },
+          "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm"
+          },
+          "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm"
+          },
+          "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm"
+          },
+          "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm"
+          },
+          "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.aarch64.rpm"
+          },
+          "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm"
+          },
+          "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm"
+          },
+          "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.aarch64.rpm"
+          },
+          "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm"
+          },
+          "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm"
+          },
+          "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm"
+          },
+          "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.aarch64.rpm"
+          },
+          "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm"
+          },
+          "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.aarch64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm"
+          },
+          "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.aarch64.rpm"
+          },
+          "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.aarch64.rpm"
+          },
+          "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.aarch64.rpm"
+          },
+          "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.aarch64.rpm"
+          },
+          "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.aarch64.rpm"
+          },
+          "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.aarch64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm",
+        "checksum": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm",
+        "checksum": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm",
+        "checksum": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm",
+        "checksum": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
+        "checksum": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm",
+        "checksum": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm",
+        "checksum": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm",
+        "checksum": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm",
+        "checksum": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm",
+        "checksum": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm",
+        "checksum": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm",
+        "checksum": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm",
+        "checksum": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm",
+        "checksum": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm",
+        "checksum": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm",
+        "checksum": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm",
+        "checksum": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm",
+        "checksum": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm",
+        "checksum": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm",
+        "checksum": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm",
+        "checksum": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.aarch64.rpm",
+        "checksum": "sha256:75452a8bdd269f95bf7f5b1d38877aa981887362ea68c354c9858eb31efb737f",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2a08d286b9015d162f3e8248e8ced742d9065e54fcc33a01689714a1d0b64651",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:04f0ffbfe393f84aa48f458d929d701191b4dc9063f236db21b7c061da1d0799",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5764e0cf4c455327edd28c478d3e46dece61d419497a55f319d59ada578b9c9c",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a141789dc071c315b35f694a589c21db351c78edcaa4634dfadbed07878acf8d",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b26994af6e0aafe1706f898ed1be912044c648b6c2633a5b6ece597a524f0cd2",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.aarch64.rpm",
+        "checksum": "sha256:c78eac85685b72ab97a7ab8835cacbf18786218cba3b2ed6a0ff356b1a1cbfa4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cb7a19f92b0b42f970235c99f6cd1b0b7fb6c466ae63cf87805eb60711964745",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:027a05496337c01e355843f4b1370b098701984beee5579baf8b0fc00aae96f2",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:1805475ff188c8532296a05ab17a7f13ed45e34f0ef93e51fb4ab564ebb8015e",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.aarch64.rpm",
+        "checksum": "sha256:4f44719fe6f5f25e5a3bd33450f397719a6759cede18d7d99262201a02a7110e",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:cbc3b7f789f0c0e1a6a88582d699f812020d87c7ea90b21faa76344f138992bc",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.aarch64.rpm",
+        "checksum": "sha256:884646f991f0933338144306ae6b9d67236f62e443707543c4ce901564a69bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:24c7bba2c03e5448393c3ad47677f9fc3ad550aab4a63092cb7d214d4b393cc0",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.aarch64.rpm",
+        "checksum": "sha256:67676b49e5e6b93349a459c053e5bdda75c0a5a241058ffd9a9711241c94f755",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f4499ef74bb386eef243481f9fbc7ba6aa7f8187b05bc90298549c67306c72f8",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:852a03da5786a6a5606376c9541141b9ddefedceb36e2694e5cd9c9b7a5e059d",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:126f3ee41c2bb96347d3ab0229bb006a989f7e48ccdfd44d3862afdee6eac107",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:9b1ea6f96ffa1d5d9f103073d6f39cccf40f3e2d3ade4c30b9d41cf353709c9b",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.aarch64.rpm",
+        "checksum": "sha256:788a7b7555ea8d20a731c549d895472595e54866e1ab20c8a9ddd7f5b64edaa1",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.aarch64.rpm",
+        "checksum": "sha256:dbd082622d6f4310d289f4959d3c00f389cbd270ba85e2bc6b38376a181a1d64",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:38ebb700f11be9e1ac2f8753e6037648b53c937411b1858a08dc29ceecb813db",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8aa090f3e7647b8f9fea241410b96277e8f9577da1b86f868681584aceeba400",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8742c24ce33c2df36bba94451a96eee6fe9a95a2524c0985125953cbe610014c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:41c95fd87ce2a0b728954ed6848ebf80e4519837f745f6dbeac729f2abe3b651",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e178cf8f39471a8829e584f3c1e9d94fdb621709dc1bc7dc2e230bf21b665bdf",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3e7ade694611570adcd423ec51a0d9b28dda7b3297fe3737e6f08eb3dd61e2ef",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a99eacd2ba27f5fef25cedf1f0d336936f70e07df32b289496371d095453c705",
+        "check_gpg": true
+      },
+      {
+        "name": "efi-filesystem",
+        "epoch": 0,
+        "version": "5",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efi-filesystem-5-5.fc36.noarch.rpm",
+        "checksum": "sha256:0ab2c23246afd84bfc450a68990ed5e67f38b759eba4ed0165c796b00f51a4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "efibootmgr",
+        "epoch": 0,
+        "version": "16",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efibootmgr-16-12.fc36.aarch64.rpm",
+        "checksum": "sha256:8d3f567968ae37eb62da4a462efb65e9ac701e1e5c653f031b56c41011b2cad0",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4d36faded5e082ec50b4cdde0597f1c05455a16418649fd5b519cd5ee70c385b",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a803c7c7c9f413489484d019a551aa14356a0ea2959120b1294c93227dd0a673",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm",
+        "checksum": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:3b44cb9d28bbcba95bad6b67da20c16fe220bf05b325f2697c19a3a253f606c8",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.aarch64.rpm",
+        "checksum": "sha256:affacd45c75de8136352649ce1dafdb7232b8912f0011064c920f408215d68f5",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6435175abe74dca35e5a78a57e88cbb2b163ba38b006613c1afd62c6d9275cc3",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d89202b7d0490913a6729d3207ec266430754ded9a1bdb26b84dbb033f12d602",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:096c032db3c0c78df89b0e051f1f807b77b4a4661fd59437e0e489cc9fbfe1c7",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.aarch64.rpm",
+        "checksum": "sha256:d87b335b253e9759addac1a9e06084b98da1ab5d4cb331ef8498358a52d00999",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5f7e410d07ff8220cd5558c5a23223f4b932ae36b956f3f85e3189a662fbe7ba",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:1ea2ac0301b8c0b0046ffaf8949e96627038a3f7526307e34eaa84f112fb0add",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f852b0426c18e7d8e8357c0c097af2c7f421ad27916170d82df205e6bae32a0",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:06f414daf778bda2bef49efa9f8d92b92f12e3d46b342f2abec876f8188caa9f",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.aarch64.rpm",
+        "checksum": "sha256:641fcf49fc1c1d591ea71aea69c0881b5e5feaed2b7ac4a0475f4f9773f5c304",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8fdbe6d0888d5b6e057d7b04ec2786a8d429c53790f97b9d42f6ac5ff8e92142",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.72.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5c3f31303fcd1c402f9c8dfe908e76a3c1bb818a2bb72bb918b6fb8e5c13a615",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:a93ddba157c3ed782eb2837d8776015b502e8340438fa0fc542325dfc0ad8f0d",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grep-3.7-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a32759e37d5c1ef6ff35c2b68e14492ded88be2fb4cae54014e0d6126b94513a",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.aarch64.rpm",
+        "checksum": "sha256:3274448af5863e4d033cae37e1283c647618ee95ea9e5b5dae485db15b915239",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.aarch64.rpm",
+        "checksum": "sha256:7197823e0bee7b0994af44fafb672fc64e64f61c631332953f107941d16f1309",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.aarch64.rpm",
+        "checksum": "sha256:e5967560228521bbfde1c3de892d72dcfe0443fcc36f421270d3e5fb711bc241",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.aarch64.rpm",
+        "checksum": "sha256:6adf1b0421c75dfb110ddd7246bc9809b20826da096a3fed2524aafa3dd688e6",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5e718c0fbbe1aa1811ac61df7a8d1d7b284ed969fae26da057a46155788e00fd",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm",
+        "checksum": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:af613725d58b9cb001a9ed68bdb69cca8c85c0057f46f572685414cf2f40388b",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.15.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:20c9d6f3e8674e639c0d370620654cf9556c570cdf06cdb4ab33fda6d57aff34",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.aarch64.rpm",
+        "checksum": "sha256:814cab6e8a8ce7ed2a001be07bd1803dd0272297773f6f484eea4fcc0abef9c0",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6f1e84b2dc7e805a465cb79a81322cdb6c0ba2bdd825a303072167f6545654b2",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.aarch64.rpm",
+        "checksum": "sha256:7ac5303ac6a3e0bece7270d9b36a5c3f7d522374607cbafc74bf04c72fc5f3d3",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.aarch64.rpm",
+        "checksum": "sha256:5b2aa00b613a153dc0963a25e1b6212b7aafcebf238e61f67febd4c57a626a53",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.aarch64.rpm",
+        "checksum": "sha256:f7612c662435439a6e09ac050816590d1c98bacbce2d70c18696afe15272e205",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:32bdee52ac0cb28a8b55acaf3fc80e407d79758099da5487838cd41c871b5812",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/jq-1.6-13.fc36.aarch64.rpm",
+        "checksum": "sha256:8a548ba4d90ce68be3ac7083c86d89465dcbc85339f03399b102eac973252ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f640eacf6844ceb4b1adf6a11570d0e7261bb67437d39f93055787c568217c7f",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.aarch64.rpm",
+        "checksum": "sha256:63a7183b381bcdc27a0f40f49330acdf1d8df39f38ac5a41fcfd6e300d4ceb44",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:e43da66bc2123116ef4cfb6fb3b1f77f40db85b14d20b615e901599a08a2b4f9",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e6c8dafacc7167f9d79ddeef30d7986e347f41bd149a0c12b8179913a55285d7",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:6757f4a14068cd7e80705feeae95dbb6efe06de161cf81a782b82d6ddbfb04d0",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.aarch64.rpm",
+        "checksum": "sha256:d5cd999fa5579ef91044baac4e2483ab8bac7475d362da1329d6aac190b528ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f980bec5185672778fb6600c9f0472e1b062444d6617ace67b8e44a6b670c170",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/less-590-3.fc36.aarch64.rpm",
+        "checksum": "sha256:8571e0aaae58fae1f5c077f018d8c8e7205f6d759c07a0c174e1272c7698e44e",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ded1d0e4fb7728dc7153bdd7d6ec96313f9188a13935a3382d14cb1d3db22acb",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.aarch64.rpm",
+        "checksum": "sha256:b62055e75833f9668150628dc7e8f9ac18c52d8876dcdf1a7882b871b26300b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "22.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.aarch64.rpm",
+        "checksum": "sha256:6f9f65c27c5d61050717ff42938f5b1e588b73b0d96aa5f85599e0585fd12dbb",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:c2e525d114e0d4121ba8148aaf7bcfba94f3a897599ea387b8c5899c7189dd51",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:f247b28f422aa4ecbcff2d556429db9a59de36deb0c66394a801bd86bc4b2a28",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.aarch64.rpm",
+        "checksum": "sha256:97b1a470a6d47aa502672233c648d745ed9b88ba9a5427eda8062c5bfe8a1578",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.aarch64.rpm",
+        "checksum": "sha256:a5edfcff067d1e13b22d3fa7b605e64569e75b3faae99019eff417076c707a01",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:43c4cb82452f99ed40beb114631be84b1ac13a65944345c9b4391851065194a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.aarch64.rpm",
+        "checksum": "sha256:dd3ded5f10c06ebc2ca7fc9e4ab89dabc1d6cdb3d64b8b717de495e95a6d0c68",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5297c43ba2d9bdcf0df76243c0faf16b84fddf360453aa0d9ecd2fe416429a7b",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.aarch64.rpm",
+        "checksum": "sha256:e1937625b5b6344ccef8ed465a2a4b4d73e1265cf327f20f0dfd5ebae51a4858",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.aarch64.rpm",
+        "checksum": "sha256:941052911c293bbd82a8bd120b27ec7d0efcc798a6ee2460e538348e15950859",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.aarch64.rpm",
+        "checksum": "sha256:c468c65cb0f9660357380096464e136fbe851492b75e229a2caebf1b47960b9f",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:c03532cc4cb47aa6c9c588d89698b5df04d7dd23349f6e3e2ff683946f5fe388",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.aarch64.rpm",
+        "checksum": "sha256:12654036e2d1dd40bff4e9c81a48a6ea85e52484b548382177f3f4ccf905e6a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2236f17e9ceeea51905135f90ee49e1d8166284dd43f7a9482f2796d52b31ca1",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.aarch64.rpm",
+        "checksum": "sha256:3b43ae92d85960e6a29b847f786285b72fa84a5d2b4a4a8292d3822e4dcba1a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3b1e1fc51a5ee0b29690ec7b55eba7f5a048a9c042e55f197938a7a805dfaf79",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:a1eafb080b3662d4a6defb25434390821aa04bd33588ae763f676a9719cc6ead",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.aarch64.rpm",
+        "checksum": "sha256:905194dbd14a47d86152644643a9fa69992465f39cca7de578676fcc9ce4f7c2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.aarch64.rpm",
+        "checksum": "sha256:0395ad209dc004e63178aabe17031446693f54d961695a520f67ba432c6ee82e",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgudev-237-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cac3a8242ae62dbfa931be632123487920b635a37858f6e54e3c0b89d3ecfd34",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.aarch64.rpm",
+        "checksum": "sha256:57bc09a4192d79a1c48d9f770daded8ac8d94dd177974608aaae88868e5efb07",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2960bca7d94a6533182b3d72331d3369c774bc5ee9cb842b6a2acec83c53bb6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.aarch64.rpm",
+        "checksum": "sha256:77e0fe0190c1e45324e0967766dda104359f68e8a7ac24832bde202cb46c3872",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:a06ad3aac9087efe26dd1a00ca34922287292debc1a0a61f8b7a74cd1849e0ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9251a60ce56aed426a00f82160dbb3f93493f2c393632b78c52b79db43d8cf5e",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e17233da1399eeee76e7d6614bb2af0a252b62357824034de808873994af63ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.aarch64.rpm",
+        "checksum": "sha256:29e67d901617165167763e9421a84af8c35eacfdb07bbfc97c8a56cadbff403e",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:f34685b66f0b0847aaac6903e0b92d2ff778e0d8f5e95c7852ee38bb87100a78",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:292256d4c9001078c7ee49f703fe7630b1622f514510a5c8ab33acd5235770a1",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.aarch64.rpm",
+        "checksum": "sha256:0855f5b2b07917099be76c6813474b45cfa73d7ee5c3afad4e20d3f9ccc970d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:bb7051047e7a1e8bc3b4960cea2dde77ec452c18383d16f2258216f489100525",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.aarch64.rpm",
+        "checksum": "sha256:d690dfccef93e95be27982044eef6a4d0251c77e94c7304bd99de45c20c238f0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8eeb1a2e783a61a814b20b12cddb3ffec8b27c02c6fbdcbf3cdef583fa59fa04",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:8c0ed9385ccb82bec74755e2ba3977a1edecfc449998b88e03e1096f8f5084d0",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2498f161d9d4d847efdc08c44edf420a8eab5605572a98ddded1ddce78ffdb57",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2bfaf3bc6e8b141e7aab8e3dcb4aa7a4be76a28afe59c53f1dd9ffba54bd7574",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fa26eac9e0cea2e41735fc6786aa66472f5967a0484ccc3e89f32ce1416005d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.aarch64.rpm",
+        "checksum": "sha256:f90ba4f8bdcbb2a340d4ee9727d16e6808fcb850fe697d217a5a2ce496b0968a",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:9caa3d6d1d101b8fccbea3f13004308300b326dc675989bac3b3a7d178201812",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:ed120f43b16b9ea8473b4ff6be591de9f4c9f3724c7f232b76f70764b35018df",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.aarch64.rpm",
+        "checksum": "sha256:05853c6732ae99b390dd47f85a55227c434ac3fad73c2f238baef7b73a1f434e",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.aarch64.rpm",
+        "checksum": "sha256:683a9a0d8324ff209827059fe344e6c4ebb361027edae752ce29d9a8bc4d8393",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:706ca338a869ed017d3e0c4c5d8d8541deca2579a9a4afa0e87a73dd024cf558",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "50.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.aarch64.rpm",
+        "checksum": "sha256:c1335f3bc82fd0981738f4b1c6eea10f55af5e2a481977c87d32e11a7f21889b",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9864471ae21a0ab2df4acb7b01ccc873ce9e96df9e09533d73b413144f62359e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d17ce6aa8886afdc6acbf54208c18b49155e9169e0804eeb4958105d484c930c",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:e0164268287c9bc014b0345b366eba731aae966887a8500700e11191d07a0979",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4abbc51cdf34bf003abe0bcdcf96ec91765f716cf2baf48575f9efcf3d951cdd",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba37ee4362bac14ae7a144fecaca12c1cb82fb5ca58f438e388edaa86b9268ba",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.aarch64.rpm",
+        "checksum": "sha256:1f2b4a33b29790a56345ad7cbef9504f8b3e19b428b1698e7194ecdbd4c84410",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c5f938b31f90a447b7d33ec8cfa945b18563363583464ed4cc74b353e67a7a3a",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:a3962cdd23efd8ba09e5eff563f225f6ad1738b90e4e2d376fb59dc0f85c2d8d",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.aarch64.rpm",
+        "checksum": "sha256:ba06ed3d2fb36cf5cd05003978f824536b870cef02b119cd57c4b96222cb7ff0",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:280c88a92a3edcedc5a31aebc8bc79a25998746e9e9454c7faaa1dcd7b054863",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:5bcdd418086a9fd8574c3d528e0c310810aaf1445d6e97c63d808794397acd36",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.aarch64.rpm",
+        "checksum": "sha256:28c22176fa563a26d898595c71215b5ad687748024138721500976ecdad6d10f",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:602ee5ec03f73f7e555cde5ef9fa9f660e12f07c3f1b73dec4a893276a8323a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.aarch64.rpm",
+        "checksum": "sha256:f2be980efad7c111d859023ff1562c2b3663179fda9713e76946a12df33e3992",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0f4d63c769183bbb950de6ce0e257c68f56d377baab6bfd89fb4351260717b81",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:1c4b251dd6794647b9164d593048782afb0502cadb1b6e9d5455d920a82d3fc0",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.aarch64.rpm",
+        "checksum": "sha256:ba36e96b3e1d2cba281156c8a2cbfa50245425193a25fdf7dfc3668f2028850b",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.aarch64.rpm",
+        "checksum": "sha256:149eb6ce4aaccecd786dc48834f07c79add87503e058de8c6bf78dff711b2977",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c73d08e2220771482e9fd937ee71b2d789c726acf65b3944b0609669296cc5e1",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.aarch64.rpm",
+        "checksum": "sha256:f94e4072a677d5315650798b6ad0251023e9dfe91e5eb933a5c0a44df1d54b6d",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.aarch64.rpm",
+        "checksum": "sha256:9bce33c50c5cc10387ed614ee8e1b91e304ce439f2ece1c590065a026655c8ca",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3b6e03653f831b1e3a27b30f55e89bae80325bf2ace04a874f0e9cc2ae011a51",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:8973584f89fad237e15776d4428895fbe8cd898f0cf89f3d7306b51e49f170d3",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:18e6c9215635ae3603ca0176b0b59cb81b844a7f91b37ebf3a6251a2a5a4a280",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fbdaaba781d15ef4acf291749a770ee2a6a83a60d0f7680997300a07951fb1aa",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.aarch64.rpm",
+        "checksum": "sha256:40b73f7d195fad67f3a930d63a1e3843893eca79f20ffca400329fc8f1a88617",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7c7fce49c2645f923257dabd33e22e55d7582e7b0fb1efea7ddf973fa8059f98",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:1840ce806b5f04a2fe552a5cbd0f1aa3e731032760e4429e128a9e494e444480",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nano-6.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c504b5dc406c2c1414fd5f2d15e0e02f1085e31f32a9f8b4df2315ffb19015e8",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:effff0e3bf2d0dcfc701c8ed1cdfc517297de99222193d5c656e17a22c685fe0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.aarch64.rpm",
+        "checksum": "sha256:536025ef966978c27ed0b630fba025ee7f99c1046c8d4941275ffc2bd9291b9d",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:d62545616da3a47fd25b32f03fcfa2f35473d111b972f10b33393419b96773e6",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/n/npth-1.6-8.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf4d3f64e9460dd6206027f5760b3ad5b1284f0a33cddba9c34c7e03a87f794",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:51a67a8e86ce54b668fd70163798e3f1083ab04605f43b00028a37fe214c3817",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:58cf82736ed0d866f86f4fa396eae4c6267b0ba7851d9e456d1d721e4c7dd423",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:55d253ad1a90b0dd8079b93b13167627f49d6e11c2d4ef4054af931403d1b1c4",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.aarch64.rpm",
+        "checksum": "sha256:4fa92481e4a0d90cd43d18c5b29f346f46daad907606ae096c269b9717ce43e7",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.aarch64.rpm",
+        "checksum": "sha256:74a41b907929afecbc63eee29317608a0f20d1ebf8850a93a531993fb0b387ab",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:86bea9dfa140f7e8e232548a17693f81ab4a738b350553d767930ef722ca57ec",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:51b96bd33d3969b5c751b6c5ea8b46e572883e4261ecce7707b4e1f80e5918d2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:cc2298b6351a2631dd07350b8a842e3c95778af3539bfcd80a0138d3b3c817c2",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.aarch64.rpm",
+        "checksum": "sha256:12bc71ae5428aa3b9a5903da6b6345dab5853e36fc3eab59dccd5269fcc706f2",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/parted-3.4-12.fc36.aarch64.rpm",
+        "checksum": "sha256:afe8edcd9ce0b0d86ef388100d88c9d2a78672d08c3be56ed28eec3766e85ea4",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.aarch64.rpm",
+        "checksum": "sha256:e33fd672f043426d3ab578d2b72fe2a969e54acd7c7df32487e58c1861d5ed3f",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.aarch64.rpm",
+        "checksum": "sha256:6411bebd465bb724fe94864ec8a4d36a43df90ba48350a4650a5d00f63030d38",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5b6a7cf86b9a8741590da8a1a72a20cea153babf004db8f543e51ebedce6df0c",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:5edc290d9f5ab21421fd23f0454472ca1086fdad55bc0c1ce992684788a47b17",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a97dc4e08be47862c1804038ff1035d767979f80e9d37dcecfdff4984fb82426",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:54d879df37f53234af6ef191b7427e2c5c4402b4c0c0e808a40a16820c5a5bef",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9ae38a5147ae91c75ad22a30efc7cefaec4ab3dda140d19b410173461a4752b",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.aarch64.rpm",
+        "checksum": "sha256:55121b137cf32d1a71160c3d8c6e4875e4c19f28968ee76ebdd48a7f3df3a440",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:ce799cfef53276047634cf1418c6463c2bd06ffce8d3b41272cd9f3e16d2d242",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.aarch64.rpm",
+        "checksum": "sha256:07d6ac3bde8fd80b026d90087b17816aa544f60aedcf67c57cabb83bfba68112",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.aarch64.rpm",
+        "checksum": "sha256:36844ba28f2810c5cf2c9bf29cf669923633ce092eb3da22e19a914c6b4c4423",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/popt-1.18-7.fc36.aarch64.rpm",
+        "checksum": "sha256:3dd4b459f34bf3fcec0bac537bdea3f2860e2c79f6e3ace425c27305db3c6a38",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.aarch64.rpm",
+        "checksum": "sha256:81fc8a0805e1a3dd97126ecec98fdebdc0f608176537da414ff4c522a3c9b107",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:70672771b5d1207a7994f362e2ffa281f086f8f186f4a1cf7cd880860e2398ff",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.aarch64.rpm",
+        "checksum": "sha256:7741248fcc49a78a93652544bc8040b553cb5247b033591391a0b4e548ea0eed",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "8.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm",
+        "checksum": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.aarch64.rpm",
+        "checksum": "sha256:a8c4a706f63a757c207a3b2f7fd0d5798e8c4e1c0d1dc7460966ab0e930e1b76",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:28988067197e9ad286df064d9c28fb64d0813fb45915d50b6e10916cbd2d54f7",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.aarch64.rpm",
+        "checksum": "sha256:ee8470ec697de1eeac209ef3b08c5a68d9dc45039d0eef7f778462e0ff6ae97b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:fde5b07254aea246a374a735acc04ef3f772a736e3188cfb06b462817a17ad36",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:43c817e2e39c45fc3056cfedfd3af60b3f221c6abd6912d56e4492c9376dfe21",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm",
+        "checksum": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:c0b524a0abfed63f722a2b8b426e7cbfd79074bff42636513a162818c74df3ec",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/readline-8.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:bac5f04319abf0861fa2878a1bda3028802212da4497608068e5394fbfb02828",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "31.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm",
+        "checksum": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:5c476f28435bc633f07a88ff07ab5f782b600ba91888e0ba6c21455f2eba2456",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:fbd583bf2317307de7e6610c39d65e3013b33570151d141fc3997f2efb73e22c",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:0fb0f73618df0a7abda8c22846e60aa3fd617f002508b44011d8a1512f5de5fd",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:775c95fcda57ff525cde658c8661e9ef2250f2eb5ee6f987fd34b1d762ae18e2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:e299af5e2cf5530f50f128f24d24f98a74212edb511257266a524e9fb7d09703",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.aarch64.rpm",
+        "checksum": "sha256:995b579ad1e52d4ef1725862f1d40d8f51959d13c8fa1dac32837cde752d206d",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sed-4.8-10.fc36.aarch64.rpm",
+        "checksum": "sha256:3f066431907dfcf1d9db978d642d14fb8837ffef5fa59142ca23f8b3e2fc43c3",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:2b3b3439f1d01b93ff52ec4c37d0ab6ec0d7dbeba3d4e1f62e051d3411353620",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "3.fc35",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.aarch64.rpm",
+        "checksum": "sha256:f88d6063fe15fd262ed1a3531b74cfc5a76224fc3291099d3a6214717d2f2af8",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.aarch64.rpm",
+        "checksum": "sha256:5cf6cc00044fdcde580ca98b99f3226fee98d7ac51b8993df12c9701d5ddcd6a",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.aarch64.rpm",
+        "checksum": "sha256:bba50d4ba38c5cc615d67e39d0a197eb55ee14f9dedddf831a7888a5da138af3",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.aarch64.rpm",
+        "checksum": "sha256:4f46a54f9379b4959f7e7a9d0d97436a36ebfb198bab76b91f44b00881385afa",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3095c13fd2561e9e004ece1959f1a9a22bc5c3673ed8467c66ebd880633a5d21",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.aarch64.rpm",
+        "checksum": "sha256:86a25e18a0d5e1c314e35653ae975f01dc951108467b021a2d24da0a7a896dbd",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:bf034a64a7f5b0c4abb5da8ff274def143c12a0ec5a043b28048c2c854c56e17",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "15.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.aarch64.rpm",
+        "checksum": "sha256:6bc2bfb1fe071a65bc4ad3fed6a107457c2e4875aecdc8d42fd866aaa417fc0d",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.14.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:eb0a844d22ec62c476a689afad1f62e152de69f56d35d4958098426c9c53cbde",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:f4cc81aa968b2809fb1232b1e94a60b13613c3165fdd8867f6321d12ba9dd521",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.aarch64.rpm",
+        "checksum": "sha256:b8d27bfb68202a584d528af93678cf86f904d182e993fa15f061f7794cf44e01",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.aarch64.rpm",
+        "checksum": "sha256:8a929fce4cf768b44b6fc0a548b89f84d2a26d46f1edb863d037defc372ff054",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:39e2a80b7b68271aca9317ff0d96183a26d5077e3aeef8ca28269c28dda72a0a",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm",
+        "checksum": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2e070ecfd7a0068d61423ea75d1608a5a9013a01a319d2bddeec8a965cea5a0d",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:3032035b371e27c6347c1fa7f01a802cb451c699095d68cbcec22c70471b2b0c",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6141c8c3bbed6c6fcd4a69041ae165b7bf1d58d88f533be47d9f8a5109b64be9",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:babded4fef20e096f235f2444eac579126552794972a0dabb027f0f65adad3a8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3054ee4f903538d7cec2950b68c4f7b3465f3bc42f5ff76e2fdb8e74ef659125",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:2435bb4d3ce8d7c22ca5607de3574f70fde79f589ae4805984d0dfc0128996a7",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bac9afe146f7535eb2eea4c6d0e0c08eca5b5d3ef2a56141b340994ca340501",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cb397c60cbb5cffa69fbf48a0570fa60c9f1d14a7c3df5e5016145e94c49c07e",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm",
+        "checksum": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:2f8c5d39b8a1b5b98bc0fb04fb6966f8fe257044b4d7d08e02f4614bd2baf738",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:d7a1d7c985b283cc07df75e83b30bbaa916db62e15e0aba3263dd73f5e34427a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.aarch64.rpm",
+        "checksum": "sha256:71226c4213b782b15bc6d3be138d9f2ff6009d8d32fcc1197f9ecfb779b251e0",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:ac3fc3af7df5af00455180726fff651412eff2423614b57cc00e9e798e5f5da0",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3468c03d68ee562d80f7a2bd830e54abbc95f7c915028c78ec4a8cc2930f790e",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dad7181357cf9ad9f6b43663aa67d16993355b140a900db1ce7b274808893b06",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c297d39659648688bfa140649057942fbde26942f9388f8a2f2a6f3b89feab1d",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a91d250ca05b736fc50e8c2b029f2ee0f160dfc639287cc0b419ee7dd17d898e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.aarch64.rpm",
+        "checksum": "sha256:fbf042700542b50ce9c93e1457c1d4d49cde8cf609562ebc46ef38be3a8e3be0",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:065befa0aa9e24df7b5c5c29943ff559b0508600a668ede3f75aa86dfb306ae1",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:d692e1f8233e404a31e203fa86fe9c26ee62a59b57f1c1fd2a555b3cff603bb9",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:742e85bb391cee0804329270f258ea984f22ac613c4d6a34772673074e6adc7f",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:aa716436c8fbeebc3b1cd124ff64c262aaed859c3fac7017956c42b5ee2a5def",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.aarch64.rpm",
+        "checksum": "sha256:786271496f200ef64cbee44d56217621f727e9a41c7cb17a3a82421fc6aa547f",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:db82a25bca1d37ce148e2b7fd4edbf5ef673573a650a46ede399f92d6c5d1384",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d580be005d64283434e750f9ef760554ce814dfaa527699541a655f5d7de4d8c",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3d3293398c397ada3d74243def9e2aaa72b2944383924213aef7fd8ccfcfcbf5",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-efi-aa64",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-efi-aa64-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:5fc05299dd26a52da3011a466b1454da89727ab7dd7815595bd162b83adc28b7",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:440af4f0df2a1ad128e1ba2737c55d5c32da5e2c4b90c2944d93c725c22e392d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.aarch64.rpm",
+        "checksum": "sha256:eadc21a5181a7dcce43c916f5c5ea6c1be1024f8b39267239bdc41ba14ffc6e3",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "55",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/i/inih-55-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d317220153bb88b12eb170b840dc08b2b2d82e95811be4cd4437c29b0b80a58a",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:543d7ee043aa48bbe5e59e7c3be68a1e388165b2d739975b05875c50b5787e17",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:ac55ff27ae14022eafd2045548223d137159d9d593675cbb99a41143f7ce9e99",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.aarch64.rpm",
+        "checksum": "sha256:42bc60e4eb49930b10fd5c8567d82aacd7bece633b47f25773ff75d9591f7740",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.aarch64.rpm",
+        "checksum": "sha256:df7a82a371f19592a0b89715fd5727dcb6c4f4e909c65f31db17fa166d81db59",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.aarch64.rpm",
+        "checksum": "sha256:6b05ab620f10b424ae18d8de36a8c68fd8a627956dba8a6feb0295f84f3cbc2e",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.aarch64.rpm",
+        "checksum": "sha256:993824a548628c2bc68bafa3bcd27f8aacc536b5f8624af69dd3c1e3928073ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:81a058836176b0bab03aebca07203198f4b8791392fbb72c021ebf66b6be0884",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb3668ab3897dc10e8ae032491b2597cb07b066232bc8cb0c50d9c4f506c379d",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d4f1a2968526b12ffba46005e3136b7e561e9fc9a415270884d74824e4d4c248",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:103b7bfd272a52e9b3d2c455c0dab98103635ca44c225c3460cbdc32682e9510",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:83c0479bbcf44639596f844f0ca89bee8b8df547cf63ad6d95e1e42cac505ddd",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:54916f1a8a37e1e569d984a965e420d0d90a172176128b4d841976ec324bf41e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e7a9c68d4537d5085f2da7bea020c15c1bc99d80a210d07ccf0aa1bc1f8535fd",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:3150aca3cbb4c9e18866293fb7c78ebf88c781fb0ce0e82ecbb56216153eb142",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2168561de6b48e138ac894fa7bdccd054603516c5e1acae01c1f06de96376580",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:386f62ac622233eac07b3b2582f52bd82022068a0431c5ca23a8344179317c8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:19414d35ff0112965137f13f5b65f76ccceae4f11b76430e2be5e5fbaa7d1410",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:a906e5bccb482e2a96cd61f7a5e1a2b40e6817b1d299f8d86b923c2e3f5f7324",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e2c8cf981ac3b4ce62fed5fc692965ef1db5935df990bc024781785e354dcc16",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.aarch64.rpm",
+        "checksum": "sha256:da1a39e38af8e5fe8c03194dc627dc66aaf3a04ed2b5735c84d057c63202f072",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:cf7fd9b6579cafbaf0a8eb7f2b920b811a9eb140100e1c3757ed8e3d8981fcf0",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:5185077ce91bdc539a6d4c8822ffada94c08c42acff9b383611921e89d82a0c4",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b4e7deca9db24b16ab4c0929beaee1ede1b4ce52e9c7400b41e41bf5c592b949",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.aarch64.rpm",
+        "checksum": "sha256:84e4a800f416ce13abb43c46dea5dcb9b45211246a0040fc24ae786d2d0c44e2",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fb60acbd9b3474eb233de5ac65d82a797a37462bb2a2cdc0ce81f8c80cbdf648",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f70da11ef9bc7627629c465d506e693397bfc34be61eba550fdb8f62cf571510",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.aarch64.rpm",
+        "checksum": "sha256:3d86220c34713ac28d674be349ccc9eb53aa790c2b39025596532ffb92eafcbc",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:1513639e8a21c9e23c998dad07484abb911441a7a614790a0cfd42789446c8ff",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8defe410aa1c967c90c87bfcffb39cda4ef7e22dec00cfd9b4d7fe4cdffbd1ca",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c1377fd3611a3076ff1b721e77ae153239cf4bc33c530f0ea3fa354fa1c0193",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:26d9bfa8bcccabc4565c64027146f39a11f4750e937179a9e023ec272aa3a480",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c2fa391f0c8dab9b77728f5506a1cce5f644a6399c57e230f24da11edb645764",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6619af57c800fb5ec8cdd5ec8ea070897f012c968235f748e313d4de71abd342",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:bbe13975c08a9a12cc6515a62938e3b9f78df54ad322eac5ac1ea502f415067d",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.aarch64.rpm",
+        "checksum": "sha256:364f7226e498df8c3100d07a2795413268fdc1bc0ef038e3b58265d1f45bb0d4",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:9076efd678b1ce0c33b970507a60d055f94fe9f764dd696ded14271d79f2732e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c2f825a9c528760b292febdcaf6c2a90e4085a5654e5e47fff04aceb9ed25a0",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:d4af1f337b8fba9e963211d361544438cadfed85b6bad7da4d924989bfef80e7",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:20c18c9dd69a8a760b193d007ceb51696d645c870674e423f2028e27d8b162ee",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd73559eb343aa30c46c1c2ee7767d2b1268f09cbf9d6f51ebc2aa402fbb5a7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fdfb32e0a20b992aa5264195c22882bcca86c46be2d82d1f9681dc1acae4fd47",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:20c7cb6eed94c035c9b1e3a24f839a4dbbd6ef33bc66795f2d4a860b7734c9d3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:4af8d1faa176bd1fe8271b2bc4dbff6bea7331e3ec696155c87011c367a48467",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e6040063dc14542de3e3f78d4110e9b0f5f2824f19db6b6132e2d50d191b489d",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.aarch64.rpm",
+        "checksum": "sha256:c06d2726504c282659c8bb1ad3e060b0f09a405bc0dae7c9a673843f0fae666c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.aarch64.rpm",
+        "checksum": "sha256:08752167a3f35572f3aee4281ccb0925a91e88a04448e13c41a7fd66fbe8f0ef",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b989e8ff8c0e0183b45d788932bbbd56c7300cdd5f1e345744c7146f491df70c",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b94ba8770e171d3b66e378180e10fb364b53688511f98d940f33ba069dd9c1e1",
+        "check_gpg": true
+      },
+      {
+        "name": "mokutil",
+        "epoch": 2,
+        "version": "0.6.0",
+        "release": "3.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mokutil-0.6.0-3.fc36.aarch64.rpm",
+        "checksum": "sha256:3a2faf2c81074e12b902585c1dc9df7a5c4dfe9abd651c9849a5cdf52462d2b5",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:aa387421816ee1b9b1313282810c8a05da4175e3817f13a71486e9608a3617e5",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:168429c25bcc7d36dde47ef25e5aaf1ca50b7f6f9350a058c45f4e67d5cdce40",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:fc45c301e200fee07cafcd3a3e10f4c139fa4a9ca1f181813933fa92569c4e68",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:e2c31e98b36dcad624e0b01560f97aaeabd212979b19904fc273630f71ba9f0a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:724954cb4c5dc17ebd72ac3d9b58ff5d4df10d235ec5f4d7b48f852614c0167a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c28a0626decb9d370ee2a0119c041dceba4293715df8773991a8c8ed5abd96c",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d7073d75482635b4d8f9cd4955447edf54c0bedab4656c71fd76ca5f97479020",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.aarch64.rpm",
+        "checksum": "sha256:23b6dad4a3d114360b897128785498229edcff1b1a9f18016cdabdc1b4b8a719",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:6c80b2a2f0b2e3daf7f3feaa708bea6487a17f729ee80be687ebab9ea8fa85fa",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:33e0afc0fd03e559ee53e6179868783da343158d8257e6401b3def99a59ac67b",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "9.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.aarch64.rpm",
+        "checksum": "sha256:5a5a6f87ef42ce9bce5bb1cb4308eed0b85ea020d870bfdcd2baac3e471fe7ee",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.aarch64.rpm",
+        "checksum": "sha256:912c53614e3488d3ba7226a4615f43c59fd6f63c18baa1fd38d2d5093abdc6f2",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:558d90151758e0894a377aadd6f4d651f139e7491f211c4d7548f644a55675ab",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b4bd7b370996634a9132a6027c2bd1b9a7091e42df6b8be87890596672bf52a9",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap-compat",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8beac96d9b0e29c84ec86a891585c48f2db50248f2e4e361936e56d0eb5c6d33",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b13face310fdf806a49518bbe4680fe5b6daeb1954c324731da7c8176862a22c",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.aarch64.rpm",
+        "checksum": "sha256:03577a913408c5d52d7b2a496b7772bc2d925a637cdfd6c560179e4dffb94ce6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:ab0f174db1bf134f5288510c8c7c0fa64d3d28ac85ed45fb58d6e0d4ae8af564",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2646322ae496c10f0ad319945a943e726010e2e1e6e7dcf904b7ffcacff9662f",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:36d844b02c2ae134bcca144b5a8585c124cfc1c0536cbd9191cec132b5fc03d6",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:b392422dfd62022636b6d6eae7d21e32236abfe5f90b7ef438ef8cf6e3a2c2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.aarch64.rpm",
+        "checksum": "sha256:913ac376a600ae00bcc55346bbbbd1b52e2b77713ff9fe01ae564a72fa337531",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:d2fdac173bf9bc76ee4dc10cdca0b7e27666b722edf72dd0275410d2b8aa4eac",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.aarch64.rpm",
+        "checksum": "sha256:4df251d7f0566e132997e1813732b7f315a4d64e706b0377e4b97637a1ced615",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.aarch64.rpm",
+        "checksum": "sha256:8c558db2ae4944865ffd3643fe237478a51b86b2d20eb61415816806702a8783",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:4ce75259eee99d0f7c5a7a3a41169b22059c9996bd7c0de7509ff63f363ef5f2",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "shim-aa64",
+        "epoch": 0,
+        "version": "15.6",
+        "release": "1",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/shim-aa64-15.6-1.aarch64.rpm",
+        "checksum": "sha256:f8efcccc5141a5360ab8af037ad9be02d2b617a43db19117133e672806245e34",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:06667da4cd013c4a8c06dc2af38f243ce14d947c0af801b0ee5a49b41ee34944",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:30dab70d00871471edc0c2e9fff73780297291e4740243bc3af3f7c99d32c599",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.aarch64.rpm",
+        "checksum": "sha256:632e6035364601a88d882591ab095bdd32cbacdb66a5bf9e12ad1900b6494b6e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f932007e9b593a5c9795d4411b36ebd16e1966b394718de16374b3c32fe6ecd1",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:8a0ccb30c01ba40a68228115b155def5583a3e1fe59ac760b38658c553b0f86f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:526676cbd9b31ad66729da0dbc0f02330ddc05af6e8017417859c095e9692a04",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm",
+        "checksum": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:f9a50f64d67e39ac2a9c48c8b460b59cdba22d2961c520c539e8990fc81ff13a",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:dd5b6de3aaced37da3b8b6a9640250ec31d6ea9aa7b0523900e8f4ec489f7af5",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.aarch64.rpm",
+        "checksum": "sha256:9bc51c1451f89fa7fbcef8724e6593d14fc1c7bec42ceea0abbc77c7ad629ef5",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.aarch64.rpm",
+        "checksum": "sha256:1f5e069f7741d6a5278149c5d9953aab4c421c8dd617bf2eaee900c4f2238ca7",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:d65c4fd710921eccd2afa6a00ae9f213fdae2c460979231cec9a575e669442db",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.aarch64.rpm",
+        "checksum": "sha256:b592f8e8cff68e0b49a362397020180485d1f9475a065915cac69d16356102de",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm",
+        "checksum": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.aarch64.rpm",
+        "checksum": "sha256:2ee60160a557cdd0a9180895d929366b2fbc1ce570f4d5e255f2b6be56d75353",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "aarch64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-aarch64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.aarch64.rpm",
+        "checksum": "sha256:4353f287a746991e48316aebba2fd8c835a3e411db294b32082af78abf0597fc",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/test/data/manifests/fedora_36-x86_64-armsysready-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-armsysready-boot.json
@@ -1,0 +1,11385 @@
+{
+  "compose-request": {
+    "distro": "fedora-36",
+    "arch": "x86_64",
+    "image-type": "armsysready",
+    "repositories": [
+      {
+        "name": "fedora",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-modular-20220617/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true
+      },
+      {
+        "name": "updates",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      },
+      {
+        "name": "updates-modular",
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-modular-20220705/",
+        "gpgkey": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        "check_gpg": true,
+        "metadata_expire": "6h"
+      }
+    ],
+    "filename": "armsysready.img",
+    "blueprint": {}
+  },
+  "manifest": {
+    "version": "2",
+    "pipelines": [
+      {
+        "name": "build",
+        "runner": "org.osbuild.fedora36",
+        "stages": [
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
+              "labels": {
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "os",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.kernel-cmdline",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "kernel_opts": "ro no_timer_check console=ttyS0,115200n8 biosdevname=0 net.ifnames=0"
+            }
+          },
+          {
+            "type": "org.osbuild.rpm",
+            "inputs": {
+              "packages": {
+                "type": "org.osbuild.files",
+                "origin": "org.osbuild.source",
+                "references": [
+                  {
+                    "id": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "options": {
+              "gpgkeys": [
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n",
+                "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAkKwgBEAC+IQKqp/BI1VIvRRqcnRoAxkzsY3pxIS1L+C4gaWjIMf1eBBTq\nv9eKd4xHsW80VL/tl81WZWO/7JXKmgHODiXrv4HmDIOo6Z1hxehjVRF3Ih4+sKHR\nXCJgwcdJnMfqTKnHiycQggeDuheWbfjV2Fgmvxy0jh0M5PCB5taNz41LmPOaUQmn\nPXcI05CjP5msKjRBObw5Cd2oad60pTNhnBWRf288S8W4wH4jNISOZLZTOf6HU5gJ\nw9wU9RZoaz8kZPNArlJjZsN83S0XLCxpa6UUgYdzPDHOWGtcWGs3bvNAlTYuacun\noICOvTH/ZJU7mgaZbbdSPVLDJdLBKRVgHbdTAK0J913FEiU93GJR5bf/W5FMN7DV\n6hsJVMiY/knJmkTFE9whDSjEc0TAYhQuC1HnzvMPGJvkeEz9nRqna5QUuo7V6LI4\nfZNTSlqFyIi/Oa3ZoliOyOshxJmU3y1HaNcHerO1nFbTtZ7s/TKBhY9oFq4T4gJV\nyFWy33p/JDxOtlVjpHEkzwXGdPe6R4xK8xHObEVraOMZMaweII+tMOGwVbxZu2kC\nA1aflM+oeyU1Fx9qqM0+dYyHO+kp3M5UtfM006RcNcdfoGrA4l6z9sUnHKsYzOLP\nRvKkzxiX3T91vHtRGCXjPOgOsJJzjkFtE1a5oFZg39fC99HZdbX0rUqAtQARAQAB\ntDFGZWRvcmEgKDM2KSA8ZmVkb3JhLTM2LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEU97Sy5Iti42eY/0YmZ98vzircfQFAmAkKwgCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQmZ98vzircfSGaxAAlDBWuY1Ch3YsssGE\nuaeOuaHmDj08p08WUAFUPBN0ID+0pmRQjywFzrufw8Z2g/lHwic+tpXXr/RtMmcl\n+WzLh1E34TRqEngjDJ27QBq1Jyid3h1manKLhZhJ8b1usKHP7Dqh7n+eMTv2Qgrt\n6MrCNe4otWZ9WJ5vp/Bay5yAtU6lNoWBmJ+6BS1/2mg2jhoXrfg/Vey+/i6nYZIk\nM4IcYCyGCi9rjc8NMgkCyzPkPJtsy2taB+VdUcZyjFpc1acmC8sR/2/SEl4+pOtM\nUzW+OUOQFrerX/8MC5LqvmtsiPMyRDCOw3reJTXyoUIehoHoK9QtAdIRRP2nAkPy\nGKycVzsLbtheJXUZharXL1DwOkpMNlm3hp9BxX89m7dLblMSjtrQPs8CkpAExAQW\nFBltsD73ZhGnfE/XdWp7343m1w5W2m85/rczP+2et+c+HPmYTgaJTu8fAF0FoTDd\nuD1r9DxRa2oN3YBiPP/nXnhJaH//GgF/RRw7Fbc66fCh8DTrMsPgmyi/O3/pdSGe\nk0UqEfSdzNPbl7gVFlCbr4Ur5n1ph+sEZqOhMuyszLZZvYvUrHsDuanML5X25coP\nh+rqyjHJJeYlS2tMAQB1fmHB0LWhRhKYaOROAXFmUutFUxVVoigNCl8mV561DCz6\n6/zy81ZGeyUGOEIZ1NFuoY0EhC8=\n=KaIq\n-----END PGP PUBLIC KEY BLOCK-----\n"
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.fix-bls",
+            "options": {
+              "prefix": ""
+            }
+          },
+          {
+            "type": "org.osbuild.locale",
+            "options": {
+              "language": "en_US"
+            }
+          },
+          {
+            "type": "org.osbuild.hostname",
+            "options": {
+              "hostname": "localhost.localdomain"
+            }
+          },
+          {
+            "type": "org.osbuild.timezone",
+            "options": {
+              "zone": "UTC"
+            }
+          },
+          {
+            "type": "org.osbuild.fstab",
+            "options": {
+              "filesystems": [
+                {
+                  "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+                  "vfs_type": "ext4",
+                  "path": "/",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+                  "vfs_type": "ext4",
+                  "path": "/boot",
+                  "options": "defaults"
+                },
+                {
+                  "uuid": "7B77-95E7",
+                  "vfs_type": "vfat",
+                  "path": "/boot/efi",
+                  "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+                  "passno": 2
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.grub2",
+            "options": {
+              "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "legacy": "i386-pc",
+              "saved_entry": "ffffffffffffffffffffffffffffffff-5.18.9-200.fc36.x86_64",
+              "write_cmdline": false,
+              "config": {
+                "default": "saved"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.selinux",
+            "options": {
+              "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"
+            }
+          }
+        ]
+      },
+      {
+        "name": "image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "armsysready.img",
+              "size": "3958374400"
+            }
+          },
+          {
+            "type": "org.osbuild.sfdisk",
+            "options": {
+              "label": "gpt",
+              "uuid": "D209C89E-EA5E-4FBD-B161-B461CCE297E0",
+              "partitions": [
+                {
+                  "bootable": true,
+                  "size": 2048,
+                  "start": 2048,
+                  "type": "21686148-6449-6E6F-744E-656564454649",
+                  "uuid": "FAC7F1FB-3E8D-4137-A512-961DE09A5549"
+                },
+                {
+                  "size": 409600,
+                  "start": 4096,
+                  "type": "C12A7328-F81F-11D2-BA4B-00A0C93EC93B",
+                  "uuid": "68B2905B-DF3E-4FB3-80FA-49D1E773AA33"
+                },
+                {
+                  "size": 1024000,
+                  "start": 413696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "CB07C243-BC44-4717-853E-28852021225B"
+                },
+                {
+                  "size": 6293471,
+                  "start": 1437696,
+                  "type": "0FC63DAF-8483-4772-8E79-3D69D8477DE4",
+                  "uuid": "6264D520-3FB9-423F-8AB8-7A0A8E3D3562"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "7B7795E7"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 4096,
+                  "size": 409600,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
+              "label": "boot"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 413696,
+                  "size": 1024000,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
+              "label": "root"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1437696,
+                  "size": 6293471,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:os"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "boot": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 413696,
+                  "size": 1024000
+                }
+              },
+              "boot.efi": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 4096,
+                  "size": 409600
+                }
+              },
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "armsysready.img",
+                  "start": 1437696,
+                  "size": 6293471
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.ext4",
+                "source": "root",
+                "target": "/"
+              },
+              {
+                "name": "boot",
+                "type": "org.osbuild.ext4",
+                "source": "boot",
+                "target": "/boot"
+              },
+              {
+                "name": "boot.efi",
+                "type": "org.osbuild.fat",
+                "source": "boot.efi",
+                "target": "/boot/efi"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.grub2.inst",
+            "options": {
+              "filename": "armsysready.img",
+              "platform": "i386-pc",
+              "location": 2048,
+              "core": {
+                "type": "mkimage",
+                "partlabel": "gpt",
+                "filesystem": "ext4"
+              },
+              "prefix": {
+                "type": "partition",
+                "partlabel": "gpt",
+                "number": 2,
+                "path": "/grub2"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "sources": {
+      "org.osbuild.curl": {
+        "items": {
+          "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm"
+          },
+          "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm"
+          },
+          "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm"
+          },
+          "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm"
+          },
+          "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.x86_64.rpm"
+          },
+          "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm"
+          },
+          "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm"
+          },
+          "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm"
+          },
+          "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm"
+          },
+          "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.x86_64.rpm"
+          },
+          "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm"
+          },
+          "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.x86_64.rpm"
+          },
+          "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm"
+          },
+          "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm"
+          },
+          "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm"
+          },
+          "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm"
+          },
+          "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm"
+          },
+          "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm"
+          },
+          "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm"
+          },
+          "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm"
+          },
+          "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.x86_64.rpm"
+          },
+          "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.x86_64.rpm"
+          },
+          "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm"
+          },
+          "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm"
+          },
+          "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm"
+          },
+          "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm"
+          },
+          "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm"
+          },
+          "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.x86_64.rpm"
+          },
+          "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm"
+          },
+          "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm"
+          },
+          "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm"
+          },
+          "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm"
+          },
+          "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm"
+          },
+          "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.x86_64.rpm"
+          },
+          "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm"
+          },
+          "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm"
+          },
+          "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm"
+          },
+          "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nano-6.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm"
+          },
+          "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm"
+          },
+          "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.x86_64.rpm"
+          },
+          "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm"
+          },
+          "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm"
+          },
+          "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm"
+          },
+          "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.x86_64.rpm"
+          },
+          "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm"
+          },
+          "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm"
+          },
+          "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.x86_64.rpm"
+          },
+          "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm"
+          },
+          "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.x86_64.rpm"
+          },
+          "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm"
+          },
+          "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm"
+          },
+          "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/i/inih-55-1.fc36.x86_64.rpm"
+          },
+          "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm"
+          },
+          "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.x86_64.rpm"
+          },
+          "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm"
+          },
+          "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm"
+          },
+          "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm"
+          },
+          "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.x86_64.rpm"
+          },
+          "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm"
+          },
+          "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-modules-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm"
+          },
+          "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.x86_64.rpm"
+          },
+          "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm"
+          },
+          "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.x86_64.rpm"
+          },
+          "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm"
+          },
+          "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm"
+          },
+          "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.x86_64.rpm"
+          },
+          "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm"
+          },
+          "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm"
+          },
+          "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.x86_64.rpm"
+          },
+          "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm"
+          },
+          "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm"
+          },
+          "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm"
+          },
+          "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.x86_64.rpm"
+          },
+          "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm"
+          },
+          "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm"
+          },
+          "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.x86_64.rpm"
+          },
+          "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.x86_64.rpm"
+          },
+          "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm"
+          },
+          "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsmbios-2.4.3-5.fc36.x86_64.rpm"
+          },
+          "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.x86_64.rpm"
+          },
+          "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm"
+          },
+          "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.x86_64.rpm"
+          },
+          "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm"
+          },
+          "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm"
+          },
+          "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm"
+          },
+          "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm"
+          },
+          "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm"
+          },
+          "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm"
+          },
+          "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.x86_64.rpm"
+          },
+          "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm"
+          },
+          "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm"
+          },
+          "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.x86_64.rpm"
+          },
+          "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjaylink-0.2.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.x86_64.rpm"
+          },
+          "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm"
+          },
+          "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm"
+          },
+          "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm"
+          },
+          "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm"
+          },
+          "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm"
+          },
+          "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm"
+          },
+          "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.x86_64.rpm"
+          },
+          "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm"
+          },
+          "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm"
+          },
+          "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm"
+          },
+          "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/less-590-3.fc36.x86_64.rpm"
+          },
+          "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pciutils-libs-3.7.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm"
+          },
+          "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.x86_64.rpm"
+          },
+          "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm"
+          },
+          "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.x86_64.rpm"
+          },
+          "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.x86_64.rpm"
+          },
+          "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm"
+          },
+          "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm"
+          },
+          "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm"
+          },
+          "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm"
+          },
+          "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.x86_64.rpm"
+          },
+          "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm"
+          },
+          "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm"
+          },
+          "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.x86_64.rpm"
+          },
+          "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm"
+          },
+          "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm"
+          },
+          "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.x86_64.rpm"
+          },
+          "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.x86_64.rpm"
+          },
+          "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm"
+          },
+          "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.x86_64.rpm"
+          },
+          "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm"
+          },
+          "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm"
+          },
+          "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm"
+          },
+          "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm"
+          },
+          "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm"
+          },
+          "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgudev-237-2.fc36.x86_64.rpm"
+          },
+          "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm"
+          },
+          "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm"
+          },
+          "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm"
+          },
+          "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.x86_64.rpm"
+          },
+          "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/parted-3.4-12.fc36.x86_64.rpm"
+          },
+          "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm"
+          },
+          "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm"
+          },
+          "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm"
+          },
+          "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.x86_64.rpm"
+          },
+          "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm"
+          },
+          "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm"
+          },
+          "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm"
+          },
+          "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.x86_64.rpm"
+          },
+          "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm"
+          },
+          "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm"
+          },
+          "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.x86_64.rpm"
+          },
+          "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm"
+          },
+          "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm"
+          },
+          "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.x86_64.rpm"
+          },
+          "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.x86_64.rpm"
+          },
+          "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm"
+          },
+          "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm"
+          },
+          "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm"
+          },
+          "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm"
+          },
+          "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm"
+          },
+          "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm"
+          },
+          "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm"
+          },
+          "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.x86_64.rpm"
+          },
+          "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm"
+          },
+          "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm"
+          },
+          "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm"
+          },
+          "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.x86_64.rpm"
+          },
+          "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm"
+          },
+          "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm"
+          },
+          "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm"
+          },
+          "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.x86_64.rpm"
+          },
+          "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm"
+          },
+          "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.x86_64.rpm"
+          },
+          "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm"
+          },
+          "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm"
+          },
+          "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm"
+          },
+          "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.x86_64.rpm"
+          },
+          "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm"
+          },
+          "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm"
+          },
+          "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm"
+          },
+          "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.x86_64.rpm"
+          },
+          "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm"
+          },
+          "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.x86_64.rpm"
+          },
+          "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm"
+          },
+          "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm"
+          },
+          "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm"
+          },
+          "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1": {
+            "url": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jq-1.6-13.fc36.x86_64.rpm"
+          }
+        }
+      }
+    }
+  },
+  "rpmmd": {
+    "build": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm",
+        "checksum": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm",
+        "checksum": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm",
+        "checksum": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm",
+        "checksum": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
+        "checksum": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm",
+        "checksum": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm",
+        "checksum": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm",
+        "checksum": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm",
+        "checksum": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm",
+        "checksum": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm",
+        "checksum": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm",
+        "checksum": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm",
+        "checksum": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm",
+        "checksum": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm",
+        "checksum": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm",
+        "checksum": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm",
+        "checksum": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm",
+        "checksum": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "32.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm",
+        "checksum": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm",
+        "checksum": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-modules-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm",
+        "checksum": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      }
+    ],
+    "os": [
+      {
+        "name": "alternatives",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/alternatives-1.19-2.fc36.x86_64.rpm",
+        "checksum": "sha256:904a986d78a659d2c8fa5b810d884c0362f345979c74e0731065e22ab8988c9d",
+        "check_gpg": true
+      },
+      {
+        "name": "audit",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bafbc5e2d6b05c4911cb000b4f80f7475cac9afcd14172b26a8b0038c8491f1e",
+        "check_gpg": true
+      },
+      {
+        "name": "audit-libs",
+        "epoch": 0,
+        "version": "3.0.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/a/audit-libs-3.0.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e0826095bb40863ddd1aed39a40fe8f041e1472049f322702f1fdcd024afe819",
+        "check_gpg": true
+      },
+      {
+        "name": "basesystem",
+        "epoch": 0,
+        "version": "11",
+        "release": "13.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/basesystem-11-13.fc36.noarch.rpm",
+        "checksum": "sha256:980fcdf5271317b6222bf1b207e77244e145644a9e0c7bd2924c69577d3f6010",
+        "check_gpg": true
+      },
+      {
+        "name": "bash",
+        "epoch": 0,
+        "version": "5.1.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bash-5.1.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:41e48721a1bc39ded294bef9e9051c591bc43f3b8e691c188de688c892c115df",
+        "check_gpg": true
+      },
+      {
+        "name": "bluez",
+        "epoch": 0,
+        "version": "5.64",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bluez-5.64-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4db9bb285f364b472000badad7fc7e29999f8edf0b62b6d1ef5d379435fd165f",
+        "check_gpg": true
+      },
+      {
+        "name": "bubblewrap",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bubblewrap-0.5.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:28b98634695e2f0a9f5f616b84ecb21d2726f1b360ca16ba8f48aceda4a8e0fa",
+        "check_gpg": true
+      },
+      {
+        "name": "bzip2-libs",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/b/bzip2-libs-1.0.8-11.fc36.x86_64.rpm",
+        "checksum": "sha256:dfe5b8a66e8c4593b0f5d7e6fc3bbeb605ec3cd0853fc9bc3a51afeb71d2f4e4",
+        "check_gpg": true
+      },
+      {
+        "name": "c-ares",
+        "epoch": 0,
+        "version": "1.17.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/c-ares-1.17.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a9e689f42a53bf760c2d56e0254f4c69213f13b57b1a0cd12ee2ef0529c6f70b",
+        "check_gpg": true
+      },
+      {
+        "name": "ca-certificates",
+        "epoch": 0,
+        "version": "2021.2.52",
+        "release": "3.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/ca-certificates-2021.2.52-3.fc36.noarch.rpm",
+        "checksum": "sha256:859e0f1a7bd1b4f82a016a4249d6184985481eb6ad0f4fea2db9e715d5956d2a",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:9a16ff0282725909ce05ee23e8c6b1ec05917811e7a45af0933472781b1efd96",
+        "check_gpg": true
+      },
+      {
+        "name": "coreutils-common",
+        "epoch": 0,
+        "version": "9.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/coreutils-common-9.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec6fd803e89c5842f4969fe25f774a87786f8dd3e9da99a5d8da0f5a89aa078a",
+        "check_gpg": true
+      },
+      {
+        "name": "cpio",
+        "epoch": 0,
+        "version": "2.13",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cpio-2.13-12.fc36.x86_64.rpm",
+        "checksum": "sha256:fc4044c5f26f16a256716e0912a7f88fade8c50de8735d2cb4d20609e2e11ee5",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:d4bb564556892ebaba5990b3f797d9100bd46be9678eb7031e40e0ac4a41d3b3",
+        "check_gpg": true
+      },
+      {
+        "name": "cracklib-dicts",
+        "epoch": 0,
+        "version": "2.9.6",
+        "release": "28.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cracklib-dicts-2.9.6-28.fc36.x86_64.rpm",
+        "checksum": "sha256:f7516bcfc6dae3781d581225f488e410531184b85bb221ce409bb7583fc20439",
+        "check_gpg": true
+      },
+      {
+        "name": "cryptsetup-libs",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cryptsetup-libs-2.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:98f17aa3b01b1edaccdcfa96cc03889b0781a7b8a5f1f8dc7238a5ebb215747c",
+        "check_gpg": true
+      },
+      {
+        "name": "cyrus-sasl-lib",
+        "epoch": 0,
+        "version": "2.1.27",
+        "release": "18.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/c/cyrus-sasl-lib-2.1.27-18.fc36.x86_64.rpm",
+        "checksum": "sha256:530724a3a2ff521c3b4d7a38ab82b215bdb31ac21e0d4794d1a7e5b613d66a39",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abfc68c11e202ba2bf9222db0912c083a17ee508e0a95632fa91097c19271277",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-common",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-common-1.14.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:6b31afabeec2f75828a9dbf31a059307a91d69f4387c0c20cef6f1085b0f1d9a",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-libs",
+        "epoch": 1,
+        "version": "1.14.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dbus-libs-1.14.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eaeb5140174492d0bd26806a079ae00c26e78da1d67aecbbdd274e1e74f4ca93",
+        "check_gpg": true
+      },
+      {
+        "name": "deltarpm",
+        "epoch": 0,
+        "version": "3.6.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/deltarpm-3.6.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:89ce9d545da60404ed91ec236b2d3040c3fcbc9c61658c0a07baf0adcb512360",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:58b25dc11c58ad8e3d318ea429cc111fe3908ac206ea1bc69287bc300dde0544",
+        "check_gpg": true
+      },
+      {
+        "name": "device-mapper-libs",
+        "epoch": 0,
+        "version": "1.02.175",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/device-mapper-libs-1.02.175-7.fc36.x86_64.rpm",
+        "checksum": "sha256:655e9e13097ec637aa8387a24de8123b15237e2fad4e6b6c9a0bb330a7df477d",
+        "check_gpg": true
+      },
+      {
+        "name": "diffutils",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/diffutils-3.8-2.fc36.x86_64.rpm",
+        "checksum": "sha256:26a52a1f741452daf0aa9ae664782f185aafaa190698403553838ef28001e562",
+        "check_gpg": true
+      },
+      {
+        "name": "dmidecode",
+        "epoch": 1,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dmidecode-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2ee89bb45ed9fea2cd576a967978acd3c93095f22414fd81e2042522ec04d79e",
+        "check_gpg": true
+      },
+      {
+        "name": "dosfstools",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dosfstools-4.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a562433d14503b4605f425a4f962d3aca81f7b544b8d50ba3ede2c90dc14cccd",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5ea12c063c4ef96868d2788aa784f1a81d11ba62c28740a4e75dd86f9aa5d74c",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-generic",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-generic-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:55b9b9595efb83f4f6638c47125817cabb3b486ecbc786d4ce2b014e8a81cca9",
+        "check_gpg": true
+      },
+      {
+        "name": "dracut-config-rescue",
+        "epoch": 0,
+        "version": "056",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/d/dracut-config-rescue-056-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c775dfbd34c0f950be4aa77dd67f7d9b30c880f64b29b453896d83812a69722f",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1f0542fc05afa188fe48ff0a27f704905f97ed8d64b08723b5a1cef1cf572f3c",
+        "check_gpg": true
+      },
+      {
+        "name": "e2fsprogs-libs",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/e2fsprogs-libs-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:611ad0e901c7c82a439f3791d92946bbed051b7fad6ac7119e42cc06fa4fa653",
+        "check_gpg": true
+      },
+      {
+        "name": "efivar-libs",
+        "epoch": 0,
+        "version": "38",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/efivar-libs-38-2.fc36.x86_64.rpm",
+        "checksum": "sha256:eaf42f29c0f991a0059fcaa41c79b1ebff0c243c5b8f398bfba2aab2b5c89cf0",
+        "check_gpg": true
+      },
+      {
+        "name": "expat",
+        "epoch": 0,
+        "version": "2.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/e/expat-2.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f9033ba1a971637f022a54c7a06dcf4ec415b3d9db91baa60371517f74be8270",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-gpg-keys",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-gpg-keys-36-1.noarch.rpm",
+        "checksum": "sha256:6f77d6472fc78a366d51eca781d634a018f44f6f20230da99f8f50b03a45040e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-36-17.noarch.rpm",
+        "checksum": "sha256:72ff0b23a27d42aa59faa9a399b4f27bcf36bbfb78e300c5ff33e48d3801992d",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-common",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-common-36-17.noarch.rpm",
+        "checksum": "sha256:972a244cd66eac2898c9055ec6d76951187aff499317577bfac7166c9d18d09e",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-release-identity-basic",
+        "epoch": 0,
+        "version": "36",
+        "release": "17",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-release-identity-basic-36-17.noarch.rpm",
+        "checksum": "sha256:2ead2f5425caffc7793bf77d1c6988cb2f04407f896eb871a2bd8a42ea40f07b",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-36-1.noarch.rpm",
+        "checksum": "sha256:af61689ff8c73c9b6d3d0300b684b0acabfcc044c72fed474fb38b90e0fd8488",
+        "check_gpg": true
+      },
+      {
+        "name": "fedora-repos-modular",
+        "epoch": 0,
+        "version": "36",
+        "release": "1",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fedora-repos-modular-36-1.noarch.rpm",
+        "checksum": "sha256:12b00a73fc02a7248bf84ce57b88e141d07074de7c9e2ab008bb7a06b4e0ccaa",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:48fa6437623d6150920e0943c3da1dfc33fa3cacd8da0f855a5ddcffcb391dd1",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.41",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/file-libs-5.41-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bde9b344041c56e2675affde84ec7b664edd7b5772fd45f8a2443bf86a1ecf56",
+        "check_gpg": true
+      },
+      {
+        "name": "filesystem",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/filesystem-3.16-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ed4ee3a033cc2863dac1a0764a5a5a8baf6a9ea38df7e95627d1888661f550cd",
+        "check_gpg": true
+      },
+      {
+        "name": "findutils",
+        "epoch": 1,
+        "version": "4.9.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/findutils-4.9.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8538fa89782bc58d5f0d7fdf67186710198f3e1f66fc4fc0bce7e32bf738ffd4",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:5e8c3a4880ee1eb5c71cbf078bd2a9a34a438bcd4e1eb0563ab0bb535c7140fb",
+        "check_gpg": true
+      },
+      {
+        "name": "firewalld-filesystem",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/firewalld-filesystem-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:438307832ee7be7b1b5244368a5a74fa986712499d0772f6140f3c1758701aad",
+        "check_gpg": true
+      },
+      {
+        "name": "flashrom",
+        "epoch": 0,
+        "version": "1.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/flashrom-1.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:7c4dfb2d2b98022bdcfa0bcde99345c340ba2ec1cbb19ddc33a02dd8f70a12e3",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "14.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/f/fuse-libs-2.9.9-14.fc36.x86_64.rpm",
+        "checksum": "sha256:db0832b77165d95aa970827fd43ebaf81f959ea55eab291579e1b98a5ad91ff7",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:a3ce0c0d3def5892dea6212c47976c61783ac3a0cf62007e32d08371090a443e",
+        "check_gpg": true
+      },
+      {
+        "name": "gawk-all-langpacks",
+        "epoch": 0,
+        "version": "5.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gawk-all-langpacks-5.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:848901e0a048af821fa26a48732ff6325c8352cf46e084d4e5cbccd5b21f1f9e",
+        "check_gpg": true
+      },
+      {
+        "name": "gdbm-libs",
+        "epoch": 1,
+        "version": "1.22",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gdbm-libs-1.22-2.fc36.x86_64.rpm",
+        "checksum": "sha256:96fad4de70bd7fbffd5f8f7c0283954c8c28b2b63833e6690f2e1bbcca9fd5ff",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-city",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-city-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:0dfd263efc2bc080ea25546accbfd1b18ec64577bce2d829037676f1b3484c2a",
+        "check_gpg": true
+      },
+      {
+        "name": "geolite2-country",
+        "epoch": 0,
+        "version": "20191217",
+        "release": "6.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/geolite2-country-20191217-6.fc36.noarch.rpm",
+        "checksum": "sha256:4fbf1684a4ed40e6652817d41bdedde84c2ffa1c722067907d301c526b69f11b",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:f1e3e65c4c281021ac5e18136360a2ea563122e13b53acb178a88faa68f81d71",
+        "check_gpg": true
+      },
+      {
+        "name": "gettext-libs",
+        "epoch": 0,
+        "version": "0.21",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gettext-libs-0.21-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5ae8b46b3233b6af6850fdb84ee26ffa896cee9ccb5847f834db452b210a35b1",
+        "check_gpg": true
+      },
+      {
+        "name": "gmp",
+        "epoch": 1,
+        "version": "6.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gmp-6.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f1bf5a7a69bdd9f51c3f9cded7e8e9a1e589b9718d059e5ac43f690526a9f52",
+        "check_gpg": true
+      },
+      {
+        "name": "gobject-introspection",
+        "epoch": 0,
+        "version": "1.72.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gobject-introspection-1.72.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eb95ae512e34a19ec7d2b4f36e244c7fbb2622e2046a79aa7f9cf514d817a9ab",
+        "check_gpg": true
+      },
+      {
+        "name": "gpgme",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gpgme-1.15.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:d4cf97f8df32e57949d6cd29c95da335bc3f1b8bbe8d5f73dfb327e64fd500e7",
+        "check_gpg": true
+      },
+      {
+        "name": "grep",
+        "epoch": 0,
+        "version": "3.7",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grep-3.7-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c46fc6b15fa0792536c795f620f78ef97f53fa52983ed536579910c209eedc3e",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/groff-base-1.22.4-9.fc36.x86_64.rpm",
+        "checksum": "sha256:fa180f3216a84395f92ca6e4044b5f8067c351cd516d91c25a16335cabe4a43e",
+        "check_gpg": true
+      },
+      {
+        "name": "grubby",
+        "epoch": 0,
+        "version": "8.40",
+        "release": "57.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/grubby-8.40-57.fc36.x86_64.rpm",
+        "checksum": "sha256:683ee90d7b9877c6e1f776ccb1fffd6ef6b664b94fa90b34c13261f9a4cb9847",
+        "check_gpg": true
+      },
+      {
+        "name": "gzip",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/g/gzip-1.11-3.fc36.x86_64.rpm",
+        "checksum": "sha256:37bb01612b09113de244ccbb1cb786d60a3fa9994e3f9ff36b2b0dfe7520c8bc",
+        "check_gpg": true
+      },
+      {
+        "name": "hostname",
+        "epoch": 0,
+        "version": "3.23",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/h/hostname-3.23-6.fc36.x86_64.rpm",
+        "checksum": "sha256:6828edb88734beb0ed0a3f92257c2d8528fba1fac90bfd44747d8491e83eaf57",
+        "check_gpg": true
+      },
+      {
+        "name": "ima-evm-utils",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ima-evm-utils-1.4-5.fc36.x86_64.rpm",
+        "checksum": "sha256:20026a80599cc22463cefafe5607d90d249dd414306e5f3bb5616cb45836403a",
+        "check_gpg": true
+      },
+      {
+        "name": "initscripts-service",
+        "epoch": 0,
+        "version": "10.16",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/initscripts-service-10.16-2.fc36.noarch.rpm",
+        "checksum": "sha256:3d3f8a87e7ef8e316ee503579adcf295a33e28f0bfc4bf50d1770629abddc19c",
+        "check_gpg": true
+      },
+      {
+        "name": "ipcalc",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipcalc-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:90373252c19e5af71af8c0db1775727a9fc66e801bfa94390e8e482d38c209bc",
+        "check_gpg": true
+      },
+      {
+        "name": "iproute",
+        "epoch": 0,
+        "version": "5.15.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iproute-5.15.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1adc225761ab40fe003e4136e8d327e8afa0fe5da74d1aeecebc706b2ece4f8b",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-7.15-2.fc36.x86_64.rpm",
+        "checksum": "sha256:1ca472a7624eaeae3dcb111e9d9ba3eac791f1a44567c77c680f1a4b06f03e22",
+        "check_gpg": true
+      },
+      {
+        "name": "ipset-libs",
+        "epoch": 0,
+        "version": "7.15",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/ipset-libs-7.15-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a24ce1c4e69fe649d79a58f2636e4891c365bf36c3c9a35c49114fe72df5426",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-libs",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-libs-1.8.7-15.fc36.x86_64.rpm",
+        "checksum": "sha256:6218b686e396a0eec312f93e7d1418e00b7a32ae95926fb7d7835f44e72f8526",
+        "check_gpg": true
+      },
+      {
+        "name": "iptables-nft",
+        "epoch": 0,
+        "version": "1.8.7",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iptables-nft-1.8.7-15.fc36.x86_64.rpm",
+        "checksum": "sha256:43c0e8bfebcaa60781ebe874e6790fdeea4ea0fde572ce47d8cffce1f2f2c89a",
+        "check_gpg": true
+      },
+      {
+        "name": "iputils",
+        "epoch": 0,
+        "version": "20211215",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/i/iputils-20211215-2.fc36.x86_64.rpm",
+        "checksum": "sha256:3bea089c91795fb1754cbcd7f54f84caa5adff4a36422c6b74d150f3f30d4734",
+        "check_gpg": true
+      },
+      {
+        "name": "jansson",
+        "epoch": 0,
+        "version": "2.13.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jansson-2.13.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4aef4b7bd425f1118403818bf469878b1ba2881d21385074bec813d1ba3f3fb9",
+        "check_gpg": true
+      },
+      {
+        "name": "jq",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "13.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/jq-1.6-13.fc36.x86_64.rpm",
+        "checksum": "sha256:fdfa9da9d905dc4c5dd71a0b22a829bcdd05e9274ebd0538e57e18036fe63ad1",
+        "check_gpg": true
+      },
+      {
+        "name": "json-c",
+        "epoch": 0,
+        "version": "0.15",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-c-0.15-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0656e202aedb1c8ae6de07dd6a68bffeeb37a1a76eef14486ce65cf0b7d1d30e",
+        "check_gpg": true
+      },
+      {
+        "name": "json-glib",
+        "epoch": 0,
+        "version": "1.6.6",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/j/json-glib-1.6.6-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4538200e6752e1cc8844a50115193d736ee06d4fb6096c51bd925d1a2bd9bd8d",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-2.4.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:bf2808493f17c4bbd08f8bd9955fb67d5b19dea82a7c35cfe47a87f7a4e4b041",
+        "check_gpg": true
+      },
+      {
+        "name": "kbd-misc",
+        "epoch": 0,
+        "version": "2.4.0",
+        "release": "9.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kbd-misc-2.4.0-9.fc36.noarch.rpm",
+        "checksum": "sha256:e239a9bc15922bd4dbf00e0e9a41f5c8abb143260550b1ae8df665bb6e2c2d01",
+        "check_gpg": true
+      },
+      {
+        "name": "keyutils-libs",
+        "epoch": 0,
+        "version": "1.6.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/keyutils-libs-1.6.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1c543edcd48e7a658bae3f365bfee3f72119b1b1845f53d2235b611c2b207514",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:9888e72e3d67137d0b769eb00e13b695c7b3f01a130ee7120577829df77c1857",
+        "check_gpg": true
+      },
+      {
+        "name": "kmod-libs",
+        "epoch": 0,
+        "version": "29",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kmod-libs-29-7.fc36.x86_64.rpm",
+        "checksum": "sha256:4a7da64a421279d015c56bf9dae07831ca2c2da1297924f4977ca77fae944493",
+        "check_gpg": true
+      },
+      {
+        "name": "kpartx",
+        "epoch": 0,
+        "version": "0.8.7",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/k/kpartx-0.8.7-8.fc36.x86_64.rpm",
+        "checksum": "sha256:60bea9c2d4879da68d99705a0298c3c78afb541ba4e37be47721ba0135fbd3bc",
+        "check_gpg": true
+      },
+      {
+        "name": "less",
+        "epoch": 0,
+        "version": "590",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/less-590-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b30ca62dd91fcddba2a393ef7e023ceb9f9ee2ac4d59b9a61d56ab929832da0b",
+        "check_gpg": true
+      },
+      {
+        "name": "libacl",
+        "epoch": 0,
+        "version": "2.3.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libacl-2.3.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:46771abbb30acbfc225f629ff0147d0214798d5ab78fc4fdd5a2d76f96a2f354",
+        "check_gpg": true
+      },
+      {
+        "name": "libassuan",
+        "epoch": 0,
+        "version": "2.5.5",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libassuan-2.5.5-4.fc36.x86_64.rpm",
+        "checksum": "sha256:1f4f8b80a39f4cde1a15072097cba266333cc1a840f494c7f33affbcc0f66f49",
+        "check_gpg": true
+      },
+      {
+        "name": "libatasmart",
+        "epoch": 0,
+        "version": "0.19",
+        "release": "22.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libatasmart-0.19-22.fc36.x86_64.rpm",
+        "checksum": "sha256:b7169456c74b621072ff489f95505802556ec1598c9d69185c95904344e19f86",
+        "check_gpg": true
+      },
+      {
+        "name": "libattr",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libattr-2.5.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:95b56c893908fc754a12cf3b642b15a7bd5125adac68e1bb4fe132c97c5078c0",
+        "check_gpg": true
+      },
+      {
+        "name": "libbasicobjects",
+        "epoch": 0,
+        "version": "0.1.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbasicobjects-0.1.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:c1c0911df45e7a2ed245ee9481ed9aef3c2264cf866e7237498f1d24140054c8",
+        "check_gpg": true
+      },
+      {
+        "name": "libbrotli",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libbrotli-1.0.9-7.fc36.x86_64.rpm",
+        "checksum": "sha256:0a11734d106ef686aff422bf6f73013146258d681d598abedec508ecc3336e08",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap",
+        "epoch": 0,
+        "version": "2.48",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcap-2.48-4.fc36.x86_64.rpm",
+        "checksum": "sha256:4a75ce0a307f5868d30f8a60a55699f8be8b19e99d5d3e505a2a575a643106b0",
+        "check_gpg": true
+      },
+      {
+        "name": "libcbor",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcbor-0.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:ec881b6244fc5bb962cd9eb2e71ccd3d4e7ca55f3e33571210eebdf480bdb344",
+        "check_gpg": true
+      },
+      {
+        "name": "libcollection",
+        "epoch": 0,
+        "version": "0.7.0",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcollection-0.7.0-50.fc36.x86_64.rpm",
+        "checksum": "sha256:f2f4ad1b7ed2110117dae0e82ab0478be595cc8c0491b18128165bc825e389a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libcom_err",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcom_err-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e78ba87054515198a1350ccc112bcbec69d1df781eacab57dc5eff2ec3d8b5bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libcomps-0.1.18-2.fc36.x86_64.rpm",
+        "checksum": "sha256:5599f35f62d74cde1a7cec626faf41c1aca4b4b872b1a017adc898a543179359",
+        "check_gpg": true
+      },
+      {
+        "name": "libdb",
+        "epoch": 0,
+        "version": "5.3.28",
+        "release": "51.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdb-5.3.28-51.fc36.x86_64.rpm",
+        "checksum": "sha256:ce955a3983c0fea67347506403a70feb043e14d20e3d91ddcac07fbb4ba84437",
+        "check_gpg": true
+      },
+      {
+        "name": "libdhash",
+        "epoch": 0,
+        "version": "0.5.0",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libdhash-0.5.0-50.fc36.x86_64.rpm",
+        "checksum": "sha256:0f2fa774b2b443df4aadea87a4e8efe331d67f232884d2be49921370d431b413",
+        "check_gpg": true
+      },
+      {
+        "name": "libeconf",
+        "epoch": 0,
+        "version": "0.4.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libeconf-0.4.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0c558b415cfa3127af49f9946ae3adae76da529552cb83a317ea62d79f02f0ea",
+        "check_gpg": true
+      },
+      {
+        "name": "libedit",
+        "epoch": 0,
+        "version": "3.1",
+        "release": "41.20210910cvs.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libedit-3.1-41.20210910cvs.fc36.x86_64.rpm",
+        "checksum": "sha256:dffa57881ede2980c3384f2d8890b60169581414031b25253f9bf032ae7ed48e",
+        "check_gpg": true
+      },
+      {
+        "name": "libevent",
+        "epoch": 0,
+        "version": "2.1.12",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libevent-2.1.12-6.fc36.x86_64.rpm",
+        "checksum": "sha256:457fa6f66b9b5c70fdf563334a531459d5449441bfb22441cae0bf4fdf826df6",
+        "check_gpg": true
+      },
+      {
+        "name": "libffi",
+        "epoch": 0,
+        "version": "3.4.2",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libffi-3.4.2-8.fc36.x86_64.rpm",
+        "checksum": "sha256:b712ea287d8aed5bebc6189de0e67ef0e3eee9b0d0f7f7c2fa51582d12587eb7",
+        "check_gpg": true
+      },
+      {
+        "name": "libfido2",
+        "epoch": 0,
+        "version": "1.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfido2-1.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:77b303a39821a826e060ccc30766124ec77c7b998c903160cf7a6229f0c012c9",
+        "check_gpg": true
+      },
+      {
+        "name": "libfsverity",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libfsverity-1.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:fcf12edb225a10edfbf0e4af820fc6495997218b357c25ec638f6fa458fdc383",
+        "check_gpg": true
+      },
+      {
+        "name": "libftdi",
+        "epoch": 0,
+        "version": "1.5",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libftdi-1.5-3.fc36.x86_64.rpm",
+        "checksum": "sha256:f55cdb2f49ab0910aacfb5745b65291399a00fda3f012c624c464aee70457bbf",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcab1",
+        "epoch": 0,
+        "version": "1.4",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgcab1-1.4-6.fc36.x86_64.rpm",
+        "checksum": "sha256:2d4db64668bfb08b1fe6be0276ef811e4c92239f27c0d45932b3287ae9639b38",
+        "check_gpg": true
+      },
+      {
+        "name": "libgudev",
+        "epoch": 0,
+        "version": "237",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgudev-237-2.fc36.x86_64.rpm",
+        "checksum": "sha256:d28889b38e09168928ff3a9e3acdbdcb4c8beb53f79d987b5471341e4e7ae310",
+        "check_gpg": true
+      },
+      {
+        "name": "libgusb",
+        "epoch": 0,
+        "version": "0.3.10",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libgusb-0.3.10-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6e83a644bea22129ba6a3ea31a7432418037b3e9440002dddf1c2cbbf0ce5847",
+        "check_gpg": true
+      },
+      {
+        "name": "libibverbs",
+        "epoch": 0,
+        "version": "39.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libibverbs-39.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:8b4a9e98cb73582362e6e70390c1c643b26f50c289ea0acbc74b5bb75d85e23b",
+        "check_gpg": true
+      },
+      {
+        "name": "libidn2",
+        "epoch": 0,
+        "version": "2.3.2",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libidn2-2.3.2-4.fc36.x86_64.rpm",
+        "checksum": "sha256:3cdba1d04e8b43122439878179138bd908088b22c29ffbfb82e79af768a3c291",
+        "check_gpg": true
+      },
+      {
+        "name": "libini_config",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libini_config-1.3.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:1d02acd08b3208cd1af93820b7e8961538e4819c1903ec7452af12f4aad2ef91",
+        "check_gpg": true
+      },
+      {
+        "name": "libjaylink",
+        "epoch": 0,
+        "version": "0.2.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjaylink-0.2.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9c3da481a459d940f0e9d99f7e41b336e0709ef226bf7651cdce30b3ea0562df",
+        "check_gpg": true
+      },
+      {
+        "name": "libjcat",
+        "epoch": 0,
+        "version": "0.1.10",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libjcat-0.1.10-1.fc36.x86_64.rpm",
+        "checksum": "sha256:60144990fba08c95b1f9fb68055d85b608870c09426af187b6048912b6337708",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5cdd1b648e7c68c9703ffb66ea23637c12745a3b269a9f45c1584fc676b31328",
+        "check_gpg": true
+      },
+      {
+        "name": "libkcapi-hmaccalc",
+        "epoch": 0,
+        "version": "1.3.1",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libkcapi-hmaccalc-1.3.1-4.fc36.x86_64.rpm",
+        "checksum": "sha256:484ecfaef025085ea3a1f708333c7bfc283569b633d30aca655c0eb3aa42c827",
+        "check_gpg": true
+      },
+      {
+        "name": "libksba",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libksba-1.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:991f6fd822110685e42f499f3059cc5abab2beeff405fc24c74f9e89c41088b5",
+        "check_gpg": true
+      },
+      {
+        "name": "libmaxminddb",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmaxminddb-1.6.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b9070b6896e9ea6dbfcfcbdcdf2d2e427603522e95187854dd10faf38f5a7b98",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmnl-1.0.4-15.fc36.x86_64.rpm",
+        "checksum": "sha256:995d03ccc92a1c35fc0e25a7f7ba3f4bde6bac5068220a0e2722f377dfaf26a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libmodulemd",
+        "epoch": 0,
+        "version": "2.14.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libmodulemd-2.14.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:00cda4f023ab0f5d5b64f29cc36325e2b1395bf5c23547c515140051d50df1cd",
+        "check_gpg": true
+      },
+      {
+        "name": "libndp",
+        "epoch": 0,
+        "version": "1.8",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libndp-1.8-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2dae9a479c013680294508bf366c3501d84b1e7f564ee9f1d31af320ac150b95",
+        "check_gpg": true
+      },
+      {
+        "name": "libnetfilter_conntrack",
+        "epoch": 0,
+        "version": "1.0.8",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnetfilter_conntrack-1.0.8-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bc3339d24b5e60cb8967a671cd9dd357955f46c3825ccf1e4a3b542dcc4ae19a",
+        "check_gpg": true
+      },
+      {
+        "name": "libnfnetlink",
+        "epoch": 0,
+        "version": "1.0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnfnetlink-1.0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:08786a771c7d95deefd7e8dea790e7e14fbf337c2fff980778005a9fb7a0050c",
+        "check_gpg": true
+      },
+      {
+        "name": "libnftnl",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnftnl-1.2.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8a397257a1b5fc428cc663bf266b3feccbe94198d5ebe93bc168022d64dbf4fb",
+        "check_gpg": true
+      },
+      {
+        "name": "libnghttp2",
+        "epoch": 0,
+        "version": "1.46.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnghttp2-1.46.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4d9efa5f3291b6f19eecbc9531dad32df415fb8f98545071cbe90bf12514fbb5",
+        "check_gpg": true
+      },
+      {
+        "name": "libnsl2",
+        "epoch": 0,
+        "version": "2.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libnsl2-2.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:b9d53d524b6497ab0ec8e5a71991d0ecc13ed9e109c665a2e8921d201f6d67da",
+        "check_gpg": true
+      },
+      {
+        "name": "libpath_utils",
+        "epoch": 0,
+        "version": "0.2.1",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpath_utils-0.2.1-50.fc36.x86_64.rpm",
+        "checksum": "sha256:3dec50f65f6e49c3ce1c000af1006984c0ac7a5ce6b9ab28715de70abcd3c668",
+        "check_gpg": true
+      },
+      {
+        "name": "libpcap",
+        "epoch": 14,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpcap-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:899f4f96d68160c167c1b59f8b3e0dd4e4586864c312e4377fc1a5cc58a054ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libpipeline",
+        "epoch": 0,
+        "version": "1.5.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpipeline-1.5.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ecd2362482d03354b6e79229bcd59533629c072982ef31b41762a888b7718b50",
+        "check_gpg": true
+      },
+      {
+        "name": "libpsl",
+        "epoch": 0,
+        "version": "0.21.1",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpsl-0.21.1-5.fc36.x86_64.rpm",
+        "checksum": "sha256:6a21858e905c84f6c45912034f00c3000ccaf1dadfc3a3b61ff538ca986ff927",
+        "check_gpg": true
+      },
+      {
+        "name": "libpwquality",
+        "epoch": 0,
+        "version": "1.4.4",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libpwquality-1.4.4-7.fc36.x86_64.rpm",
+        "checksum": "sha256:325a6e77ccfb0ef67aadefa462cbc3a78b8786a11894e1c0919413cdc921753a",
+        "check_gpg": true
+      },
+      {
+        "name": "libqrtr-glib",
+        "epoch": 0,
+        "version": "1.0.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libqrtr-glib-1.0.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:a0c3b904030213a5c81258bbffe122d5f80b3d8115ef1d3062b18e7a1c20fe4c",
+        "check_gpg": true
+      },
+      {
+        "name": "libref_array",
+        "epoch": 0,
+        "version": "0.1.5",
+        "release": "50.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libref_array-0.1.5-50.fc36.x86_64.rpm",
+        "checksum": "sha256:62d444882048ea292185a97922b013e7b276fa257fae4cc8ee3ca92973f76ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "libreport-filesystem",
+        "epoch": 0,
+        "version": "2.17.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libreport-filesystem-2.17.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:60a91ef0c820cb10026c446e9fc8b1fd652f363819d8ff8ab916abdba8c532ac",
+        "check_gpg": true
+      },
+      {
+        "name": "libseccomp",
+        "epoch": 0,
+        "version": "2.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libseccomp-2.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:32e9b670a5f0cf66e0f86a3c2d6d42ca18571d263736899400e168e92580db45",
+        "check_gpg": true
+      },
+      {
+        "name": "libsecret",
+        "epoch": 0,
+        "version": "0.20.5",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsecret-0.20.5-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a028d16393155c75d89016ddc1d5fa3b9c05ad3c6393aa6366a4ea330431532d",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:d003d29a0e3887a412aebc8ebcfe3be1847001d6b3070db0a4b34969f730763b",
+        "check_gpg": true
+      },
+      {
+        "name": "libselinux-utils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libselinux-utils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f2fc1cee6bcd478654f1cab55abc32325e0f322ad923d7b958dbb8686b3789a3",
+        "check_gpg": true
+      },
+      {
+        "name": "libsemanage",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsemanage-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:09c7b5c2d212a69bdf3319dd99dc9931ef6ed27934921fedec989353c39e8277",
+        "check_gpg": true
+      },
+      {
+        "name": "libsepol",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsepol-3.3-3.fc36.x86_64.rpm",
+        "checksum": "sha256:428c66793687987aee4644ca201f48d76431fb73948d0dfa0c4eb4a10a0fe501",
+        "check_gpg": true
+      },
+      {
+        "name": "libsigsegv",
+        "epoch": 0,
+        "version": "2.14",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsigsegv-2.14-2.fc36.x86_64.rpm",
+        "checksum": "sha256:95790c2047fd69620a6b1328de28b30391d570db7ba0d9cfb385b47c72c36f8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmbios",
+        "epoch": 0,
+        "version": "2.4.3",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libsmbios-2.4.3-5.fc36.x86_64.rpm",
+        "checksum": "sha256:88c97e93ff20a638e697b0d02dd0c58ca413d0c135e85c8f9596c2d02ef29430",
+        "check_gpg": true
+      },
+      {
+        "name": "libss",
+        "epoch": 0,
+        "version": "1.46.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libss-1.46.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0eefa9f51083306bb738e98e67af5c2ac952a9077d5ed4aa78b61170213d5014",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-0.9.6-4.fc36.x86_64.rpm",
+        "checksum": "sha256:cceda77d0c81ef15164d9224b7cb9c64d785f8f423396f8e17185556bd9c4edb",
+        "check_gpg": true
+      },
+      {
+        "name": "libssh-config",
+        "epoch": 0,
+        "version": "0.9.6",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libssh-config-0.9.6-4.fc36.noarch.rpm",
+        "checksum": "sha256:a76500c073bef5a92c9d9a1e927331d127fd6de27b6467ef6a8ac527494979c3",
+        "check_gpg": true
+      },
+      {
+        "name": "libtasn1",
+        "epoch": 0,
+        "version": "4.18.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtasn1-4.18.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:06b111ed04bcd2814e907d2f757f2677ec3154edc464febbcd95e7604580b9a7",
+        "check_gpg": true
+      },
+      {
+        "name": "libtirpc",
+        "epoch": 0,
+        "version": "1.3.2",
+        "release": "1.rc1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libtirpc-1.3.2-1.rc1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:f2de40b66e97f6d89fefcf11dc8d3d9221fd971325dd6770ef0b34661f4b7b8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libudisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libudisks2-2.9.4-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9c2e78543b7f7d2e9b4e9aa6e32170b386ec56da3266d56c7aaa229a17becf88",
+        "check_gpg": true
+      },
+      {
+        "name": "libunistring",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libunistring-1.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:83f55ced13e7437d36a270aaee6c55f76c956ce7654b37136f090eb934c86f9d",
+        "check_gpg": true
+      },
+      {
+        "name": "libusb1",
+        "epoch": 0,
+        "version": "1.0.25",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libusb1-1.0.25-8.fc36.x86_64.rpm",
+        "checksum": "sha256:d514b1df4f58c8c23e7a386dc8edcf616339a0b2ee84aad2203c034c2cb439d7",
+        "check_gpg": true
+      },
+      {
+        "name": "libuser",
+        "epoch": 0,
+        "version": "0.63",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libuser-0.63-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1dd0909aa6d4efe3f024b1f52bfbcf7b4ec6e9ab981d9c18efce53ab4ea2fbce",
+        "check_gpg": true
+      },
+      {
+        "name": "libutempter",
+        "epoch": 0,
+        "version": "1.2.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libutempter-1.2.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:67af27dcb30cc3ad5529d50ce6938d3a5a1c8a35c51e4623b945a107096a3dc2",
+        "check_gpg": true
+      },
+      {
+        "name": "libverto",
+        "epoch": 0,
+        "version": "0.3.2",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libverto-0.3.2-3.fc36.x86_64.rpm",
+        "checksum": "sha256:6927b8d98d9d586c9252c56588ed539d691ad4552f1f26d1791d485ea50061d1",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13afa109ba04d161ddee7a1d9827dde4254abd658fad42d0e7a51bb85fc6505c",
+        "check_gpg": true
+      },
+      {
+        "name": "libxcrypt-compat",
+        "epoch": 0,
+        "version": "4.4.28",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxcrypt-compat-4.4.28-1.fc36.x86_64.rpm",
+        "checksum": "sha256:daf26028401a3eeb7b1d829a4f04271c1baa119eba7464441ebedd0955267a55",
+        "check_gpg": true
+      },
+      {
+        "name": "libxkbcommon",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libxkbcommon-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b618be7131a0e55277016a729fc3820433c8ae46cb62b8e481123c1093fe05de",
+        "check_gpg": true
+      },
+      {
+        "name": "libyaml",
+        "epoch": 0,
+        "version": "0.2.5",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/libyaml-0.2.5-7.fc36.x86_64.rpm",
+        "checksum": "sha256:23cc660bf40b82d9c1739412d9cdcaebb70da60ae2d05cf2a9fbea088f22cdd3",
+        "check_gpg": true
+      },
+      {
+        "name": "lmdb-libs",
+        "epoch": 0,
+        "version": "0.9.29",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lmdb-libs-0.9.29-3.fc36.x86_64.rpm",
+        "checksum": "sha256:d87d94a884629f4538f36f1e54190dfd230dc7ad3eb44b8da31ee22d79794f14",
+        "check_gpg": true
+      },
+      {
+        "name": "lua-libs",
+        "epoch": 0,
+        "version": "5.4.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lua-libs-5.4.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd384ec2ee1bf9f3c94220a6cdd2371289e0982ee11664cfe1b5237a3205786f",
+        "check_gpg": true
+      },
+      {
+        "name": "lz4-libs",
+        "epoch": 0,
+        "version": "1.9.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/l/lz4-libs-1.9.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:bff381205b624b35f258551530ec15ed62ecc4396b748e94bda4c15b6db99e32",
+        "check_gpg": true
+      },
+      {
+        "name": "man-db",
+        "epoch": 0,
+        "version": "2.10.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/man-db-2.10.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:c88d2e0f7ff66362269a62f5ca96ec627c18336a975d4aef2ade8ccb51ff32ae",
+        "check_gpg": true
+      },
+      {
+        "name": "mdadm",
+        "epoch": 0,
+        "version": "4.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mdadm-4.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dae93958303747451864dcd8092e402fee9b2cb56ab3442d847ef12852c61f52",
+        "check_gpg": true
+      },
+      {
+        "name": "memstrack",
+        "epoch": 0,
+        "version": "0.2.4",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/memstrack-0.2.4-2.fc36.x86_64.rpm",
+        "checksum": "sha256:241d1b49d117d229191f8f188bc9d767ce3a6be8bcb1e1bdb147d81825cf8cd7",
+        "check_gpg": true
+      },
+      {
+        "name": "mpdecimal",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpdecimal-2.5.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:833f6c63f9dda3fe294763b8423c0b234a9c04e7f8225a36fa8a8fc54d1a36ec",
+        "check_gpg": true
+      },
+      {
+        "name": "mpfr",
+        "epoch": 0,
+        "version": "4.1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/m/mpfr-4.1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:a0761340128a7a5b9307e3e77a037b74af7b437bb329639b84267cf914e7b6a0",
+        "check_gpg": true
+      },
+      {
+        "name": "nano",
+        "epoch": 0,
+        "version": "6.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nano-6.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:47bc2405ee5e88c02004bc467006df9a8dfaaf15e8d561891639d6825b41adc9",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c7ec9cbcec2b2fb49e5959b51b8ca1fde6da526cbca9e89eb73e3eb04cddc157",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-base",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-base-6.2-9.20210508.fc36.noarch.rpm",
+        "checksum": "sha256:42e774e1bb639f26e68cae9f0a19a64584ea61cb89465284da8d8111c99177a6",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses-libs",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "9.20210508.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/ncurses-libs-6.2-9.20210508.fc36.x86_64.rpm",
+        "checksum": "sha256:c897a9d5a0a2059f98b79bed4f03faa6bac0b2438b11a176b125f2646ccc93f2",
+        "check_gpg": true
+      },
+      {
+        "name": "nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/nftables-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:70f255fc22530dc6213d015700dd237d0173784e616cbc2ffc284e5a2f7b10c9",
+        "check_gpg": true
+      },
+      {
+        "name": "npth",
+        "epoch": 0,
+        "version": "1.6",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/n/npth-1.6-8.fc36.x86_64.rpm",
+        "checksum": "sha256:6fb42c4b7617f96e5ef0c7050315d7a7e0a4100cec0cfee39722a8301ebec8e3",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:a97a365db61e244f5b5b400f8e91b63b3beea0db30ab9e6a9c4664b0f273fc17",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-clients",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-clients-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:31879e909524e7e7971dc6d3858786a65ed4fba8f58e2f9d11029a2772ffb5cc",
+        "check_gpg": true
+      },
+      {
+        "name": "openssh-server",
+        "epoch": 0,
+        "version": "8.8p1",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssh-server-8.8p1-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:bfc877337ecf753c9b20f7d8ce2c4670936972dec92b5ce95e0d7b672b28b148",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-pkcs11",
+        "epoch": 0,
+        "version": "0.4.11",
+        "release": "8.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/openssl-pkcs11-0.4.11-8.fc36.x86_64.rpm",
+        "checksum": "sha256:2c710d5a8439467430aa667979c4b39c099337ee0b86e2510d9daf5906a82ee6",
+        "check_gpg": true
+      },
+      {
+        "name": "os-prober",
+        "epoch": 0,
+        "version": "1.77",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/o/os-prober-1.77-9.fc36.x86_64.rpm",
+        "checksum": "sha256:5d464e57c26cb9c9b151aa86d20e73bb5499c517d100d3a12b1bc40d53db3558",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6a44364e067f8aaec427b630e935e12a8f54c2a7afb6f43cca67fc3d5a3998a4",
+        "check_gpg": true
+      },
+      {
+        "name": "p11-kit-trust",
+        "epoch": 0,
+        "version": "0.24.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/p11-kit-trust-0.24.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f79c1f53ae4b5e06996f83a112d76f90f3b95b2062a8397c7711052698f869c6",
+        "check_gpg": true
+      },
+      {
+        "name": "pam",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:3666c6199031f48b0b17f39b75e24287117761b92526b84249e6798e5d47b651",
+        "check_gpg": true
+      },
+      {
+        "name": "pam-libs",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pam-libs-1.5.2-12.fc36.x86_64.rpm",
+        "checksum": "sha256:69d275d09ee2760b50cf8601b9a75e9101a78f858e238d794a97bbfd964329d6",
+        "check_gpg": true
+      },
+      {
+        "name": "parted",
+        "epoch": 0,
+        "version": "3.4",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/parted-3.4-12.fc36.x86_64.rpm",
+        "checksum": "sha256:d899a6ced2354d6e86191a85e08df4d581ff3bce47544300d07d6d40f258f32b",
+        "check_gpg": true
+      },
+      {
+        "name": "passwd",
+        "epoch": 0,
+        "version": "0.80",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/passwd-0.80-12.fc36.x86_64.rpm",
+        "checksum": "sha256:57ecedb3b77bce1226a4bd179b6c6749bc56a6c888c6996504f45bd862eeec15",
+        "check_gpg": true
+      },
+      {
+        "name": "pciutils-libs",
+        "epoch": 0,
+        "version": "3.7.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pciutils-libs-3.7.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:b59f54f0b25de26d10cbde4a3823a7420410a664eaeb3c5cedb6f0801d5da245",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre",
+        "epoch": 0,
+        "version": "8.45",
+        "release": "1.fc36.1",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcre-8.45-1.fc36.1.x86_64.rpm",
+        "checksum": "sha256:cd565ce3ac0a716ecd95eb35c2453c3c3c79209da4e10a0a205b1157ba9b32c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-ccid",
+        "epoch": 0,
+        "version": "1.5.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pcsc-lite-ccid-1.5.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c77199fb123dc6f9a0ce3f7f10e0f0519f2cbf5d5439e76d13df1837cd349934",
+        "check_gpg": true
+      },
+      {
+        "name": "pinentry",
+        "epoch": 0,
+        "version": "1.2.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/pinentry-1.2.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c7c429d157a9e803c56ac9b28bf74ae8908fc0d33515c9729ed51509a696026",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5cb911922237fbb08da19a35b650aa3f9a3ea6dd48f74885b34337716373eb83",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-core-libs",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-core-libs-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:df15662946f61c06fafb3f9256ccd7170accefa3ddb348926add49f1b9995c44",
+        "check_gpg": true
+      },
+      {
+        "name": "plymouth-scripts",
+        "epoch": 0,
+        "version": "22.02.122",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/plymouth-scripts-22.02.122-1.fc36.x86_64.rpm",
+        "checksum": "sha256:3d8ef454ffc43ea87c135c0d3df3ec23fa80a9042b8fb220db299cc9963c5e26",
+        "check_gpg": true
+      },
+      {
+        "name": "policycoreutils",
+        "epoch": 0,
+        "version": "3.3",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/policycoreutils-3.3-4.fc36.x86_64.rpm",
+        "checksum": "sha256:b97e8afaf61a44f0a75c2785b59acde28c26545fbdb96fc334573a27b34de15e",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:7d995b70b266834c71640b61a57f4a83c011035cebea52813d9faca21e9bda52",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-libs",
+        "epoch": 0,
+        "version": "0.120",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-libs-0.120-5.fc36.x86_64.rpm",
+        "checksum": "sha256:d748ab15ed2bf7f64489dd6c0819ce7f5419af488322703553b2318c542c78fe",
+        "check_gpg": true
+      },
+      {
+        "name": "polkit-pkla-compat",
+        "epoch": 0,
+        "version": "0.1",
+        "release": "21.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/polkit-pkla-compat-0.1-21.fc36.x86_64.rpm",
+        "checksum": "sha256:1cce2c735fd092558a5d050708e93200768f523bc36a4071a6c2857c6bad23f8",
+        "check_gpg": true
+      },
+      {
+        "name": "popt",
+        "epoch": 0,
+        "version": "1.18",
+        "release": "7.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/popt-1.18-7.fc36.x86_64.rpm",
+        "checksum": "sha256:736770b975973d8e62fd6b39917fa2c57d7d96b1fd22516dd697b61ab5d483ef",
+        "check_gpg": true
+      },
+      {
+        "name": "procps-ng",
+        "epoch": 0,
+        "version": "3.3.17",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/procps-ng-3.3.17-4.fc36.x86_64.rpm",
+        "checksum": "sha256:f348d2a52f30d4d49278ed59e8f14f4789442c3274af95762e425ae3e738f47f",
+        "check_gpg": true
+      },
+      {
+        "name": "protobuf-c",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/protobuf-c-1.4.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:30bb23da61ac270b3a011384f2e87a41d7a31e1808b21e6ca7caa60491c9c630",
+        "check_gpg": true
+      },
+      {
+        "name": "psmisc",
+        "epoch": 0,
+        "version": "23.4",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/psmisc-23.4-3.fc36.x86_64.rpm",
+        "checksum": "sha256:5c1eb0ffd38925eef11269d600d506a31581b3d7d741cae6557d021eeef5e6df",
+        "check_gpg": true
+      },
+      {
+        "name": "publicsuffix-list-dafsa",
+        "epoch": 0,
+        "version": "20210518",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/publicsuffix-list-dafsa-20210518-4.fc36.noarch.rpm",
+        "checksum": "sha256:c8420edbc54cef6510c9b6118bc7b6d1b7492146bf003671169eec2d5c47a64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-pip-wheel",
+        "epoch": 0,
+        "version": "21.3.1",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-pip-wheel-21.3.1-2.fc36.noarch.rpm",
+        "checksum": "sha256:0fa3c04cf8015c97195bc0df0d07c057bfabc7b42d582d72002af841a30ed276",
+        "check_gpg": true
+      },
+      {
+        "name": "python-setuptools-wheel",
+        "epoch": 0,
+        "version": "59.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python-setuptools-wheel-59.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:eec7f473be90e8a404598b191e93ac9cbf17f72a2655e43ecd23dbfbdba42463",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dateutil",
+        "epoch": 1,
+        "version": "2.8.1",
+        "release": "8.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dateutil-2.8.1-8.fc36.noarch.rpm",
+        "checksum": "sha256:e6363ddf8c6f98997c31d196ebdda02877412748615181102dc1ea7bfa19f989",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dbus",
+        "epoch": 0,
+        "version": "1.2.18",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-dbus-1.2.18-3.fc36.x86_64.rpm",
+        "checksum": "sha256:2eb7ace975fa86defcb8e5962e0636b02f62dc8fc1e733d1bc041b12bf28fd63",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-distro",
+        "epoch": 0,
+        "version": "1.6.0",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-distro-1.6.0-2.fc36.noarch.rpm",
+        "checksum": "sha256:f732448121ab355b23f9f68f885e7ce954538c3082c7446ece722b005682ab08",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-firewall",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-firewall-1.0.4-1.fc36.noarch.rpm",
+        "checksum": "sha256:aa4e6dd219f1982b2e681f981865e2fa12ac17b781eff6191350042b4c9842c0",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gpg",
+        "epoch": 0,
+        "version": "1.15.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-gpg-1.15.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:ac440f60f60e271dfdcfdb16ec82cba720bb2f903a2f7cf2330bd4e18aa4154b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libcomps",
+        "epoch": 0,
+        "version": "0.1.18",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-libcomps-0.1.18-2.fc36.x86_64.rpm",
+        "checksum": "sha256:daa3aa3f516d08d8a5053aabc521f8b3af4fcef3a1304a051ceca93ae18bfa3f",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-nftables",
+        "epoch": 1,
+        "version": "1.0.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-nftables-1.0.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:00cb1f66de0fc574ae601b76b96c3326834a6682ff119445e5940bca2249302c",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:777e4333ca9437d55b2bae930fadfe5db487ed6acd8a66ab42a7d0cd8680cf33",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-six",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "5.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/p/python3-six-1.16.0-5.fc36.noarch.rpm",
+        "checksum": "sha256:77a3f267c752560416f75bf228512f2c88bcfe6574fbcfa82caf2485cc657c41",
+        "check_gpg": true
+      },
+      {
+        "name": "qrencode-libs",
+        "epoch": 0,
+        "version": "4.1.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/q/qrencode-libs-4.1.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0a303bfc4c6cbe736ee4723c7ae41e4647b880a969578a4625b04d6a7b02568f",
+        "check_gpg": true
+      },
+      {
+        "name": "readline",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/readline-8.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:dd238d77e158d6c0a138405e5a99647cfc143b234b832206b698b09fdb13bee4",
+        "check_gpg": true
+      },
+      {
+        "name": "rootfiles",
+        "epoch": 0,
+        "version": "8.1",
+        "release": "31.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rootfiles-8.1-31.fc36.noarch.rpm",
+        "checksum": "sha256:c2c9054a57bbf8937e5e99b5f61127c2c76b6042a688f53caf37fd31a5cd7895",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:f4e35e46838400b00b251c3830c47d3ed6f382d91b2da6863075d4c2333b762e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-build-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-build-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:b401b7b05c6142cba74685a40d003d902de2a6cccd1c60134c618189073bbe87",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:1207be19e74708a2f5596bd1a708c608b2c7a5bb6866acc1a265ba400a38a33e",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-selinux",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-selinux-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:d13fdf6696fb0f656b2e61c2e0ae719c4089f65574ce9c8c57d04cc0d9b09e47",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-plugin-systemd-inhibit",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-plugin-systemd-inhibit-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:43eb75ad2afc0b4a538cbdc6a0ae4a4be8c84d00a03aa450787b0702abd2e5c2",
+        "check_gpg": true
+      },
+      {
+        "name": "rpm-sign-libs",
+        "epoch": 0,
+        "version": "4.17.0",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/r/rpm-sign-libs-4.17.0-10.fc36.x86_64.rpm",
+        "checksum": "sha256:26b776eaf819fc466d562e595860f86cf183066494d0577f146f6a2c9dc4c6d5",
+        "check_gpg": true
+      },
+      {
+        "name": "sed",
+        "epoch": 0,
+        "version": "4.8",
+        "release": "10.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sed-4.8-10.fc36.x86_64.rpm",
+        "checksum": "sha256:da5842f2ef753f60824209a4081072703b3ec5d3523fafab23da20ff23ed158d",
+        "check_gpg": true
+      },
+      {
+        "name": "shadow-utils",
+        "epoch": 2,
+        "version": "4.11.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shadow-utils-4.11.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:0922bd6bb3f6ac788f4f345d6758773ce60c43b78ce0d59fc0c4909088a958db",
+        "check_gpg": true
+      },
+      {
+        "name": "shared-mime-info",
+        "epoch": 0,
+        "version": "2.1",
+        "release": "3.fc35",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/shared-mime-info-2.1-3.fc35.x86_64.rpm",
+        "checksum": "sha256:6a049afa68579427322ee38b9085251115a6c022786530d804d6a2081a84ceca",
+        "check_gpg": true
+      },
+      {
+        "name": "sqlite-libs",
+        "epoch": 0,
+        "version": "3.36.0",
+        "release": "5.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sqlite-libs-3.36.0-5.fc36.x86_64.rpm",
+        "checksum": "sha256:0cc46b44f379a4433f31db290af917420e26ee720fba957a2acd6ed8c8123cd9",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-1.9.8-5.p2.fc36.x86_64.rpm",
+        "checksum": "sha256:74c9d86eb0743f18d4fb25ac82e616b7103f5ca79c37aa8aa69be477b4d2a2f0",
+        "check_gpg": true
+      },
+      {
+        "name": "sudo-python-plugin",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "5.p2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/s/sudo-python-plugin-1.9.8-5.p2.fc36.x86_64.rpm",
+        "checksum": "sha256:dda1ae9c2d6920761996734c846883fe26d4a2222364fec6fde58fab9a9dc3dd",
+        "check_gpg": true
+      },
+      {
+        "name": "tpm2-tss",
+        "epoch": 0,
+        "version": "3.2.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/t/tpm2-tss-3.2.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:64158f8e947c3702805e8bf794c32d05ae7c3173e209ecf7619279e03169ffbe",
+        "check_gpg": true
+      },
+      {
+        "name": "udisks2",
+        "epoch": 0,
+        "version": "2.9.4",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/udisks2-2.9.4-4.fc36.x86_64.rpm",
+        "checksum": "sha256:ad06336b4a496a063e390e0f6a15b08bfe2626465a3247a45f8c98c503a4b5a6",
+        "check_gpg": true
+      },
+      {
+        "name": "userspace-rcu",
+        "epoch": 0,
+        "version": "0.13.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/u/userspace-rcu-0.13.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:a00fc7941175e0934b46efa63721dd9f45b23905b2afc1643f0113d13db63ed3",
+        "check_gpg": true
+      },
+      {
+        "name": "volume_key-libs",
+        "epoch": 0,
+        "version": "0.3.12",
+        "release": "15.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/v/volume_key-libs-0.3.12-15.fc36.x86_64.rpm",
+        "checksum": "sha256:bc1a60ef9acfc90ab773b2800eb515e3f9acd647827de3d60ee2390baf4d1f83",
+        "check_gpg": true
+      },
+      {
+        "name": "which",
+        "epoch": 0,
+        "version": "2.21",
+        "release": "32.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/w/which-2.21-32.fc36.x86_64.rpm",
+        "checksum": "sha256:30b93c6d5187de68b694cf045120008d2883808620ef5ef41c7660ca96bd7e9c",
+        "check_gpg": true
+      },
+      {
+        "name": "xfsprogs",
+        "epoch": 0,
+        "version": "5.14.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xfsprogs-5.14.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:4aa699025a0a751a62b20f9da7fbfc44c1de6517963f4c1195b9a4a640425310",
+        "check_gpg": true
+      },
+      {
+        "name": "xkeyboard-config",
+        "epoch": 0,
+        "version": "2.35.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xkeyboard-config-2.35.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:676ecdd8b45367cb5899dc9c0df3ad4813b757edb06c856583a26cdc4236549b",
+        "check_gpg": true
+      },
+      {
+        "name": "xz",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e932058789a452d620f33d5dd0ff80dc062938af410b5c792b62dd2d0fae77eb",
+        "check_gpg": true
+      },
+      {
+        "name": "xz-libs",
+        "epoch": 0,
+        "version": "5.2.5",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/x/xz-libs-5.2.5-9.fc36.x86_64.rpm",
+        "checksum": "sha256:6a81e30e5b91f0b3376651bd9895e48ddd8b3a1f47055500bc7d5eeb6a8c994f",
+        "check_gpg": true
+      },
+      {
+        "name": "zlib",
+        "epoch": 0,
+        "version": "1.2.11",
+        "release": "31.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zlib-1.2.11-31.fc36.x86_64.rpm",
+        "checksum": "sha256:5b72b44653b441b33cc0c02e9ec55c671904f2ce92899a36b6e030766699c505",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-1.1.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:1c7854309a224fbdb2715f943f8cd23f4c68038c3ae4c2399e2db092c8c78267",
+        "check_gpg": true
+      },
+      {
+        "name": "zram-generator-defaults",
+        "epoch": 0,
+        "version": "1.1.2",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-fedora-20220617/Packages/z/zram-generator-defaults-1.1.2-1.fc36.noarch.rpm",
+        "checksum": "sha256:4aa810b351f5e9d1ed3943b3daef6aa44f4f93c6af9f8788665a6d47317f2e04",
+        "check_gpg": true
+      },
+      {
+        "name": "ModemManager-glib",
+        "epoch": 0,
+        "version": "1.18.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/ModemManager-glib-1.18.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bd5c235acf908e4b0191f6f4b89589c123e218b21b991e79ecde140867b54282",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-1.38.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6b360093e3a04856310a3c967b4c59a597ec6ff33826affab4052ca212676699",
+        "check_gpg": true
+      },
+      {
+        "name": "NetworkManager-libnm",
+        "epoch": 1,
+        "version": "1.38.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/NetworkManager-libnm-1.38.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:52ac12150f661e1857b5abd1bdb57a2d6615cc26e35ba2990ee1e582907b3418",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce4c36deba9a757d43ee8995cd845325dda7d9d6c6311da46c9c147adc606ad8",
+        "check_gpg": true
+      },
+      {
+        "name": "authselect-libs",
+        "epoch": 0,
+        "version": "1.4.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/a/authselect-libs-1.4.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:74abd50eeccfe5f58cf082bcb1f67e8e1b3afd0828ce44efbe08fc2d892a96e6",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:d6c12d477c0c0e4f4e73d219d358f34191061f1075a59466942cbe2eb103320b",
+        "check_gpg": true
+      },
+      {
+        "name": "crypto-policies-scripts",
+        "epoch": 0,
+        "version": "20220428",
+        "release": "1.gitdfb10ea.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/crypto-policies-scripts-20220428-1.gitdfb10ea.fc36.noarch.rpm",
+        "checksum": "sha256:1d8f204b36d84129b810370f41f529b712da68fac18dc7ecd39ec79e93465304",
+        "check_gpg": true
+      },
+      {
+        "name": "curl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/c/curl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:78b134028174e3715b4df8c1f460dc71e251386f7cd0506d2a7080dd0c58a089",
+        "check_gpg": true
+      },
+      {
+        "name": "dbus-broker",
+        "epoch": 0,
+        "version": "31",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dbus-broker-31-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f038065a90b7ef200fefb95139cf387b1364911035768973c594b49528633a2a",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-client",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-client-4.4.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:12b80a2d8cfafd1112c6355e3886270610e816b453202595157a2828fa7aa452",
+        "check_gpg": true
+      },
+      {
+        "name": "dhcp-common",
+        "epoch": 12,
+        "version": "4.4.3",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dhcp-common-4.4.3-2.fc36.noarch.rpm",
+        "checksum": "sha256:ae2b25cdb73a77fef3c292d90e732b1da1484177dc93c31fe193460a331c84ef",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:21db07e09767b988360ba759687f2f40c9da5e4d12c10abbd54d06432692ec0f",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-data",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-data-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:829149816cac1d5ab7cb4adc48b03a3e31b56051a68e08996934f0fca15f6130",
+        "check_gpg": true
+      },
+      {
+        "name": "dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/d/dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:72abbe84bae78c4c0c7b4aa742abdb18355956017c1cb9dc44283938415a5140",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-debuginfod-client",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-debuginfod-client-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:15f8aad145dbc5f09f386c34d16894d9c9f43a0e0e7168fdaf9db652386de97b",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-default-yama-scope",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-default-yama-scope-0.187-4.fc36.noarch.rpm",
+        "checksum": "sha256:0def756e198d1266a82c2d26d11dbf7e1914c195dc8e74f5d3a5b2796318682e",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libelf",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libelf-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:c0fd8d5b8f4dce3a31f8ebe0d3603a63f021eb0e5739d0b3a1773c353f5a7b13",
+        "check_gpg": true
+      },
+      {
+        "name": "elfutils-libs",
+        "epoch": 0,
+        "version": "0.187",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/e/elfutils-libs-0.187-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9d691610a6c151650f2b2c45a37d9906a68adf20f3544c834e579fdc44e1d7d4",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bc2230cb7e68870285ecf11d82e8607e74d42f01a57889b3c3e1b1d9e386404c",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-efi",
+        "epoch": 0,
+        "version": "1.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-efi-1.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:544a6838523a5a871c593097d5a48d37b7acf3c415a5f1a23e87854a730d45ab",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-flashrom",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-flashrom-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:43ab5eacc5b675862f8821fa8328c33624eb945662536b737e2b4f064c4ddfe5",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-modem-manager",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-modem-manager-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:404eb6145247a020308ae78c6d42c6a81c0cec7f0258a5f83578ce1b6a93433f",
+        "check_gpg": true
+      },
+      {
+        "name": "fwupd-plugin-uefi-capsule-data",
+        "epoch": 0,
+        "version": "1.8.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/f/fwupd-plugin-uefi-capsule-data-1.8.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:0395a5b8959a1cb66d616c758944e985c0f5864ea4e4527fea8e1224e2b0fd5f",
+        "check_gpg": true
+      },
+      {
+        "name": "gdisk",
+        "epoch": 0,
+        "version": "1.0.9",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gdisk-1.0.9-2.fc36.x86_64.rpm",
+        "checksum": "sha256:f2da32b1fcc10b56b30f7939618450fd863c7469508250508060ebd36b61ec5e",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.72.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glib2-2.72.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:035efd371a5a69a7ea1c833af1bdcf74e7f70b6ba36f961f37bddcc9732e0bee",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:e4af2f1ef407e447fefc0d1a75c18210d779a511f62f4e880da4e1beb04af24e",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-common",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-common-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:cea228718ad9bb3ac9ec91b393ea3fb1315bbee7bb3f29fbfdf3e28c09760ce7",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-gconv-extra",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-gconv-extra-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:53044dd39b5b2c7a10d229cf6ffcd9d519c2cfcb92b15ab4a535fe5d0c8311be",
+        "check_gpg": true
+      },
+      {
+        "name": "glibc-minimal-langpack",
+        "epoch": 0,
+        "version": "2.35",
+        "release": "12.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/glibc-minimal-langpack-2.35-12.fc36.x86_64.rpm",
+        "checksum": "sha256:86ed4598b6621d672d5cce2e6d15b1b8ea4804de19ae5273eb0a2145fa1ef8f4",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:3d86ab10e70b5bcdfa8f437196fe10a8a5256cb16b941162e329c5d2eabffd70",
+        "check_gpg": true
+      },
+      {
+        "name": "gnupg2-smime",
+        "epoch": 0,
+        "version": "2.3.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnupg2-smime-2.3.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:075b89e5b1b132eacb4e6057d00764c9ee342b95d926d819c0e711d2c3ee8ac3",
+        "check_gpg": true
+      },
+      {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/gnutls-3.7.6-3.fc36.x86_64.rpm",
+        "checksum": "sha256:0e6402679ebbb705a4cb74a238d34fdfd62c395a8b3d28fc0faafc27e6f4a73f",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-common",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-common-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6c1c3034d721217909f5b2363e095dabb216d36fa98bd4ea23b4381629a58e12",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:6e265451f960d7703d83c4785b5902d1d8c7aea98f11f90868f3a32187b7e993",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-pc-modules",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-pc-modules-2.06-42.fc36.noarch.rpm",
+        "checksum": "sha256:6941e683f920e90ffeff1a2014695e62deba44f3614103c7f1d2bd084c90f13b",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:b0e0c14e5fee07f5b40b087f56739344b25f7e852434e92a1c11ceca746c6b2d",
+        "check_gpg": true
+      },
+      {
+        "name": "grub2-tools-minimal",
+        "epoch": 1,
+        "version": "2.06",
+        "release": "42.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/g/grub2-tools-minimal-2.06-42.fc36.x86_64.rpm",
+        "checksum": "sha256:496180360427f3c908b82d10ccdef890a87698ec6db5bf01acd23d94df4d4b1d",
+        "check_gpg": true
+      },
+      {
+        "name": "inih",
+        "epoch": 0,
+        "version": "55",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/i/inih-55-1.fc36.x86_64.rpm",
+        "checksum": "sha256:61544f1ac4a32d1903e24f406fa1286bf54d21151e460bec4b2bc046840a42cf",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:bafc8af7a461cbed16417ffce4d30735895e5316d3ec4af7232951acad6fdcf4",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-core",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-core-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:9e29caa9cbe813b19d8b22301af1ccc0dba47a401b7acf66eb658f3eeb5aa8ba",
+        "check_gpg": true
+      },
+      {
+        "name": "kernel-modules",
+        "epoch": 0,
+        "version": "5.18.9",
+        "release": "200.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/kernel-modules-5.18.9-200.fc36.x86_64.rpm",
+        "checksum": "sha256:e1947cb52a8cbba29dfd79456fab69ee967572ca35855340e45b1b5a2b68e594",
+        "check_gpg": true
+      },
+      {
+        "name": "krb5-libs",
+        "epoch": 0,
+        "version": "1.19.2",
+        "release": "11.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/k/krb5-libs-1.19.2-11.fc36.x86_64.rpm",
+        "checksum": "sha256:1bc3d0f8939bb9f03a4cad2c57e59cd55cc5de54028a307ba33fe3b857c5a0e9",
+        "check_gpg": true
+      },
+      {
+        "name": "libarchive",
+        "epoch": 0,
+        "version": "3.5.3",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libarchive-3.5.3-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e31fc970fd40f361695a18b5601fdbcbca4e697b603f6ee43c6ed2bf3b2ea477",
+        "check_gpg": true
+      },
+      {
+        "name": "libargon2",
+        "epoch": 0,
+        "version": "20171227",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libargon2-20171227-9.fc36.x86_64.rpm",
+        "checksum": "sha256:8d957da94e58208a238e4c5c201afa6c95e123351e60a909a3403ffcc6820dc6",
+        "check_gpg": true
+      },
+      {
+        "name": "libblkid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblkid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:08f54a41227b208f866cc6ad3537e03d583e02316177d1547ebe3e54e26c4d8b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:adfa2718dc5d4bae822b5905f1628bdc0fa830bb06c561caa331716293a2d340",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-crypto",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-crypto-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:12798887ed97a1746bb9551d61dee38717982f2587aff35dd4085adf9e95a4bb",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-fs",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-fs-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dbc8762daadb5927a05241924646bd1a5149a52170d80558e78312f192a67624",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-loop",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-loop-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:78f1f12225b42a3edcfabd694df561064ce39d02abd6d71bb85fe7beee747101",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-mdraid",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-mdraid-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:20b5d48f802024c668285d4014c0a92eeed3031738474123cb5700ea5dfefa6b",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-part",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-part-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:db1423134b954c1c00786cce7a2242d9fe98f26964f51b707ddf00f8fffd7e8e",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-swap",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-swap-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:cf0a6ad360f4ebc1b3e1f6d9e583751b100195f57106cad48cde4fe4a6eb7195",
+        "check_gpg": true
+      },
+      {
+        "name": "libblockdev-utils",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libblockdev-utils-2.27-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e9c2d1401d9c58a48eb7ee7ac873d97612662d65a4a5ead7473ec6b311145b87",
+        "check_gpg": true
+      },
+      {
+        "name": "libbpf",
+        "epoch": 2,
+        "version": "0.7.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbpf-0.7.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:73f76f507c5a2457ba637f253aea77fc136cef25df720c15caa06da13c4a05af",
+        "check_gpg": true
+      },
+      {
+        "name": "libbytesize",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libbytesize-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:996f22624b2f771360c80b1724dcd63ea1132b72db52bf0887446f7fa1c6c7cb",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7cd8e81219f64df854780aff25ef2fc7597bfa48bf3e7a1b375da0b1902ffe95",
+        "check_gpg": true
+      },
+      {
+        "name": "libcap-ng-python3",
+        "epoch": 0,
+        "version": "0.8.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcap-ng-python3-0.8.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bbac26c434fa5eb6ef77751738f9ef4b0e02d11e657812b388b6a047ab6fc7a5",
+        "check_gpg": true
+      },
+      {
+        "name": "libcurl",
+        "epoch": 0,
+        "version": "7.82.0",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libcurl-7.82.0-6.fc36.x86_64.rpm",
+        "checksum": "sha256:23618b8776d5e70c412e418963975698dfac8e5a0bd667fdd74fbade4c26dd9c",
+        "check_gpg": true
+      },
+      {
+        "name": "libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libdnf-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b0a26bee81681c31c0ff8e3dfd5031b8861bdbdd5ebf25fc59763878ceef2d7f",
+        "check_gpg": true
+      },
+      {
+        "name": "libfdisk",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libfdisk-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b0711c4fa44509f425e6f242caa719d533b2621720c7f4e63b3f9b0a4339608a",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcc",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcc-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:abb2b6380d966fc84a8af7c24a6555f6be7b52a1d1dfefaac422b9991ae4fd13",
+        "check_gpg": true
+      },
+      {
+        "name": "libgcrypt",
+        "epoch": 0,
+        "version": "1.10.1",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgcrypt-1.10.1-3.fc36.x86_64.rpm",
+        "checksum": "sha256:7d9f6208c3949e4367eb2b97689a3fecf9bc34a42fceb42da171bcf5a15c0a67",
+        "check_gpg": true
+      },
+      {
+        "name": "libgomp",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgomp-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b54a6f65a9ab578eb014c2b71a062680a69dcd6ca6ccc8853e1c25758c8f7afc",
+        "check_gpg": true
+      },
+      {
+        "name": "libgpg-error",
+        "epoch": 0,
+        "version": "1.45",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libgpg-error-1.45-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2259eb8727e5f66ba14c52a8674ff7ca2f2edd8531b4e00db72a2fb62444f13c",
+        "check_gpg": true
+      },
+      {
+        "name": "libicu",
+        "epoch": 0,
+        "version": "69.1",
+        "release": "6.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libicu-69.1-6.fc36.x86_64.rpm",
+        "checksum": "sha256:55085d771e68ac6ed4be095c5cce52bf39f49d0c65bdfdc92d6a0fe2493c99a8",
+        "check_gpg": true
+      },
+      {
+        "name": "libldb",
+        "epoch": 0,
+        "version": "2.5.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libldb-2.5.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:58e27f4659cef20e393eb063f6eae99ee32f1b421a55fb147d919bc36e42dba6",
+        "check_gpg": true
+      },
+      {
+        "name": "libmbim",
+        "epoch": 0,
+        "version": "1.26.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmbim-1.26.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:866dc0c718466213e578633155aaa9d69fb860f1ac44b44611025a957780a8fa",
+        "check_gpg": true
+      },
+      {
+        "name": "libmount",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libmount-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2c428384851f6814388f78ac0dba95a738dea022b275e1aabb49d8d2ae873eb9",
+        "check_gpg": true
+      },
+      {
+        "name": "libnl3",
+        "epoch": 0,
+        "version": "3.6.0",
+        "release": "3.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libnl3-3.6.0-3.fc36.x86_64.rpm",
+        "checksum": "sha256:76842198d98983f83241be2ae73b24efd580ee0af7d0a5a301dd02a7c417c801",
+        "check_gpg": true
+      },
+      {
+        "name": "libqmi",
+        "epoch": 0,
+        "version": "1.30.6",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libqmi-1.30.6-1.fc36.x86_64.rpm",
+        "checksum": "sha256:981e35ad67bb3aebeedfba78b4880e581d6a6db2b7ec4023484c94998fc66a5d",
+        "check_gpg": true
+      },
+      {
+        "name": "librepo",
+        "epoch": 0,
+        "version": "1.14.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/librepo-1.14.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:eb149c8897d2e78727e2dac441bcc05e064e045edb73705af0a0c57a5d17fe4e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsmartcols",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsmartcols-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:b1879ff351abdfd2bb55c6b1e4bfb4c1a48d03d067cc2c719b6b4651308bbf6c",
+        "check_gpg": true
+      },
+      {
+        "name": "libsolv",
+        "epoch": 0,
+        "version": "0.7.22",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsolv-0.7.22-1.fc36.x86_64.rpm",
+        "checksum": "sha256:dae15191393ec4f56460271f47e1cc2ac7bc847ccb03eaf0035175d1c28c219a",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_certmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_certmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c073eeb631912aa260da3cb99353cddff4e7f02ffebd775a329ef260ab42ff29",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_idmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e6cd3dfba9bd5c1d8527ee3ae8bae3bf7a1a375932f7fa4a1ee5c317eb70b0f9",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_nss_idmap",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_nss_idmap-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:49b784fc4e9fe1bd00063c509f31cfc1e08749bb203804654f4a01214455853e",
+        "check_gpg": true
+      },
+      {
+        "name": "libsss_sudo",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libsss_sudo-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:011377565612bdc103fed99f4e041100a0a836fc31fd517baa998cba6549ada4",
+        "check_gpg": true
+      },
+      {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "12.1.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libstdc++-12.1.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ce333673564d12adca690daf59b4438a2443394edd77cfa8e7d56928e1c1ae25",
+        "check_gpg": true
+      },
+      {
+        "name": "libtalloc",
+        "epoch": 0,
+        "version": "2.3.4",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtalloc-2.3.4-1.fc36.x86_64.rpm",
+        "checksum": "sha256:234d03de5e310e9afc481eb35fb9b01072c6a946ec8c22c6429d33ec59a00eed",
+        "check_gpg": true
+      },
+      {
+        "name": "libtdb",
+        "epoch": 0,
+        "version": "1.4.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtdb-1.4.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:0e791d318effa04ff1c463f60d0632acb5ff6f2ad6f04a836bbfdd07e500d91a",
+        "check_gpg": true
+      },
+      {
+        "name": "libtevent",
+        "epoch": 0,
+        "version": "0.12.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libtevent-0.12.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:929f61d675345450d11bc44ab2466cc621f9ece823b031c784ca79e657e179a9",
+        "check_gpg": true
+      },
+      {
+        "name": "libuuid",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libuuid-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e8b34ad0f1ddcb5acb788cbfaeb42a3366068251f76747477be4d8e2ed4c788",
+        "check_gpg": true
+      },
+      {
+        "name": "libxml2",
+        "epoch": 0,
+        "version": "2.9.14",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxml2-2.9.14-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a331a9c4db779f8522e886b5d20cf2081465572e5713ee215a5fd26f34f3e987",
+        "check_gpg": true
+      },
+      {
+        "name": "libxmlb",
+        "epoch": 0,
+        "version": "0.3.9",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libxmlb-0.3.9-1.fc36.x86_64.rpm",
+        "checksum": "sha256:7130cc35fa8510939a0e7e72770261982f8a5b062253e85251288d0acf5f6e21",
+        "check_gpg": true
+      },
+      {
+        "name": "libzstd",
+        "epoch": 0,
+        "version": "1.5.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/libzstd-1.5.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:c98ad28150b716732849b5fb2d41f339097d418d89f67a45b963327a7b9ff166",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:9f94651094850115d55e573d21cde8ff02029f501cdc732626b20f59544cd34e",
+        "check_gpg": true
+      },
+      {
+        "name": "linux-firmware-whence",
+        "epoch": 0,
+        "version": "20220610",
+        "release": "135.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/l/linux-firmware-whence-20220610-135.fc36.noarch.rpm",
+        "checksum": "sha256:b80140253cca321aafc3fb76219aa8a9bf2c7ee76311458fafe91dd7651908cd",
+        "check_gpg": true
+      },
+      {
+        "name": "mkpasswd",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mkpasswd-5.5.13-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d0f06003bb1472d51ccac2eb1885e4546feaa30b5cec411832bf4fccc1e3ac19",
+        "check_gpg": true
+      },
+      {
+        "name": "mozjs91",
+        "epoch": 0,
+        "version": "91.11.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/m/mozjs91-91.11.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:94021f69bdd5e8be4b186081e6b5748a27b37e8d7762ca6b8973bc0f1ab8b16c",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nettle-3.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a2b02e6ee909472aeb994d0040e1255ffd6c45150c32d9b084609d928caada61",
+        "check_gpg": true
+      },
+      {
+        "name": "nspr",
+        "epoch": 0,
+        "version": "4.34.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nspr-4.34.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5e2785ea0e99173e686416f33d9cc80a74c21a836a25af89d5b50415c6142701",
+        "check_gpg": true
+      },
+      {
+        "name": "nss",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:f8cc2172a8c6cae8fd0e3c56a266a20425194ed024b730d2f2d04ee3ab9bfb5b",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:d74d44ff991a85bc5aed1bf170446cb324bc8ba9f476a16443b856f689325e89",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-softokn-freebl",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-softokn-freebl-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:13aeb3b9889afb0dfe607b8e5a694f7debd69b5e92525e3bb8be606ef46a1c0e",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-sysinit",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-sysinit-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4ee2bd16b0321e89607019cc53a5972625f11e331f0a4e9af57e990bb6d6485a",
+        "check_gpg": true
+      },
+      {
+        "name": "nss-util",
+        "epoch": 0,
+        "version": "3.79.0",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/nss-util-3.79.0-1.fc36.x86_64.rpm",
+        "checksum": "sha256:4b1739660922063971de03928e8cd7154d96b703099e669e8a9b5523c1522310",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:2240717e975e4f42f07025fe33240470aef04dd9da9eeda02e7dc5e806bea24b",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-libs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-libs-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c4bf6b2c21cfae19a0f3f4b0279823d1d7958c40b9bb483b825d30a1d9279ecb",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfs-3g-system-compression",
+        "epoch": 0,
+        "version": "1.0",
+        "release": "9.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfs-3g-system-compression-1.0-9.fc36.x86_64.rpm",
+        "checksum": "sha256:e03035313c0396abf2c9acb21bbb5b303cc73726473ab115d1ba58aa1e3c7fb0",
+        "check_gpg": true
+      },
+      {
+        "name": "ntfsprogs",
+        "epoch": 2,
+        "version": "2022.5.17",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/n/ntfsprogs-2022.5.17-1.fc36.x86_64.rpm",
+        "checksum": "sha256:429e1f761cf68fc139e64dd6bc3cbedfec8a10f244db9c87d2368cbefae73d20",
+        "check_gpg": true
+      },
+      {
+        "name": "oniguruma",
+        "epoch": 0,
+        "version": "6.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/oniguruma-6.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:aa6dc185c17dd7421299c069850cb22fcc68ed34a9a5ff720ff03269b3d874cc",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:de5010dc30e0ac4184d0699ea4c873f53c09a52e4ac4eb978b57c5d007d7217f",
+        "check_gpg": true
+      },
+      {
+        "name": "openldap-compat",
+        "epoch": 0,
+        "version": "2.6.2",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openldap-compat-2.6.2-2.fc36.x86_64.rpm",
+        "checksum": "sha256:db4eb4ae787ee174d1d2957c80b0413ccf31e0bb539d70ba7e0c606f102bb2de",
+        "check_gpg": true
+      },
+      {
+        "name": "openssl-libs",
+        "epoch": 1,
+        "version": "3.0.3",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/o/openssl-libs-3.0.3-1.fc36.x86_64.rpm",
+        "checksum": "sha256:a17a8b5873356c471fc52f068fc5e93a488a6d432cb67b3ea133231115426237",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-10.40-1.fc36.x86_64.rpm",
+        "checksum": "sha256:c74c2200bfa79e5bcded14e23938ff6f9fb89f61aa4f46b5a187ccc7ed0b08c4",
+        "check_gpg": true
+      },
+      {
+        "name": "pcre2-syntax",
+        "epoch": 0,
+        "version": "10.40",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcre2-syntax-10.40-1.fc36.noarch.rpm",
+        "checksum": "sha256:6456c67358918819b0a5cb6253269f9f11b58420e6e0e1fa2704909e1a54074b",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e7090f335d0d210b20ec4b8ac8adb1b801c51eea363d52d3b48f821512e38500",
+        "check_gpg": true
+      },
+      {
+        "name": "pcsc-lite-libs",
+        "epoch": 0,
+        "version": "1.9.8",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pcsc-lite-libs-1.9.8-1.fc36.x86_64.rpm",
+        "checksum": "sha256:901a4d6e3875a08f48665f5ddb9d169d75639f85d93e1a877a155c026eaceada",
+        "check_gpg": true
+      },
+      {
+        "name": "pigz",
+        "epoch": 0,
+        "version": "2.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/pigz-2.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5531e9d236aafeb573689dbe4603e8fa0e3b8729f58a62523bd2ce88207db64d",
+        "check_gpg": true
+      },
+      {
+        "name": "python-unversioned-command",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python-unversioned-command-3.10.5-2.fc36.noarch.rpm",
+        "checksum": "sha256:2bf2ee6141b169124ca8c8a7c5ed8dc9a68571f0afb524c3244f688cd9ea535b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:6c70437f7244f9d3eb7be5c834cff5fb432bdf7062394f1de7910f38eb0e6bbb",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:8c803bd7fb872d2ad64953266c5209f718e087a05cb721c6f6c07179b632fe5d",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-dnf-plugins-core",
+        "epoch": 0,
+        "version": "4.2.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-dnf-plugins-core-4.2.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:6c2e88c321d3114ad65978c3448856813fe2645efb8e00726cdb53f0ead468d3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-3.42.1-1.fc36.x86_64.rpm",
+        "checksum": "sha256:77d143afad8d60b1ed9a206e8a1e2c1211218e709eb2c830c8f07744b06aef1b",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-gobject-base-noarch",
+        "epoch": 0,
+        "version": "3.42.1",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-gobject-base-noarch-3.42.1-1.fc36.noarch.rpm",
+        "checksum": "sha256:c5fc8fd2d86ecf91ddd7a9f5bed08827a9d62881d781b1f6b4687294b6c2aff3",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-hawkey",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-hawkey-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:05a455a9892b4c4c77255f1d396c738e2e46291e8c4ac381f2a343b8d98e1873",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libdnf",
+        "epoch": 0,
+        "version": "0.67.0",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libdnf-0.67.0-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b9ad1c81ed20265422b5fcc8865f055a4172bc3325b9cb212ad073266057aab5",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-libs",
+        "epoch": 0,
+        "version": "3.10.5",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-libs-3.10.5-2.fc36.x86_64.rpm",
+        "checksum": "sha256:8f27010ae9c6b34ce6f7755246dbd0794d3128912576ee9a219c1a0fcbebb010",
+        "check_gpg": true
+      },
+      {
+        "name": "python3-unbound",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/p/python3-unbound-1.16.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:5b276451caa30f1ce4739822473100781b3810423528a170c4ddd8405d1689f8",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:0d306aebff670a1e6725b77e9d7ce283c069ea0d7e8058bc5d657449fa556cc4",
+        "check_gpg": true
+      },
+      {
+        "name": "selinux-policy-targeted",
+        "epoch": 0,
+        "version": "36.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/selinux-policy-targeted-36.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:fb4d05d62799c365d5d3577c136baac08a7825e2472f1b11587e1317322a316e",
+        "check_gpg": true
+      },
+      {
+        "name": "setup",
+        "epoch": 0,
+        "version": "2.13.10",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/setup-2.13.10-1.fc36.noarch.rpm",
+        "checksum": "sha256:468fc451847689e1300a4f143fba17d8649ef35afd05b285d84a7649f324e634",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-client",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-client-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:ef1f95d053d7c6dc6a2fc14039358f2db3db91b42ce79194a98c28a0c34376bd",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-common",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-common-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:b0580325e7f48f65cee2a914fb36712f068eb6202a607f962ee36b6e3cd9605c",
+        "check_gpg": true
+      },
+      {
+        "name": "sssd-kcm",
+        "epoch": 0,
+        "version": "2.7.1",
+        "release": "2.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/sssd-kcm-2.7.1-2.fc36.x86_64.rpm",
+        "checksum": "sha256:e37d6a627ace13dd51f94114e5c669fa8a5a6f695bb9dc446eed1b9a9bd6919f",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:07cd809f83c6cf5cfc2af411a51110ccbe39841eb015d5df50a444bec044da56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-libs",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-libs-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:e04548622d8725b0715f6cf1017b151607f91039d4ff4b5eeb0e04a60e593900",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-networkd",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-networkd-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:288bbd347e7bc7a4c6d63a5eed8e1c3e91a1b18157f3f6004189018daa7b7b3e",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-oomd-defaults",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-oomd-defaults-250.7-1.fc36.noarch.rpm",
+        "checksum": "sha256:1296ab1b2e589b63b27e3e190b0d67cead1261db7f7e80880b55f4ee83f5ce56",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-pam",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-pam-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:894f501c1470ec4ed5ffa8af99dd282373dec74f373d373a750737863841ae61",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-resolved",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-resolved-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ac41fef33a2d3ab64f95df70c719d68bccc2f1938be8bbaf44ae905e633955af",
+        "check_gpg": true
+      },
+      {
+        "name": "systemd-udev",
+        "epoch": 0,
+        "version": "250.7",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/s/systemd-udev-250.7-1.fc36.x86_64.rpm",
+        "checksum": "sha256:bef1b419af70422d8b78b70d2d2605352be6fc3ea88ea8f3322e092b8347913d",
+        "check_gpg": true
+      },
+      {
+        "name": "tzdata",
+        "epoch": 0,
+        "version": "2022a",
+        "release": "2.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/t/tzdata-2022a-2.fc36.noarch.rpm",
+        "checksum": "sha256:e6fc67a156d09ea6e1eb1057312a2a1d5351b5c2b2f8408fb9e1624dfab052bc",
+        "check_gpg": true
+      },
+      {
+        "name": "unbound-libs",
+        "epoch": 0,
+        "version": "1.16.0",
+        "release": "4.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/unbound-libs-1.16.0-4.fc36.x86_64.rpm",
+        "checksum": "sha256:9bfc17431245ff01b7431893884275d6357138d014d4634c073b20bb5007d798",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:736ebc6f2339860c767d8bd550bded09d7ef79ac387bd9ae3d2fff3d740383c3",
+        "check_gpg": true
+      },
+      {
+        "name": "util-linux-core",
+        "epoch": 0,
+        "version": "2.38",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/u/util-linux-core-2.38-1.fc36.x86_64.rpm",
+        "checksum": "sha256:ddf655f8565794a714f1686c15a7baaf60cf4fc8aa8d967b1ce7bfe9f18f52fe",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-data",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-data-8.2.5172-1.fc36.noarch.rpm",
+        "checksum": "sha256:3e02c4cb3b3f6dc73ebd246212513f002ac91dcaeac29858ef0e782ec3051ec0",
+        "check_gpg": true
+      },
+      {
+        "name": "vim-minimal",
+        "epoch": 2,
+        "version": "8.2.5172",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/v/vim-minimal-8.2.5172-1.fc36.x86_64.rpm",
+        "checksum": "sha256:853e915ae73a3b0a08f3cb36a8289552e488f99a4245c4bc431ff8ac531138bd",
+        "check_gpg": true
+      },
+      {
+        "name": "whois-nls",
+        "epoch": 0,
+        "version": "5.5.13",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/w/whois-nls-5.5.13-1.fc36.noarch.rpm",
+        "checksum": "sha256:5c05e31efa75b41ae4e2383fdf0cee624d4b67dcade39426797f3a4debaabedf",
+        "check_gpg": true
+      },
+      {
+        "name": "yum",
+        "epoch": 0,
+        "version": "4.13.0",
+        "release": "1.fc36",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/y/yum-4.13.0-1.fc36.noarch.rpm",
+        "checksum": "sha256:a429fe07a0a5b0247e1d4f2498a8a503f9ff976bb8d6567fafa636bfec70a593",
+        "check_gpg": true
+      },
+      {
+        "name": "zchunk-libs",
+        "epoch": 0,
+        "version": "1.2.2",
+        "release": "1.fc36",
+        "arch": "x86_64",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/f36/f36-x86_64-updates-released-20220705/Packages/z/zchunk-libs-1.2.2-1.fc36.x86_64.rpm",
+        "checksum": "sha256:5d1d3f4da399ce50321395fcea3e52fb527089ee7252e842d944617667aa863d",
+        "check_gpg": true
+      }
+    ]
+  },
+  "no-image-info": true
+}

--- a/tools/test-case-generators/format-request-map.json
+++ b/tools/test-case-generators/format-request-map.json
@@ -421,6 +421,18 @@
     },
     "overrides": {}
   },
+  "minimal-rpm": {
+    "compose-request": {
+      "distro": "",
+      "arch": "",
+      "image-type": "minimal-rpm",
+      "repositories": [],
+      "filename": "minimal-rpm.img",
+      "blueprint": {}
+    },
+    "no-image-info": true,
+    "overrides": {}
+  },
   "image-installer": {
     "compose-request": {
       "distro": "",


### PR DESCRIPTION
This pull request includes:

- New image type named 'minimal-rpm' has been added to fedora. 
- Reference taken from https://github.com/osbuild/osbuild-composer/pull/2878 which is now superceded by #3004 , since ref PR is in draft stage , marking this one as draft too.
- Image is basically a minimal rpm bootable image supports aarch64 & x86
- After building the image with osbuild-composer, its tested on both x86 and aarch64 machines, boots fine.

https://github.com/osbuild/osbuild-composer/pull/2878

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
