### PR TITLE
packit: Enable Bodhi updates for unstable Fedoras

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,7 @@ jobs:
 - job: bodhi_update
   trigger: commit
   dist_git_branches:
-    - fedora-stable # rawhide updates are created automatically
+    - fedora-branched # rawhide updates are created automatically
 - job: koji_build
   trigger: commit
   metadata:


### PR DESCRIPTION
As we don't only want to get Bodhi updates for the stable releases, but also the ones still in development, we need to use 'fedora-branched'.

See https://packit.dev/docs/configuration/#aliases