### PR TITLE
cloudapi: make ImageRequests tied to their UploadOptions

### DIFF
--- a/internal/cloudapi/v2/errors.go
+++ b/internal/cloudapi/v2/errors.go
@@ -48,6 +48,7 @@ const (
 	ErrorUnsupportedImage             ServiceErrorCode = 32
 	ErrorInvalidImageFromComposeId    ServiceErrorCode = 33
 	ErrorImageNotFound                ServiceErrorCode = 34
+	ErrorNoUpload                     ServiceErrorCode = 35
 
 	// Internal errors, these are bugs
 	ErrorFailedToInitializeBlueprint              ServiceErrorCode = 1000
@@ -123,6 +124,7 @@ func getServiceErrors() serviceErrors {
 		serviceError{ErrorUnsupportedImage, http.StatusBadRequest, "This compose doesn't support the creation of multiple images"},
 		serviceError{ErrorInvalidImageFromComposeId, http.StatusBadRequest, "Invalid format for image id"},
 		serviceError{ErrorImageNotFound, http.StatusBadRequest, "Image with given id not found"},
+		serviceError{ErrorNoUpload, http.StatusBadRequest, "You need to specify one of: ComposeRequest.koji, or ImageRequest.upload_options"},
 
 		serviceError{ErrorFailedToInitializeBlueprint, http.StatusInternalServerError, "Failed to initialize blueprint"},
 		serviceError{ErrorFailedToGenerateManifestSeed, http.StatusInternalServerError, "Failed to generate manifest seed"},

--- a/internal/cloudapi/v2/openapi.v2.gen.go
+++ b/internal/cloudapi/v2/openapi.v2.gen.go
@@ -22,6 +22,41 @@ const (
 	BearerScopes = "Bearer.Scopes"
 )
 
+// Defines values for AWSEC2ImageRequestImageType.
+const (
+	AWSEC2ImageRequestImageTypeAws AWSEC2ImageRequestImageType = "aws"
+
+	AWSEC2ImageRequestImageTypeAwsHaRhui AWSEC2ImageRequestImageType = "aws-ha-rhui"
+
+	AWSEC2ImageRequestImageTypeAwsRhui AWSEC2ImageRequestImageType = "aws-rhui"
+
+	AWSEC2ImageRequestImageTypeAwsSapRhui AWSEC2ImageRequestImageType = "aws-sap-rhui"
+)
+
+// Defines values for AWSS3ImageRequestImageType.
+const (
+	AWSS3ImageRequestImageTypeEdgeCommit AWSS3ImageRequestImageType = "edge-commit"
+
+	AWSS3ImageRequestImageTypeEdgeInstaller AWSS3ImageRequestImageType = "edge-installer"
+
+	AWSS3ImageRequestImageTypeGuestImage AWSS3ImageRequestImageType = "guest-image"
+
+	AWSS3ImageRequestImageTypeImageInstaller AWSS3ImageRequestImageType = "image-installer"
+
+	AWSS3ImageRequestImageTypeIotCommit AWSS3ImageRequestImageType = "iot-commit"
+
+	AWSS3ImageRequestImageTypeIotRawImage AWSS3ImageRequestImageType = "iot-raw-image"
+
+	AWSS3ImageRequestImageTypeVsphere AWSS3ImageRequestImageType = "vsphere"
+)
+
+// Defines values for AzureImageRequestImageType.
+const (
+	AzureImageRequestImageTypeAzure AzureImageRequestImageType = "azure"
+
+	AzureImageRequestImageTypeAzureRhui AzureImageRequestImageType = "azure-rhui"
+)
+
 // Defines values for ComposeStatusValue.
 const (
 	ComposeStatusValueFailure ComposeStatusValue = "failure"
@@ -29,6 +64,20 @@ const (
 	ComposeStatusValuePending ComposeStatusValue = "pending"
 
 	ComposeStatusValueSuccess ComposeStatusValue = "success"
+)
+
+// Defines values for ContainerImageRequestImageType.
+const (
+	ContainerImageRequestImageTypeEdgeContainer ContainerImageRequestImageType = "edge-container"
+
+	ContainerImageRequestImageTypeIotContainer ContainerImageRequestImageType = "iot-container"
+)
+
+// Defines values for GCPImageRequestImageType.
+const (
+	GCPImageRequestImageTypeGcp GCPImageRequestImageType = "gcp"
+
+	GCPImageRequestImageTypeGcpRhui GCPImageRequestImageType = "gcp-rhui"
 )
 
 // Defines values for ImageStatusValue.
@@ -44,43 +93,6 @@ const (
 	ImageStatusValueSuccess ImageStatusValue = "success"
 
 	ImageStatusValueUploading ImageStatusValue = "uploading"
-)
-
-// Defines values for ImageTypes.
-const (
-	ImageTypesAws ImageTypes = "aws"
-
-	ImageTypesAwsHaRhui ImageTypes = "aws-ha-rhui"
-
-	ImageTypesAwsRhui ImageTypes = "aws-rhui"
-
-	ImageTypesAwsSapRhui ImageTypes = "aws-sap-rhui"
-
-	ImageTypesAzure ImageTypes = "azure"
-
-	ImageTypesAzureRhui ImageTypes = "azure-rhui"
-
-	ImageTypesEdgeCommit ImageTypes = "edge-commit"
-
-	ImageTypesEdgeContainer ImageTypes = "edge-container"
-
-	ImageTypesEdgeInstaller ImageTypes = "edge-installer"
-
-	ImageTypesGcp ImageTypes = "gcp"
-
-	ImageTypesGcpRhui ImageTypes = "gcp-rhui"
-
-	ImageTypesGuestImage ImageTypes = "guest-image"
-
-	ImageTypesImageInstaller ImageTypes = "image-installer"
-
-	ImageTypesIotCommit ImageTypes = "iot-commit"
-
-	ImageTypesIotContainer ImageTypes = "iot-container"
-
-	ImageTypesIotRawImage ImageTypes = "iot-raw-image"
-
-	ImageTypesVsphere ImageTypes = "vsphere"
 )
 
 // Defines values for UploadStatusValue.
@@ -113,6 +125,18 @@ type AWSEC2CloneCompose struct {
 	ShareWithAccounts *[]string `json:"share_with_accounts,omitempty"`
 }
 
+// AWSEC2ImageRequest defines model for AWSEC2ImageRequest.
+type AWSEC2ImageRequest struct {
+	// Embedded struct due to allOf(#/components/schemas/AbstractImageRequest)
+	AbstractImageRequest `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	ImageType     AWSEC2ImageRequestImageType `json:"image_type"`
+	UploadOptions *AWSEC2UploadOptions        `json:"upload_options,omitempty"`
+}
+
+// AWSEC2ImageRequestImageType defines model for AWSEC2ImageRequest.ImageType.
+type AWSEC2ImageRequestImageType string
+
 // AWSEC2UploadOptions defines model for AWSEC2UploadOptions.
 type AWSEC2UploadOptions struct {
 	Region            string   `json:"region"`
@@ -125,6 +149,18 @@ type AWSEC2UploadStatus struct {
 	Ami    string `json:"ami"`
 	Region string `json:"region"`
 }
+
+// AWSS3ImageRequest defines model for AWSS3ImageRequest.
+type AWSS3ImageRequest struct {
+	// Embedded struct due to allOf(#/components/schemas/AbstractImageRequest)
+	AbstractImageRequest `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	ImageType     AWSS3ImageRequestImageType `json:"image_type"`
+	UploadOptions *AWSS3UploadOptions        `json:"upload_options,omitempty"`
+}
+
+// AWSS3ImageRequestImageType defines model for AWSS3ImageRequest.ImageType.
+type AWSS3ImageRequestImageType string
 
 // AWSS3UploadOptions defines model for AWSS3UploadOptions.
 type AWSS3UploadOptions struct {
@@ -142,6 +178,25 @@ type AWSS3UploadOptions struct {
 type AWSS3UploadStatus struct {
 	Url string `json:"url"`
 }
+
+// AbstractImageRequest defines model for AbstractImageRequest.
+type AbstractImageRequest struct {
+	Architecture string       `json:"architecture"`
+	Ostree       *OSTree      `json:"ostree,omitempty"`
+	Repositories []Repository `json:"repositories"`
+}
+
+// AzureImageRequest defines model for AzureImageRequest.
+type AzureImageRequest struct {
+	// Embedded struct due to allOf(#/components/schemas/AbstractImageRequest)
+	AbstractImageRequest `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	ImageType     AzureImageRequestImageType `json:"image_type"`
+	UploadOptions *AzureUploadOptions        `json:"upload_options,omitempty"`
+}
+
+// AzureImageRequestImageType defines model for AzureImageRequest.ImageType.
+type AzureImageRequestImageType string
 
 // AzureUploadOptions defines model for AzureUploadOptions.
 type AzureUploadOptions struct {
@@ -268,6 +323,18 @@ type Container struct {
 	TlsVerify *bool `json:"tls_verify,omitempty"`
 }
 
+// ContainerImageRequest defines model for ContainerImageRequest.
+type ContainerImageRequest struct {
+	// Embedded struct due to allOf(#/components/schemas/AbstractImageRequest)
+	AbstractImageRequest `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	ImageType     ContainerImageRequestImageType `json:"image_type"`
+	UploadOptions *ContainerUploadOptions        `json:"upload_options,omitempty"`
+}
+
+// ContainerImageRequestImageType defines model for ContainerImageRequest.ImageType.
+type ContainerImageRequestImageType string
+
 // ContainerUploadOptions defines model for ContainerUploadOptions.
 type ContainerUploadOptions struct {
 	// Name for the created container image
@@ -334,6 +401,18 @@ type Filesystem struct {
 	Mountpoint string `json:"mountpoint"`
 }
 
+// GCPImageRequest defines model for GCPImageRequest.
+type GCPImageRequest struct {
+	// Embedded struct due to allOf(#/components/schemas/AbstractImageRequest)
+	AbstractImageRequest `yaml:",inline"`
+	// Embedded fields due to inline allOf schema
+	ImageType     GCPImageRequestImageType `json:"image_type"`
+	UploadOptions *GCPUploadOptions        `json:"upload_options,omitempty"`
+}
+
+// GCPImageRequestImageType defines model for GCPImageRequest.ImageType.
+type GCPImageRequestImageType string
+
 // GCPUploadOptions defines model for GCPUploadOptions.
 type GCPUploadOptions struct {
 	// Name of an existing STANDARD Storage class Bucket.
@@ -373,19 +452,7 @@ type GCPUploadStatus struct {
 }
 
 // ImageRequest defines model for ImageRequest.
-type ImageRequest struct {
-	Architecture string       `json:"architecture"`
-	ImageType    ImageTypes   `json:"image_type"`
-	Ostree       *OSTree      `json:"ostree,omitempty"`
-	Repositories []Repository `json:"repositories"`
-
-	// This should really be oneOf but AWSS3UploadOptions is a subset of
-	// AWSEC2UploadOptions. This means that all AWSEC2UploadOptions objects
-	// are also valid AWSS3UploadOptionas objects which violates the oneOf
-	// rules. Therefore, we have to use anyOf here but be aware that it isn't
-	// possible to mix and match more schemas together.
-	UploadOptions *UploadOptions `json:"upload_options,omitempty"`
-}
+type ImageRequest interface{}
 
 // ImageStatus defines model for ImageStatus.
 type ImageStatus struct {
@@ -396,9 +463,6 @@ type ImageStatus struct {
 
 // ImageStatusValue defines model for ImageStatusValue.
 type ImageStatusValue string
-
-// ImageTypes defines model for ImageTypes.
-type ImageTypes string
 
 // Koji defines model for Koji.
 type Koji struct {
@@ -482,13 +546,6 @@ type Subscription struct {
 	Organization  string `json:"organization"`
 	ServerUrl     string `json:"server_url"`
 }
-
-// This should really be oneOf but AWSS3UploadOptions is a subset of
-// AWSEC2UploadOptions. This means that all AWSEC2UploadOptions objects
-// are also valid AWSS3UploadOptionas objects which violates the oneOf
-// rules. Therefore, we have to use anyOf here but be aware that it isn't
-// possible to mix and match more schemas together.
-type UploadOptions interface{}
 
 // UploadStatus defines model for UploadStatus.
 type UploadStatus struct {
@@ -789,119 +846,118 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9+XPiuPL4v6Lifatmp8J9BJKqrfeAkIQrB5BzmUoJW7YFtuRIMke25n//lmQbDHYC",
-	"2Z3dd3xmf5hgW+putbpbre6W9veURh2XEkQET53+nnIhgw4SiAVPJpJ/dcQ1hl2BKUmdpm6giQAmOlqm",
-	"0im0hI5ro63mc2h7KHWaKqS+f0+nsOzz6iG2SqVTBDryi2qZTnHNQg6UXcTKle+5YJiYqhvHbwm4rzxn",
-	"ghigBsACORxgAhDULBAAjFITAlhTk8+/S49q+xE938OPCnT9YdhqFps2Jagp2ccVIpdRFzGBffQMmYrk",
-	"GKx0iluQoZcFFtYL1DTqBbwPiE+d/pYqFEvlynG1dpIvFFPf0ik12ERYwQvIGFyp4TH06mGGdAkmoOHb",
-	"uhmdTJEmZD9/CHeuTaF+rbjLPxrDmrYU8jILxEWmkEr/nSNLpziBLreoePHnLEqTs8qEX+NUJfMkmdZ9",
-	"nBoKKLwERkEHb1MEHZzJa7VSvnpSqlYrlZOKXp4kceyTLN4ZjMSb3jPNw9KeWXa9iY01X9cM6NkidWpA",
-	"m6P0ju61DcCRAIIC9Rn8IiwEgi5AadnXNIDApsRMAzoxPK5BgXRwN+iNCeaAIeExgvQsaAsO0NLFDErQ",
-	"wMGmJcAEAU4pQQwICxJgUAaosBADniJ/TARkJhI8OyZjsqFFMA9JtNyiTCAmsYEIMgCJPiZ4GyHmQNLO",
-	"oYMA5AqVfI6iAxtsm1mYUGojSP78vB02Y+9Jm8fsZJsZRSEbJcJ/8xjaIxHYgSZa69mOBZZMo4ZimM8q",
-	"pAPVQc4rcDyuptIj+NWTy4RqaOI5IoAhTj2mIWAy6rlZNYsSiZwP6mAhhcVg1FFd5FgQF3JqGSQ6dQAl",
-	"CEwgRzqgBEBwd9c+A5iPiYkIYlLS/LnaMguKsCS9s6kGRTCD2wPsBV/AwkIMKVoUFClhnq2rwYXjhkQH",
-	"ci65QEzhv6QLKZQ25gJA2wYhGn46JpYQLj/N5XSq8ayDNUY5NURWo04OkYzHc5qNc1BOTy4wSP+cY7T4",
-	"Vb3KaDbO2FAgLv4B30KL9SIRvayRfNlhgJRG5MmpTTY9/nS8qOn4eKa3p+4A1uzOxYh6GiSDAMyFwpi0",
-	"gHiTNQkvWI8T1T6TJEWb/QFiyqii1yZFLQMnxXKmXC6UMid5rZI5LhRL+WNUy5+gYhJ1AhFIxAd0SSL8",
-	"RodRFYiLgYkOsAi1RakouKFMQPsQuQllRuA5yuiYIU1QtsoZHtGhg4iANo99zVh0kRE0I1FnfJJ3mFTR",
-	"qsioTI4zBa1kZMo6zGfgcbGYyU/yx/li6USv6tW9hm7DsfjcxiQwopV7LNd7lnHbcB1iCXbojQBIIiHq",
-	"8jWovpJYKEHXRur0t99T/48hI3Wa+kdu41PnAq8xl+Ayfv+2A3GAuEuJ70xC2z4A6rWibIAMxBDRUOp7",
-	"OsYRfZsThWIJSQcsg2onk0yhqJcysFw5zpSLx8eVSrmcz+fzqXTKoMyBInWa8jw1U3u4pidwaz26zWT9",
-	"8UF91H5LJHy0Pj/b+v8QJ/0h9ajJf+iglLxPPGzr/vOOOx6QkE4tMybNBC8xEYgZUEO/f09y1Gd0qrzh",
-	"jyjr0ilWY0lWwICgD1nRhwQbiIsfyg8nCvTPM2NncBvoH48MCahDAX/kwCgXDKEXjToOFonL1y8W5NbX",
-	"cBWTMyBA0DxhKXShNoOmD3s3PKC++D4QJprt6ZiY4Kp1P6inIhu+j8YTwFgzIomx7/Nv4LuO8eVB87ig",
-	"Dn6Da7/3IyKa262/p1M6lgyYeCLm+jML2ZlaEqN8gWYbkj5C2ZaNQ/J3O2/L5GfA/FENjQnwFgMiHP8R",
-	"Jj7JMPE13L3DDe1/eqsr+iTTNlCSeHYgPZJ1G0CH9dli5L0KWe0yPwC0PcCPLYkPrsUYZXFt0JGA2JY/",
-	"JdP0iKGTNs1EzN8kQJ4YxoovXOvGMQL88UiFIZ6jhuJpGuJyLAbEtsekY+YiIg2FHNBGrzYNY4rVpERA",
-	"TFDCyD7YuQoKPI7WW34tBLLZeL67ZfR91QDuBuxailU0YgumoAA5E6Rv+dX+fpGtssEr5cgrpKcCmonb",
-	"Dpu/zBHDxio+KMkFRm0w6g2BaoMNHPjQEaQqSBKLYuzKlz++RL83HFIscAB1HcsHaN9EpiCIHx08K+vp",
-	"YEiFjDYsVIzZ2ZlQrvyDRFZBM45iBM1PYvA32one2j7eREzh4azRsRmsDtuUn6n34Zocug+x8MtmMJQE",
-	"23VfxqLBqw2TgvjRNqrz27Or5LjODm9ePbjKYppzVkEQIhfMx+kHXNuNTKXDISdKW2yZ3lnGw+Eebtw3",
-	"xiLBtBvYRnzFBXIOhne+6ZIAMOocRWLfLuXCZIh/Lu7twpWcjReGXMqxoAwneV2tpWAQRNsokQ8pAdxF",
-	"GjawnFMCtv2gLBhZiKMx2eq9wLYNKLFXKmTBkS6tmY5cTu05CgJfgmE0R2skYxJq2fUQYMGRbagg8coH",
-	"RqiKDMI5xDac2ButV9IDGKUCUDYmkKyCUKwLmYg6pDpwGZXrwVdFc4j4hSPBgYGRrYcwY8PBHGCTUBYG",
-	"gw6a5UEIYZWYkEBsjjX0eV3ncvQJMaQe9nU7BKw47rcGk1UYao8Sv9FKAzO0gHayVXQwaftdCvFhIPIJ",
-	"cvzGe6khhpDt+CeJSTKv0ajRvvkaRttKQ8c/YyPueJJ5SKJp7VD9KG9XozpKNAZbPprsASOR0YSI7mHO",
-	"mkK3br4DONmhVEOWEnH4sFXrBM8+nIuDJsVn9b6NtQ8qmfLzLeu+s93H5CXME6+lt5Avlrf3+B4m4ris",
-	"hFcueC7FRGwLfG4O2d6FL9I5vUGdtAJeNG/2pGgmnjZD4v2gPSQALTEXcus9HNWvzuqDMzAUlMmtuWZD",
-	"zkFDgcjupkyCh0yA4d0tbbI7J80ySXC0seNSJoKUiUq96kDuETyBQIuYmASOd3ZMRuuYuQK0k1FaYGEF",
-	"cfKL5o1cECTT0mBhYc2SZl6uVdsrkYIVpPUkep+WLGgbak3aLI1hqmlMvmj+/oVloIszYy+fL2meh3X1",
-	"C30BPjNCdADySKRfUv2ZVNQmlRhnpRyi/z2SUFiPSS2rkwhzBY3yV25pAn6q9OyalVA+Y11BD0PuWTBE",
-	"CIS5Bs2mnp41KTWDDQr3RUclIXLrhFOQw4syMe27qp4tcCagPGwONJty6b8GGyV/wzEmvwS5pVA8fcFc",
-	"d/sq2axZlCMCoCeoAwXWoG2vdpmMvE/UJCSvdQFf1LhB2FzSq6BsS3KS+CrxzI5JC2pWKCSK64HPCuCa",
-	"Uyz0bAI0QFKeBfeKAj9qzAFk6HRMAMiAL3IxO/0dORDbWP/+5RTUCVBPAOo6Q1yKIBTSBWSISxu6waVJ",
-	"EGBnWFlwThkIuJcGX6CNNfSvyKb0SzbAHDgAdb/fJ2nwUQcg3sPtrDLK48tA1/0XdF3uUpE1g05hnyhJ",
-	"KmH0WW4E4w+zz5KuHRboDiY8kQc6dSAmp7/7fyVCpZ5g6GGBgP8W/OIy7EC2+hpHbts+QrW9km6JP/tQ",
-	"BH13ObJRvS+AMvBlh6ZkrftYNDH3+/jGQQoqgGQ1JiF/t7XpN+U9ncakIrV2fEN5OHTyUumUP21xNsv9",
-	"oM/g6Ms/XfiUDpfJD9fYH5dMVK6+hP+ymyyCXENEh0RkJgxiPVPKlyqF0l6PIQIuvS83uRX0jVcoMc3C",
-	"AmnCYzvDWdaOX47L76/z/usDYqejlYtUxNPPNezrcz0cyVZqxNs72x+wN/NX+xfqHhTp3/a1YkVWUdZt",
-	"cWWH9G/hLLwnUSjcNxwcCV67v5+OhAcx5DUrDgOwnUtNDkDvDPNTwV2pkdgOfvqU+b/DKpogAhyTxYiE",
-	"RVDBhUQDFzxjwQyzPBw8RX5y6K4f33xi/IKa4CXSTZRZ57mCpzBYFLzAhAto2+qFqbn+vyEAUyrc2iKo",
-	"v1sdMBUb+P7DBrx8ZnCx7j7nrnTzElnQDbI2yVHVjUKfI50ymGlKFy7TgPwdp9NGkO/0LOaL+fxJvprN",
-	"JzpSiM39aPumR+gvzugUZw2FOLBZWcpM9dryJltpcIaTA7d8tms1y8V0QkZijhiP5d9K+2vuAvI3qILq",
-	"3w3EDVeS7Os6ZZ2wUMhlN8ijEJVejW1QiT/9fsv3wL9nN5TOHMKdpGBFuGnfBjnDJDmGEBZxxxkfbpTj",
-	"XwQV0E76tMMFhTS9rv72i679zul39/DpVLBSxAtXIUMkYQ/chETuchBWQUQYZLHBLwHrTkG+eJwvT4o6",
-	"PEYnlfJEL5UntUmtCGulCqrAalUvTo7zhgG/pqXvBcGEQaJZGRvPEGDrdM8GHrOQnavl/JU0J03G152t",
-	"SbxFslIa8bTy/m7v1oPGObkTiYqx1ApIiPsCydLyjhglJQeDyVcYkmZ5N+ef6MIkEoFc+s6X0Dh+ZP7i",
-	"dg6bjl557xOBoQv1jkua8CFisvaUy/lexbt2Ke0zYU2jXIojjlDccECOAumI22xNJ1mGdAv6tYRyWUJE",
-	"5HTMRU4KXm0jeRIO5TnKcweYcs1C2uzFdM3IeCOV06ZrzlBCJvPi5gLM0Gqda5C83uQvVMhH1XWHo90O",
-	"XGXkf43WRfsK3FzcgJu7Rq/dBN3WE2j0rptd9XlMxsS5bV81LuraUKONVv2sZ9SeLmforXMMdbv/tKjC",
-	"i4u23YG2qHWmxWWuUeweWW2j7S0vhHs/raIx6Q3Ms7vq8RSOKu79WcU573dK7gwRNMhpI+f19XZ2tbrl",
-	"1mOR3j4uWm93w0mhedVvGs0Lc/ZYuy2OydvzjLW1JjvP3xYXrDuxoadbd0f4HpL6GXcKtafWK59U6nel",
-	"qi7uWL90+6Q/mCeDo0d8Y9zXBmPSbUxH+dL8vnGt94f8qXTSg01y3HYL13O31m7RXBu17p8Kr07z+qYO",
-	"u/lJ57LkGWa56aEZPxoNx2Rx+zBCzd7Se+4dX/cf6fVNdzHv3xrLiVl4PKvNved8V0xz2tVlcQm9/NLh",
-	"de/ksuOi2fz6ZrC0x2T1KqarZ4PRe4zOV+7i2ZzfLgQh/VrOHLa8XOd+xJ7ylaLTuhtVm9qkWp5pl+ej",
-	"c6M/s8nsIjcmeeOuXB/ASr58WVpO8zMxQaV5V7t5pDfXXrdxzy+H83z+7uKpvrpB3uqoVtXuck8tq1+d",
-	"lYb33emYHKP2s7nC/ev8wi48XZwNuppnL2b8pH7k2TOzQEeTMi+9Oc/zm3z1go6WD+XiFHYrD8OjK+sZ",
-	"oTGpHecf6b010Qpdd3g0NZ7plLOWeK7dTO6ej57m57WBy/SHOpteTjqzYscddOvLkbXkt3XesC4KY5Lv",
-	"ecviA+w38maxXbnR+nonp71Oab6maWzaePTw8oHhCvZO+o9u7XWUM4ZvVw7X2yap5V6fu2OCa7eebXjV",
-	"qvdqPeQWojgRBAtzwF+n1rLvTZ/uys+TsjUT5zWre5d7fKyWi69Wr9Jd1Af123pjTMTZ+cXzw2CuOS2z",
-	"e9YvdIf12rNzP5uUOlZv1C/0Hhsr+FCwNGLXw/faZWcOnfup3qzMx0RztCN827luNPqNZr1ePsetFro8",
-	"dph1fln17vltr98v5p8q2rNFlk+187qjdKh5saidNxez9pg0Fu2L81vaadZ5s9F4atYXreal2Wqel+v1",
-	"pjm73fQ+unqq56qNJ9e0V8P689OlNV11rTHJHRnHbzfG/XxyWcy3XkuzdvX6vHGVJ73Ho8ZdwfHmw6PX",
-	"kTcsPfRYo+SULjxbuN1Bq9PtCafSOhuTArt4e6zTUWHlnjy1a736md5vNq9X0/qU04e7WvXpzmse5SZk",
-	"ykZoUOwNrpvG6qZZPX44qVXw9f2YOJXh0YTfni2qzWKP2Xq9X+6feXT1XBhicQGfy93b3r04GrVgoYz5",
-	"0/CiOX2j1Zun2n2pcz2r5MfEfH0wa8Wr3MQptt6G1VGt9NA6mxTs+bTctudLs/3aRWah8Pb4tHTY0/C5",
-	"02ka8zfjyL4aHntL83JMpstcJ7+yn4s9PLlgxxf1+ur65O6B1Z+Hi2E/39Kmo9qi1STL2fDMW706D4v7",
-	"+VXj0Wu172vXqPQ0Jn18VzA6VzWuV89cfr6s9I8eddInt8OjSzYd3XTPSs4Ds+s6aY0s/em+Nn2euQ/W",
-	"2YqXcicn6HpMrFme9cgqP71azKBn5PBd7Vo7fpz3Z9PeoN8xK3cn991Vx3t4EG+LRzLtX1UeBueN126Z",
-	"P1On3x8TQ0xGl4WjymoyeMjVS/PGBC4HD0VRvXu7mmpvaDZ8bmHYuzrp5S61TrM9KNye145rxTO9brfO",
-	"T/QxmRXNW/w0vK1D2Ml3OvW3y/lgNuj0ema3+HT7hC+v7ldFUeqszg3OoFNZDJsP14Z1g9qrXmP03BmT",
-	"OXOv7JsJMvjopFIdGcXGVdsz355Zs3K/PBt2Z8/mwCrcX8yH7VvSXL3NblfHrbvi642LHyon0kZZN+3H",
-	"Z9alWrfU7Q1Pcvitczsa2GLar/86Jr/eGKPqmKjVpXV19tHSkxhgURnpF87t5KXSQQLamMyS128HM0YZ",
-	"T9h2hf3+KVfLX/3vmVJx7OXzxWPpQfy6DvrsW8x9JHawh9gmYk2D/JzVEBGUK/z/DPyVX2sZLhiCTgQz",
-	"lP8el/03ij65Rb0eHkBLNN2fmPnCxAw9BuDXBCj3feMzAMilW8EBVkmITYBclRqMyS8udpGNCfqaWHYQ",
-	"C5GGdUj0kzUdzOLO/gN3Z0gg5mCCOFhYKNjM+BmKrQMwyi3ynUg1KhV+SXKXEgrAYm74cCffvuODawLP",
-	"/VRx4MRtn8JEGkMiIz9FptOFnC8oSyxNkJ7lS6KLGvdQDxARTDg2rZ1Tp8nVb+kUZSYkQRXMbiCknC8V",
-	"y+9HQeIkR2ckK+c3Qvlewne2AVuEpXeZvkVDhIOR0Sftr+Kle2R18MGVnQhpem+f3VOn+7rEMt57ccTP",
-	"Me7r8k4V4/dv6VjmFfPwwBZD0PaLoNRBHzDxBIiPT+ogVFqJBKDGmCSwLQsUXAdBEmSnoG2DhIbAnzQ+",
-	"JpAhAG1OA62P4YXrtkH+e46pqsLzz7NKgseEeTbyi7wYMihDabBAwILzdY5eCQJQ6WU5ugkCcOFnO6FQ",
-	"x9I4+SLGxKWc44mtujl4qTLNDhSaBRzKEAi4DAQ1la2SxnItdu9FtiIB+s+co9oOUx8ujQf22E0NfUIW",
-	"D+yRXDSq6lU+H6hfh/oPSdX4HYNczXsV5kEcIpydbzvz+MmQP/MIeS+uHyUnKbCf5aV10D2M328C6IkQ",
-	"eVJJuMo8bmeXNrZbfUy80CB2CmB30ePcyiC9WKkUTkC9Xq83S1dvsFmwn8/ahatRqyLfta/YRbfF+k/4",
-	"qN+/W3iXcFDvOIMebb8NjOLrWVE/q7zlG6Nl7niZREQ8xO9xxPZHvN9JFapFTPMYFquhFAqfQQ0Emc+4",
-	"ifp1Hi5YnYdReDWGWj/9dmuocqn2L8jAxKBxt2wYZP4FDXwpVYHj50f8xDSXromNNRQcfQzu5Ki7ULMQ",
-	"KKpkhFpu157vYrHIQvVZuZtBX57rtZutq2ErU8zms5ZwbDWDWCiWXQ8bCn2QXmNAlbgA6OJIpO00VUz5",
-	"hXZEfjhNlbL5bEGFrIWl2JTTbEoQz/2O9e9KrpKKsC6Q8AtclLaociwQKAGgDEittJEI66v9owcqTC0p",
-	"UxU7mAdHpyK+H2Uqf78pNFK17NIBVOqHdKRno8V8bd0nJXoIM711w8tvyaeYgwPLPvGCAlOVgal7UyQf",
-	"NtemBIc+Qonz/azNJSo//KzkN3VkWJ2RVZNRzOfDevAgEQBd1w7OP+SmQS3khqAPLXKES0qctzkT5YkU",
-	"kfIPRB0keeNI28Rf9wPJAFj3URf+etR1T1hA0BlS2wvsE+JjL/312O8I9IRFGX7ztzQuYlI2wFq2fUrK",
-	"fwclM0IXZGcKKn/H7N8RtHSRJu2EKhwAVNM8JjUtasKVFofG+7dvUke45ziQrYISwqgRUsZrLU8KTk6L",
-	"3GBEkw6hNNWRGQABQYuwaxq4VA4dK+dYo4QHtaaqXnyOGAyNu7L3QfGluqrJL/7DDOhIdgkKCWOG64Zy",
-	"EZ6U940M4iI8c/9jNH77tOj37eVTGrPvMXtT+NHY23rS1AcfgQW5nD8mkP5vMzpsc470p+X5aXkOtDyB",
-	"0UiyND/KefqEvxTycI+jtHWY+SBXaQ34/5iztMWpBAna5stPh+mn2fovdZjetV/+RjDqNSX4L9Hrfg6y",
-	"JxFj9R9kRf4C32v3IqW/2/tKunYpQaTUcSa02FTQT5Bch4JT5Ml2TaClyLk2xDv0JNwpepj1Kv8oBEm6",
-	"+X1r1ZZs2To79oEC2EEx5B9ZxQ1MMLciizj4cA3HYrN0p9WOQkXFHSQgwMSXYUwJgBPqifDCOs8WHy3z",
-	"qpbz5yK/d5EPrmlKVA0pAusjfv4lj+sNIiaAUJVXxZpnQxacaQK/CIt6phWkNDrD66uv2f85RbpQ59fM",
-	"MAMdSnmSGm1dOfWhLq1bHqBOA3X/KVeXZq7vjZDEqD14YM5I9KbNLFCH1taNNaoUi4en9YLp05GB1b2q",
-	"AkTDscEdEH75ASThnRCZEFy28oEqbq7y+qmPe/Vxw6x3lHJrumOK+b+pa9vqcYDSRaqMP9a5oKGvcjE9",
-	"80/XoiXUxNZCtL5+WEcuIjrfXMyidG0d+ldnPj/SjJDOn4qxXzHWt8W9oxfhVH5GL35uUn9uUv/TNqkx",
-	"25Rk7xTwqE8RMzGbKz1ixiVpZJsmOXWA570Sh0g7dcLnL1X9zRiSpN2/g5IaIGDGTzX796iZL+j/fUoG",
-	"1wIEbRus659Cadqo2f6INiR+0QPR1neq+5Rtbh+ZrIBaOpMV9fD4EQqa/6lVv/Q3r+HvTqX6AKLvfmrx",
-	"Ty3+jBajuARJzV0X+by/Ql4HTZLlfpvYAJzSZ7mzljwI9sz/jb7Fh8P5vq6DTrJE/eAqFKp7mn9/z/ro",
-	"9XYZF3RxVuLhFg7+fwbQxf5VqBkVPUAsE97DlJsXlcexU1wmoImJ+RECLqCJ/iQaxUQSXtWyRrMPzrfv",
-	"/z8AAP//9d2HvV9rAAA=",
+	"H4sIAAAAAAAC/+x8e3PiuLL4V1Fxf1WzU+H9CCRVW+cCIQmvPIA8l62UsGVbYEuOJPPI1Hz3X0m2wWCT",
+	"kDNzds85d/aPnWBb3a1Wv9Td0reURh2XEkQET51+S7mQQQcJxIJfJpL/6ohrDLsCU5I6Td1AEwFMdLRM",
+	"pVNoCR3XRlufz6HtodRpqpD6/j2dwnLMq4fYKpVOEejIN+rLdIprFnKgHCJWrnzOBcPEVMM4fkvAfeU5",
+	"E8QANQAWyOEAE4CgZoEAYJSaEMCamnx+Lz3q2/fo+R6+VKDrD8NWs9i0KUFNyT6uELmMuogJ7KNnyFQk",
+	"x2ClU9yCDL0ssLBeoKZRL+B9QHzq9I9UoVgqV46rtZN8oZj6M51Sk02EFTyAjMGVmh5Drx5mSJdgAhr+",
+	"XH9GJ1OkCTnOn0LbgSYaoFcPcSHBQ9u+NlKnf3xL/T+GjNRp6n9yG/nIBRzI1SdcMKiJrdHf07scwPL1",
+	"i4/5WwoRz5E0wQVPpeX/MxbMMMvDwa/Inxy6/s8N4ZsJe65Nof5ClUQoPO+SqqZ5p8ZcB0N2uRShM86p",
+	"P9e82gbyznqv1zGFvMwCcZEppNJ/pRSkU5xAl1tUvPjyHaXJWWXCt3GqkuUnmdb9UuVzaiig8BIYBR28",
+	"TRF0cCav1Ur56kmpWq1UTip6eZLEsU+yeGcyEm/6A5UYlv4GjUC6iTIadRwsV0T9woQLaNuIpdIpUwLL",
+	"qKGptA9i6z2mYjNa/mBwsf58zl0LMfRzNGlY+nFF2oUREw/Xm9hY8y2/AT1bpE4NaHOU3vEEbQNwJICg",
+	"QL0GvwkLgWAIUDb/axpAYFNipgGdGB7XoEA6uBv0xgRzwJDwGEF6FrQFB2jpYgYlaOBg0xJgggCnlCAG",
+	"hAUJMCgDVFiIAZ9rYyIgM5Hg2TEZkw0tgnlIouUWZQIxiQ1EkAFI9DHB2wgxB5J2Dh0EIFeo5O8oOrDB",
+	"tpHzCaU2guTHNeMjnXhfnz1mJ3vwKAr5USL8JMWJmwymWVggTXhsx5ota8cvx+UkY0G5YAh9JNXXw5H8",
+	"SlHrUo4FZaGuhsb2veGDcNDqQ1+8NYcddEo33jyG/g5//OYTpP79aW5XAvtRYxGHcZo8pdDJ7YSKUp+o",
+	"oXTJpx7pQA2QKg8cjyst9wh+9WQ8qz408RwRwBCnHtMQMBn13KxScIlEqip1sJB2xGDUUUOYz3Cp9QwS",
+	"nTqAEgQmkCMdUAIguLtrnwHMx8REBDFphHw13vLJocGOMd6mGhSBcm9PsBe8AQtp4hUtCoo0Pp6tq8mF",
+	"84ZEB1LNuUBM4b+kC2mvbMwFgLYNQjT8dEwsIVx+msvpVONZB2uMcmqIrEadHCIZj+c0G+eUvOSCaOAf",
+	"c4wWv/sipNk4Y0OBuPgf+BaGCy8S0csayZcdBkhDhTy5tMl+31+OF7Uc76/09tIdwJrdtRhRT4NkEIC5",
+	"UBiTojdvsibhBetxotpnkqToZ/8EMWVU0WuTopaBk2I5Uy4XSpmTvFbJHBeKpfwxquVPUDGJOoEIJOId",
+	"uiQR/keHURWIi4GJDrAItUWpKLihTED7ELkJZUbgOcromCFNms6c4REdOogIaPPY24xFFxlBMxJ1xid5",
+	"h0kVrYqMyuQ4U9BKRqasw3wGHheLmfwkf5wvlk70ql790AduOBZf25gERrQy0altLNc+p7ltuA6xBInm",
+	"UwFIIiG6N21QfSWxUIIOcSbxva0yx9EnA8RdSvxd72Eu6lpRNkAGYohoKMk76ducKBRLSO5+Mqh2MskU",
+	"inopA8uV40y5eHxcqZTL+Xw+n0qnDMocKFKnKc9TK/UB1/Q9zkbNbrNY//yk3vt+SyR8tD4/2/p/ESf9",
+	"KfWoyX/qpJS8Tzxs69vh2TYJ6dQyY9JM8BATgZgBNfTte9IueUan+KNIpkunWM0lWQEDgt5lRR8SbCAu",
+	"fio/nCjQH2fGzuQ20N+fGRJQhwL+zIn5cftLsKNNcl+/WZBbX0MvJldAgPUGOOYKXajNoOnD3s1jqjd+",
+	"DISJZns6Jia4at0P6qn0YRuAAMaaEUmM3c+/vRsezeOCOvgNHhRtN7e//p5O6VgyYOKJ2K6QWcjO1JIY",
+	"5Qs025D0Hsqdrcb24MP3T7tg/lkNjQnwFgMiHP8ZJj7JMPE13A+nG9r/9NZQ9EmmbaAk8exAeiTrNoAO",
+	"G7PFyHuVW99lfgBoe4LvWxIfXIsxyuLaoCMBsS3/lEzTI4ZO2jQTMX+TAHlivj3uuNYfxwjw5xPZHXNP",
+	"0xCXczEgtv2dsouINBRyQhu92nwYU6wmJQJighJm9s7OVVDgcbTOBmkhkM3Gc++W0Y9VA7gbsGspVomq",
+	"LZiCAuRMkL4VV/v7RbbKBo9UIK+QngpoJm47bP4yRwwbq/ikJBcYtcGoNwTqG2zgIIaOIFX5s1iCa1e+",
+	"/Pklxr3hlP6+PG642GFmNvz941mV9eR+MLOyB47kkq5j+QPaN5EJB/nXg0V3LbMMqZTrRs4UaTvbN8pV",
+	"EJUoT9CMoxhB85MY/GxEYki7X4B292+fYI2OzUDqtik/U8/DwCWMsWI5qs1kKAlyGr4iRpO/ERny86/b",
+	"qM5vz66Sk187vHn14CqLac5ZBZmaXLAep+9wbTezmw6nnKiSsVhmJ9YJp3u4B9xY1AT/Z2Ab8RUXyDkY",
+	"3vlmSALAaAQZqc65lAuTIf65ypwLV0rld9PN28vXWgoGQfQbJfIhJYC7SMMGlmtKwHawmAUjC3E0Jluj",
+	"F9i2ASX2SuV1ONKlydeRy6k9R0F2UDCM5miNZExCLbseAiw4sg1VZFn5wAhV6VM4h9iGE3uj9Up6AKNU",
+	"AMrGBJJVUMpwIRPRqF0HLqPSaX5VNIeIXzgSHBgY2XoIMzYdzAE2CWVhxuyHk/XpFEdsjjX0eV3ncvYJ",
+	"ibYe9nU7BKw47n8NJquwVBUlfqOVBmZoAe1kq+hg0vaHFOLTQOQT5Pgff0gNMYT8jn+SmCTzGk2tfbRe",
+	"w+i30tDxz9iIO55kHpJoWkedP2tLoFEdJRqDrUBWjoCR9HFC2vuwiFahW3++Azg5AlBTlhJx+LTV1wmh",
+	"ULgWBy2Kz+qPsg8+qGTKz7es+05OBJOXsOtnLb2FfLG8nQjxMBHHZSW80uG5FBOxLfC5OWQfOr7I4PQG",
+	"dZIHvGje/A3hqKm5qbT8/88q6l00b34w8IxBiC3hxNNmSOwv8UAC0BJzgYkJhqP61Vl9cAaGgjJoIqDZ",
+	"kHPQUCCyuwW24EcmwLA3AZIc10r/RBK2ZdhxKRNBgU11yehA7ig9gUCLmJgE27TsmIzWFRYFaKf+uMDC",
+	"CqoqF80b6Rkl29JgYWHNkv5OOu1tl6xgBf0BEr1PSxa0DeWcNzFCWJgcky+av9tlGejizNjL50ua52Fd",
+	"/YW+AJ8ZIToAeaQuJKn+TOFy05MQZ6Wcov8+Un5az0nFF5MIcwWN8ldugAN+qj6PNSuh/I11BT0s0GTB",
+	"ECEQVqY0m3p61qTUDLaz3BcdVbLKrcuTQcU3ysS0H7N7tsCZgPLwc6DZlMtAPthW+9vTMfktqESG4ukL",
+	"5nrYV8lmzaIcEQA9QR0osAZte7XLZOR9on0s2ekHfFHzBuHnkl4FZVuSk8RXiWd2TFpQs0IhUVwPgncA",
+	"15xiYYgXoAGS8iy4VxT4NQYOIEOnYwJABnyRXv30G3IgtrH+/cspqBOgfgGo6wxxKYJQyFiYIS7t0QaX",
+	"JkGAnWllwTllIOBeGnyBNtbQ/0ZSGF+yAeYgEqr74z5Jg486ALEPt7PKqNA3A133f6HrcpeKrBkMCsdE",
+	"SVLlxc9yI5h/2Ksg6dphge5gwhN5oFMHYnL6zf9XIlTqCYYeFgj4T8FvLsMOZKuvceS27SNU+0wZn/mr",
+	"D0UwdpcjG9X7AigDX3ZoSta690UTc3+MbxykoAJIVmMS8ndbm/5QYeRpTCpS6x1AKA+HLp50smrZ4myW",
+	"G2OfwdGHP9zPmw7d5J5g42eXntWeR8J/2S0tQq4hokMiMhMGsZ4p5UuVQunD0CkCLv1RJXs3cvpMFTsW",
+	"N33Y4PipEbtx3YcYYi1eH41ITmeqWCpaBYitMQq3NAdn8teR+acrGUENYB1NHgZguxaeXEDYmeankvNS",
+	"R7Ad/OlT5v8ddkEFGfyYqHeDklNytnMj+udIpwxmmjKiyDQg3xMD2QjynZHFfDGfP8lXs/lEv47Y3C8V",
+	"bEaE4cuMTnHWUIgDFcpSZqrHljfZquEznJxQ5bNdJS4X0wnllDliPFY8LH3cSxqQv0EVnLHYQNxwJUnd",
+	"1/X2BLslvUBQBCKqNhzbgBC/Cdr/ch/4fUqjBOYQ7iQlEcLN9DbIGSbJe/vwqEyc8eEGNv5GUAHtpFc7",
+	"XFBI0+szNv7RFn9weu/eOp0KWmHjDdmQIZKwJWtCIoNuhFVyDwYlePBbwLpTkC8e58uTog6P0UmlPNFL",
+	"5UltUivCWqmCKrBa1YuT47xhwK9pGQpAMGGQaFbGxjME2LpWtYHHLGTnajm/5TeHdBN93YmU418kK6UR",
+	"r4l/PGxvn3OckzsZohhLrYCE+BY0WVr2iFFSZTNYfIUhaZV3GxYSe60TiUAu3fMmNI7vmb+4ncOmo1f2",
+	"vSIw7PXeEyElvIiYrA96/Vaqz3SvXUr7TFjTKP1QJHkcNxyQo0A64jZb00mWId2CfiOk3DAhInI65iIn",
+	"Ba+2kTwJh/Ic5bkDTLlmIW32YrpmZL6REwGma85QQhn24uYCzNBqXQOQvN7UFVQGQp1XCGe7nUfJyP8a",
+	"rYv2Fbi5uAE3d41euwm6rSfQ6F03u+r1mIyJc9u+alzUtaFGG636Wc+oPV3O0FvnGOp2/2lRhRcXbbsD",
+	"bVHrTIvLXKPYPbLaRttbXgj3flpFY9IbmGd31eMpHFXc+7OKc97vlNwZImiQ00bO6+vt7Gp1y63HIr19",
+	"XLTe7oaTQvOq3zSaF+bssXZbHJO35xlra012nr8tLlh3YkNPt+6O8D0k9TPuFGpPrVc+qdTvSlVd3LF+",
+	"6fZJfzBPBkeP+Ma4rw3GpNuYjvKl+X3jWu8P+VPppAeb5LjtFq7nbq3dork2at0/FV6d5vVNHXbzk85l",
+	"yTPMctNDM340Go7J4vZhhJq9pffcO77uP9Lrm+5i3r81lhOz8HhWm3vP+a6Y5rSry+ISevmlw+veyWXH",
+	"RbP59c1gaY/J6lVMV88Go/cYna/cxbM5v10IQvq1nDlsebnO/Yg95StFp3U3qja1SbU80y7PR+dGf2aT",
+	"2UVuTPLGXbk+gJV8+bK0nOZnYoJK865280hvrr1u455fDuf5/N3FU311g7zVUa2q3eWeWla/OisN77vT",
+	"MTlG7WdzhfvX+YVdeLo4G3Q1z17M+En9yLNnZoGOJmVeenOe5zf56gUdLR/KxSnsVh6GR1fWM0JjUjvO",
+	"P9J7a6IVuu7waGo80ylnLfFcu5ncPR89zc9rA5fpD3U2vZx0ZsWOO+jWlyNryW/rvGFdFMYk3/OWxQfY",
+	"b+TNYrtyo/X1Tk57ndJ8TdPYtPHo4eUDwxXsnfQf3drrKGcM364crrdNUsu9PnfHBNduPdvwqlXv1XrI",
+	"LURxIggW5oC/Tq1l35s+3ZWfJ2VrJs5rVvcu9/hYLRdfrV6lu6gP6rf1xpiIs/OL54fBXHNaZvesX+gO",
+	"67Vn5342KXWs3qhf6D02VvChYGnErofPtcvOHDr3U71ZmY+J5mhH+LZz3Wj0G816vXyOWy10eeww6/yy",
+	"6t3z216/X8w/VbRniyyfaud1R+lQ82JRO28uZu0xaSzaF+e3tNOs82aj8dSsL1rNS7PVPC/X601zdrsZ",
+	"fXT1VM9VG0+uaa+G9eenS2u66lpjkjsyjt9ujPv55LKYb72WZu3q9XnjKk96j0eNu4LjzYdHryNvWHro",
+	"sUbJKV14tnC7g1an2xNOpXU2JgV28fZYp6PCyj15atd69TO932xer6b1KacPd7Xq053XPMpNyJSN0KDY",
+	"G1w3jdVNs3r8cFKr4Ov7MXEqw6MJvz1bVJvFHrP1er/cP/Po6rkwxOICPpe7t717cTRqwUIZ86fhRXP6",
+	"Rqs3T7X7Uud6VsmPifn6YNaKV7mJU2y9DaujWumhdTYp2PNpuW3Pl2b7tYvMQuHt8WnpsKfhc6fTNOZv",
+	"xpF9NTz2lublmEyXuU5+ZT8Xe3hywY4v6vXV9cndA6s/DxfDfr6lTUe1RatJlrPhmbd6dR4W9/OrxqPX",
+	"at/XrlHpaUz6+K5gdK5qXK+eufx8WekfPeqkT26HR5dsOrrpnpWcB2bXddIaWfrTfW36PHMfrLMVL+VO",
+	"TtD1mFizPOuRVX56tZhBz8jhu9q1dvw478+mvUG/Y1buTu67q4738CDeFo9k2r+qPAzOG6/dMn+mTr8/",
+	"JoaYjC4LR5XVZPCQq5fmjQlcDh6Konr3djXV3tBs+NzCsHd10stdap1me1C4Pa8d14pnet1unZ/oYzIr",
+	"mrf4aXhbh7CT73Tqb5fzwWzQ6fXMbvHp9glfXt2viqLUWZ0bnEGnshg2H64N6wa1V73G6LkzJnPmXtk3",
+	"E2Tw0UmlOjKKjau2Z749s2blfnk27M6ezYFVuL+YD9u3pLl6m92ujlt3xdcbFz9UTqSNsm7aj8+sS7Vu",
+	"qdsbnuTwW+d2NLDFtF//fUx+vzFG1TFR3qV1dfae60nM66tK8QvndrKrdJCANiazZP/tYLkz5gnbrnDc",
+	"P6S3/N1/nykVx14+XzyWEcTv69NpHzlzH4kd7CG2iVjTIF9nNUQE5Qr/P4J45fdahguGoBPBDOX/j8v+",
+	"E0Wf3KJeDw+gJVqGTyzEYGKGEQPwa/UqfN/EDAByGVZwgFVOfJOvVS0AY/Kbi11kY4K+JrYDxDJ2YX8Q",
+	"/WSvBbO48/FB0jMkEHMwQRwsLBRsZvyE+dbpHRUW+UGkmpXKPSSFSwnda7EwfLhTB9+JwTWB534JNwji",
+	"ts9vI40hkZGvIsvpQs4XlCW2DMjI8iUxRI1HqAeICCYcm9bOefXk1r10ijITkqA7ZTcRUs6XiuX9WZA4",
+	"ydEVycr1jVD+IeE724AtwtK7TN+iIcLByOyT9lfv514jldbP5DG3k2Xpgw9qHzhiN2V8UB7zUyOSu+pU",
+	"HvPz6cJ1wjHcCX48cLRyEd/fpxxsCMPV+XNnHT+ZeGQeIfuyi1Fyki7FyPKSX7QPT+Sm0qn3W0hVn0tM",
+	"0FRFYrsvY6NE6mXinRSxXvJd68O5lUF6sVIpnIB6vV5vlq7eYLNgP5+1C1ejVkU+a1+xi26L9Z/wUb9/",
+	"t/Au4aDecQY92n4bGMXXs6J+VnnLN0bL3PEyiYh4rtXjiH2cetxTQlDWRPMYFquhFAqfQQ0Emc+4ifrr",
+	"PLQcnYdReBOMMmT+d2uo0mb698FgYtC4fxwGFUFBA6emKvP+dQ1+wYpLH2FjDQUH6IIraOou1CwEiior",
+	"rOzeOgRZLBZZqF4rvx+M5bleu9m6GrYyxWw+awnHViuIhWLZ9bCh0AdJfgZU6RtAF0dSHqepYsrvRCLy",
+	"xWmqlM1nCyp3KCzFppxmU4J47hvWvyu5SmrOuEDCL3wrbVFtGiBQAkAZkFppIxE2oPoN7CpfKClTlXzM",
+	"gwM4ESdMmarrbRoQVLOv9MRK/ZCO9Gy026mt+6REj/Klty40+iP5LGxw7NUnXlBgqvYQdU2Q5MPmlqDg",
+	"6EAocb7D29wZ9NNP3P2pDp6qk5ZqMYr5fNgwG2RkoevaQRd9bho0i20IetciR7ikxHmbM1GeSBEp/0TU",
+	"QakpjrRN/LArkAyAdR914V+Puu4JCwg6QyrOwz4hPvbSvx77HYGesCjDb35s6SImZQOsZdunpPxXUDIj",
+	"dEF2lqDyV6z+HUFLF2nSTqjyJaCa5jGpaVETrrQ4NN5//Cl1hHuOA9kqaC2KGiFlvNbypODktMiFXTSp",
+	"S7+pzhQACAhahEPTwKVy6hja9gpolPCgB0011M4Rg6FxV/Y+aMpSN5P5TUGYAR3JIUGDUcxw3VAuwvPW",
+	"vpFBXIQnt3+Oxm+fOfy+7T6lMfseszeFn429rSctffASWJDL9WMC6X+b0WGb04i/LM8vy3Og5QmMRpKl",
+	"+VnB0yfipZCHHwRKW0diDwqV1oD/jwVLW5xKkKBtvvwKmH6Zrf/QgGmv/fI3gtGoKSF+iV4ac5A9iRir",
+	"fyMr8i+IvXav4/mro6+ky3sSREodc0CLTWftBEk/FByzTbZrAi1FzrUh3qEn4Qrdw6xX+WchSNLN71te",
+	"W7Jl60zJOwpgB11p/4wXNzDB3Io4cfCuD8di47rTakcBbU6BgwQEmPgyjCkBcEI9EV575tniPTevmup+",
+	"OfkPnXxw2U+iakgRWB/98a8KXG8QMQGEqgIX1jwbsuCsA/hNWNQzraCi1BleX33N/tcp0oU612KGpcBQ",
+	"ypPUaOviond1af3lAeo0UBescnX14vpgvSRG7cEDc0ai9zVmgTrMsv5Yo0qxeHiKJ1g+HRlYXdwqQDQd",
+	"GxyS9+vAkISH5jMhuGzlHVXcXAj1Sx8/1McNs/Yo5dZyxxTzv1PXttXjAKWLtHu+r3PBh77KxfTMP3WH",
+	"llATW45ofb+xjlxEdL65uULp2jr1r86CvacZIZ2/FONjxVjfObZHL8Kl/Ixe/Nqk/tqk/rttUmO2Kcne",
+	"KeDRmCJmYjZ3HsSMS9LMNp/k1EmKfS0Oke/UUYt/qepv5pAk7f5NhtQAATN+qdnfo2a+oP/nKRlcCxC0",
+	"beBSzvHERmtp2qjZxxltSPymB6Ktb+b2KdvcSjBZAeU6kxX18PwRCj7/Ia9f+ot9+N6lVC9A9NkvLf6l",
+	"xZ/RYhSXIKm56yaf/R7yOvgkWe63iQ3AKX2WO2vJg2DP/J8YW7w7ne/rhtQkS9QPrkiguqf593qsz8Bu",
+	"t3FBF2clHm7h4FZ86GL/Qs2Myh4glgnvZ8nNiyri2GkuE9DExHwPARfQRD+IRjGRhFc4rNF8BOfP7/8/",
+	"AAD//x9KMm1ObgAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/cloudapi/v2/openapi.v2.yml
+++ b/internal/cloudapi/v2/openapi.v2.yml
@@ -735,45 +735,111 @@ components:
           $ref: '#/components/schemas/Customizations'
         koji:
           $ref: '#/components/schemas/Koji'
+
     ImageRequest:
+      oneOf:
+        - $ref: '#/components/schemas/AWSEC2ImageRequest'
+        - $ref: '#/components/schemas/AWSS3ImageRequest'
+        - $ref: '#/components/schemas/GCPImageRequest'
+        - $ref: '#/components/schemas/AzureImageRequest'
+        - $ref: '#/components/schemas/ContainerImageRequest'
+
+    AbstractImageRequest:
       required:
         - architecture
-        - image_type
         - repositories
       properties:
         architecture:
           type: string
           example: 'x86_64'
-        image_type:
-          $ref: '#/components/schemas/ImageTypes'
         repositories:
           type: array
           items:
             $ref: '#/components/schemas/Repository'
         ostree:
           $ref: '#/components/schemas/OSTree'
-        upload_options:
-          $ref: '#/components/schemas/UploadOptions'
-    ImageTypes:
-      type: string
-      enum:
-        - aws
-        - aws-ha-rhui
-        - aws-rhui
-        - aws-sap-rhui
-        - azure
-        - azure-rhui
-        - edge-commit
-        - edge-container
-        - edge-installer
-        - gcp
-        - gcp-rhui
-        - guest-image
-        - image-installer
-        - iot-commit
-        - iot-container
-        - iot-raw-image
-        - vsphere
+
+    AWSEC2ImageRequest:
+      allOf:
+        - $ref: '#/components/schemas/AbstractImageRequest'
+        - type: object
+          required:
+            - image_type
+          properties:
+            image_type:
+              type: string
+              enum:
+                - aws
+                - aws-ha-rhui
+                - aws-rhui
+                - aws-sap-rhui
+            upload_options:
+              $ref: '#/components/schemas/AWSEC2UploadOptions'
+
+    AWSS3ImageRequest:
+      allOf:
+        - $ref: '#/components/schemas/AbstractImageRequest'
+        - type: object
+          required:
+            - image_type
+          properties:
+            image_type:
+              type: string
+              enum:
+                - edge-commit
+                - edge-installer
+                - guest-image
+                - image-installer
+                - iot-commit
+                - iot-raw-image
+                - vsphere
+            upload_options:
+              $ref: '#/components/schemas/AWSS3UploadOptions'
+
+    GCPImageRequest:
+      allOf:
+        - $ref: '#/components/schemas/AbstractImageRequest'
+        - type: object
+          required:
+            - image_type
+          properties:
+            image_type:
+              type: string
+              enum:
+                - gcp
+                - gcp-rhui
+            upload_options:
+              $ref: '#/components/schemas/GCPUploadOptions'
+
+    AzureImageRequest:
+      allOf:
+        - $ref: '#/components/schemas/AbstractImageRequest'
+        - type: object
+          required:
+            - image_type
+          properties:
+            image_type:
+              type: string
+              enum:
+                - azure
+                - azure-rhui
+            upload_options:
+              $ref: '#/components/schemas/AzureUploadOptions'
+
+    ContainerImageRequest:
+      allOf:
+        - $ref: '#/components/schemas/AbstractImageRequest'
+        - type: object
+          required:
+            - image_type
+          properties:
+            image_type:
+              type: string
+              enum:
+                - edge-container
+                - iot-container
+            upload_options:
+              $ref: '#/components/schemas/ContainerUploadOptions'
     Repository:
       type: object
       properties:
@@ -809,19 +875,6 @@ components:
           description: |
             Naming package sets for a repository assigns it to a specific part
             (pipeline) of the build process.
-    UploadOptions:
-      anyOf:
-      - $ref: '#/components/schemas/AWSEC2UploadOptions'
-      - $ref: '#/components/schemas/AWSS3UploadOptions'
-      - $ref: '#/components/schemas/GCPUploadOptions'
-      - $ref: '#/components/schemas/AzureUploadOptions'
-      - $ref: '#/components/schemas/ContainerUploadOptions'
-      description: |
-        This should really be oneOf but AWSS3UploadOptions is a subset of
-        AWSEC2UploadOptions. This means that all AWSEC2UploadOptions objects
-        are also valid AWSS3UploadOptionas objects which violates the oneOf
-        rules. Therefore, we have to use anyOf here but be aware that it isn't
-        possible to mix and match more schemas together.
     AWSEC2UploadOptions:
       type: object
       required:

--- a/internal/cloudapi/v2/v2_koji_test.go
+++ b/internal/cloudapi/v2/v2_koji_test.go
@@ -356,7 +356,7 @@ func TestKojiCompose(t *testing.T) {
 				"release":"%[6]s",
 				"task_id": 42
 			}
-		}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesGuestImage), name, version, release),
+		}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeGuestImage), name, version, release),
 				c.composeReplyCode, c.composeReply, "id", "operation_id")
 
 			// determine the compose ID from the reply

--- a/internal/cloudapi/v2/v2_multi_tenancy_test.go
+++ b/internal/cloudapi/v2/v2_multi_tenancy_test.go
@@ -43,7 +43,7 @@ func kojiRequest() string {
 				"version":"1",
 				"release":"2"
 			}
-		}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesGuestImage))
+		}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeGuestImage))
 }
 
 func s3Request() string {
@@ -64,7 +64,7 @@ func s3Request() string {
 					}
 				}
 			]
-		}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesGuestImage))
+		}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeGuestImage))
 }
 
 var reqContextCallCount = 0

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -189,7 +189,8 @@ func TestCompose(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName), http.StatusBadRequest, `
@@ -260,7 +261,8 @@ func TestCompose(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -575,7 +577,8 @@ func TestComposeStatusSuccess(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -689,7 +692,8 @@ func TestComposeStatusFailure(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -760,7 +764,8 @@ func TestComposeJobError(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -821,7 +826,8 @@ func TestComposeDependencyError(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -890,7 +896,8 @@ func TestComposeTargetErrors(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -1003,7 +1010,8 @@ func TestComposeCustomizations(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -1033,7 +1041,7 @@ func TestImageTypes(t *testing.T) {
 				"share_with_accounts": ["123456789012","234567890123"]
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesAws)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSEC2ImageRequestImageTypeAws)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1054,7 +1062,7 @@ func TestImageTypes(t *testing.T) {
 				"share_with_accounts": ["123456789012","234567890123"]
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesAws)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSEC2ImageRequestImageTypeAws)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1073,7 +1081,7 @@ func TestImageTypes(t *testing.T) {
 				"region": "eu-central-1"
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesEdgeCommit)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeEdgeCommit)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1092,7 +1100,7 @@ func TestImageTypes(t *testing.T) {
 				"region": "eu-central-1"
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesEdgeInstaller)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeEdgeInstaller)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1114,7 +1122,7 @@ func TestImageTypes(t *testing.T) {
 				"location": "westeurope"
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesAzure)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AzureImageRequestImageTypeAzure)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1135,7 +1143,7 @@ func TestImageTypes(t *testing.T) {
 				"share_with_accounts": ["user:alice@example.com"]
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesGcp)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.GCPImageRequestImageTypeGcp)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1154,7 +1162,7 @@ func TestImageTypes(t *testing.T) {
 				"region": "eu-central-1"
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesImageInstaller)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeImageInstaller)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1173,7 +1181,7 @@ func TestImageTypes(t *testing.T) {
 				"region": "eu-central-1"
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesGuestImage)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeGuestImage)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1192,7 +1200,7 @@ func TestImageTypes(t *testing.T) {
 				"region": "eu-central-1"
 			}
 		 }
-	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.ImageTypesVsphere)), http.StatusCreated, `
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name, string(v2.AWSS3ImageRequestImageTypeVsphere)), http.StatusCreated, `
 	{
 		"href": "/api/image-builder-composer/v2/compose",
 		"kind": "ComposeId"
@@ -1214,7 +1222,8 @@ func TestImageFromCompose(t *testing.T) {
 				"rhsm": false
 			}],
 			"upload_options": {
-				"region": "eu-central-1"
+				"region": "eu-central-1",
+				"share_with_accounts": ["123456789012"]
 			}
 		 }
 	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusCreated, `
@@ -1326,4 +1335,32 @@ func TestImageFromCompose(t *testing.T) {
 			"region": "eu-central-2"
 		}
 	}`, imgJobId, imgJobId))
+}
+
+func TestComposeNoUploadOptionsNorKoji(t *testing.T) {
+	srv, _, _, cancel := newV2Server(t, t.TempDir(), []string{""}, false, false)
+	defer cancel()
+
+	test.TestRoute(t, srv.Handler("/api/image-builder-composer/v2"), false, "POST", "/api/image-builder-composer/v2/compose", fmt.Sprintf(`
+	{
+		"distribution": "%s",
+		"customizations": {
+		},
+		"image_request":{
+			"architecture": "%s",
+			"image_type": "aws",
+			"repositories": [{
+				"baseurl": "somerepo.org",
+				"rhsm": false
+			}]
+		 }
+	}`, test_distro.TestDistroName, test_distro.TestArch3Name), http.StatusBadRequest, `
+	{
+		"href": "/api/image-builder-composer/v2/errors/35",
+		"id": "35",
+		"kind": "Error",
+		"code": "IMAGE-BUILDER-COMPOSER-35",
+		"reason": "You need to specify one of: ComposeRequest.koji, or ImageRequest.upload_options",
+		"details": ""
+	}`, "operation_id")
 }


### PR DESCRIPTION
Previously, one could pass GCPUploadOptions to an aws image request because the spec technically allows that. I haven't found any validation in our code, so I presume that the result would be pretty undefined.

A real-life example: If someone wanted an aws image but didn't specify `share_with_accounts`, this is valid according to AWSS3UploadOptions. Composer doesn't perform any additional checks, so it would just proceed to building such an image, and uploading it to our account where no one can use access it.

This commit makes ImageRequest be one of AWSEC2ImageRequest, AzureImageRequest etc. XYZImageRequest always requires its `upload_options` to be XYZUploadOptions. As all of these ImageRequests contain some common fields, I created AbstractImageRequest to deduplicate them.

One thing that I don't like is that image types called AWSEC2ImageRequestImageTypeAws are long, and in most cases we need to cast them to `string`, which loses a bit of type safety.

What I like is that the API spec is now more self-explanatory and helpful for composer's users.

I also had to adjust several tests that build aws images without setting `share_with_accounts`.

This  breaks backward compatibility but the only broken requests are non-sense ones.

---
This is actually a prequel to https://github.com/osbuild/osbuild-composer/pull/3006. A suggestion from @thozza was to make AWSEC2UploadOptions specified like this:

```
oneOf:
  - required:
    - share_with_accounts
  - required:
    - public
```

The issue is that, the spec validator will happily validate `AWSEC2UploadOptions` without neither of these fields set using the `AWSS3UploadOptions` spec. I did not like that, so I began thinking how to make the schema more error-proof and came out with this.

--- 

I was thinking if this is fine for future extensions: One extension that I can think of is to add the ability to upload any image to an S3-like storage. I think this is fine in the spec because we just make all image requests uploadable to both their target and to S3. A bit of code-duplication can happen but with `oneOf` and `allOf`, we should be just fine.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - the API spec is now more self-explanatory