### PR TITLE
Update Fedora IoT Installer definition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -376,8 +376,8 @@ New OSTree:
     matrix:
       - RUNNER:
           - rhos-01/fedora-35-x86_64
-          # - rhos-01/fedora-36-x86_64
-          # - rhos-01/fedora-37-x86_64
+          - rhos-01/fedora-36-x86_64
+          - rhos-01/fedora-37-x86_64
           - rhos-01/rhel-8.7-nightly-x86_64
           - rhos-01/rhel-9.1-nightly-x86_64
           - rhos-01/centos-stream-8-x86_64

--- a/Schutzfile
+++ b/Schutzfile
@@ -79,7 +79,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
+        "commit": "8a7b6d382de16b7be30c4d37e10f24c416a294f8"
       }
     },
     "repos": [
@@ -156,7 +156,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "c824e18b458823eb7dd8ca582b0a990bfdc7f257"
+        "commit": "8a7b6d382de16b7be30c4d37e10f24c416a294f8"
       }
     },
     "repos": [

--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -126,7 +126,7 @@ var (
 		bootISO:          true,
 		image:            iotInstallerImage,
 		buildPipelines:   []string{"build"},
-		payloadPipelines: []string{"anaconda-tree", "bootiso-tree", "bootiso"},
+		payloadPipelines: []string{"anaconda-tree", "rootfs-image", "efiboot-tree", "bootiso-tree"},
 		exports:          []string{"bootiso"},
 	}
 

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -288,7 +288,7 @@ func iotRawImage(workload workload.Workload,
 	img.Users = users.UsersFromBP(customizations.GetUsers())
 	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
-	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4"}
+	img.KernelOptionsAppend = []string{"modprobe.blacklist=vc4", "rw"}
 	img.Keyboard = "us"
 	img.Locale = "C.UTF-8"
 

--- a/internal/distro/fedora/images.go
+++ b/internal/distro/fedora/images.go
@@ -257,8 +257,8 @@ func iotInstallerImage(workload workload.Workload,
 
 	img.Platform = t.platform
 	img.ExtraBasePackages = packageSets[installerPkgsKey]
-	img.Users = customizations.GetUsers()
-	img.Groups = customizations.GetGroups()
+	img.Users = users.UsersFromBP(customizations.GetUsers())
+	img.Groups = users.GroupsFromBP(customizations.GetGroups())
 
 	img.ISOLabelTempl = d.isolabelTmpl
 	img.Product = d.product

--- a/internal/distro/rhel7/pipelines.go
+++ b/internal/distro/rhel7/pipelines.go
@@ -315,7 +315,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 
 	inputName := "root-tree"
 	copyOptions, copyDevices, copyMounts := osbuild.GenCopyFSTreeOptions(inputName, inputPipelineName, outputFilename, pt)
-	copyInputs := osbuild.NewCopyStagePipelineTreeInputs(inputName, inputPipelineName)
+	copyInputs := osbuild.NewPipelineTreeInputs(inputName, inputPipelineName)
 	p.AddStage(osbuild.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
 
 	for _, stage := range osbuild.GenImageFinishStages(pt, outputFilename) {

--- a/internal/distro/rhel7/pipelines.go
+++ b/internal/distro/rhel7/pipelines.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
+	"github.com/osbuild/osbuild-composer/internal/users"
 )
 
 func buildPipeline(repos []rpmmd.RepoConfig, buildPackageSpecs []rpmmd.PackageSpec, runner string) *osbuild.Pipeline {
@@ -87,10 +88,10 @@ func osPipeline(t *imageType,
 	}
 
 	if groups := c.GetGroups(); len(groups) > 0 {
-		p.AddStage(osbuild.NewGroupsStage(osbuild.NewGroupsStageOptions(groups)))
+		p.AddStage(osbuild.NewGroupsStage(osbuild.NewGroupsStageOptions(users.GroupsFromBP(groups))))
 	}
 
-	if userOptions, err := osbuild.NewUsersStageOptions(c.GetUsers(), false); err != nil {
+	if userOptions, err := osbuild.NewUsersStageOptions(users.UsersFromBP(c.GetUsers()), false); err != nil {
 		return nil, err
 	} else if userOptions != nil {
 		p.AddStage(osbuild.NewUsersStage(userOptions))

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -254,7 +254,7 @@ func imageInstallerPipelines(t *imageType, customizations *blueprint.Customizati
 	kernelVer := fmt.Sprintf("%s-%s.%s", kernelPkg.Version, kernelPkg.Release, kernelPkg.Arch)
 
 	tarPath := "/liveimg.tar"
-	tarPayloadStages := []*osbuild.Stage{osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: tarPath}, osbuild.NewTarStagePipelineTreeInputs(treePipeline.Name))}
+	tarPayloadStages := []*osbuild.Stage{osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: tarPath}, treePipeline.Name)}
 	kickstartOptions, err := osbuild.NewKickstartStageOptions(kspath, makeISORootPath(tarPath), customizations.GetUsers(), customizations.GetGroups(), "", "", "rhel")
 	if err != nil {
 		return nil, err
@@ -683,18 +683,15 @@ func ostreeCommitPipeline(options distro.ImageOptions, osVersion string) *osbuil
 	p.Build = "name:build"
 	p.AddStage(osbuild.NewOSTreeInitStage(&osbuild.OSTreeInitStageOptions{Path: "/repo"}))
 
-	commitStageInput := new(osbuild.OSTreeCommitStageInput)
-	commitStageInput.Type = "org.osbuild.tree"
-	commitStageInput.Origin = "org.osbuild.pipeline"
-	commitStageInput.References = osbuild.OSTreeCommitStageReferences{"name:ostree-tree"}
-
-	p.AddStage(osbuild.NewOSTreeCommitStage(
-		&osbuild.OSTreeCommitStageOptions{
-			Ref:       options.OSTree.Ref,
-			OSVersion: osVersion,
-			Parent:    options.OSTree.Parent,
-		},
-		&osbuild.OSTreeCommitStageInputs{Tree: commitStageInput}),
+	p.AddStage(
+		osbuild.NewOSTreeCommitStage(
+			&osbuild.OSTreeCommitStageOptions{
+				Ref:       options.OSTree.Ref,
+				OSVersion: osVersion,
+				Parent:    options.OSTree.Parent,
+			},
+			"ostree-tree",
+		),
 	)
 	return p
 }
@@ -740,10 +737,7 @@ func containerPipeline(t *imageType, nginxConfigPath, listenPort string) *osbuil
 			ExposedPorts: []string{listenPort},
 		},
 	}
-	baseInput := new(osbuild.OCIArchiveStageInput)
-	baseInput.Type = "org.osbuild.tree"
-	baseInput.Origin = "org.osbuild.pipeline"
-	baseInput.References = []string{"name:container-tree"}
+	baseInput := osbuild.NewTreeInput("name:container-tree")
 	inputs := &osbuild.OCIArchiveStageInputs{Base: baseInput}
 	p.AddStage(osbuild.NewOCIArchiveStage(options, inputs))
 	return p
@@ -847,12 +841,12 @@ func simplifiedInstallerBootISOTreePipeline(archivePipelineName, kver string, rn
 	}
 
 	inputName := "root-tree"
-	copyInputs := osbuild.NewCopyStagePipelineTreeInputs(inputName, "efiboot-tree")
+	copyInputs := osbuild.NewPipelineTreeInputs(inputName, "efiboot-tree")
 	copyOptions, copyDevices, copyMounts := osbuild.GenCopyFSTreeOptions(inputName, "efiboot-tree", filename, &pt)
 	p.AddStage(osbuild.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
 
 	inputName = "coi"
-	copyInputs = osbuild.NewCopyStagePipelineTreeInputs(inputName, "coi-tree")
+	copyInputs = osbuild.NewPipelineTreeInputs(inputName, "coi-tree")
 	p.AddStage(osbuild.NewCopyStageSimple(
 		&osbuild.CopyStageOptions{
 			Paths: []osbuild.CopyStagePath{
@@ -870,7 +864,7 @@ func simplifiedInstallerBootISOTreePipeline(archivePipelineName, kver string, rn
 	))
 
 	inputName = "efi-tree"
-	copyInputs = osbuild.NewCopyStagePipelineTreeInputs(inputName, "efiboot-tree")
+	copyInputs = osbuild.NewPipelineTreeInputs(inputName, "efiboot-tree")
 	p.AddStage(osbuild.NewCopyStageSimple(
 		&osbuild.CopyStageOptions{
 			Paths: []osbuild.CopyStagePath{
@@ -1087,7 +1081,7 @@ func bootISOPipeline(filename, isolabel, arch string, isolinux bool) *osbuild.Pi
 	p.Name = "bootiso"
 	p.Build = "name:build"
 
-	p.AddStage(osbuild.NewXorrisofsStage(xorrisofsStageOptions(filename, isolabel, arch, isolinux), osbuild.NewXorrisofsStagePipelineTreeInputs("bootiso-tree")))
+	p.AddStage(osbuild.NewXorrisofsStage(xorrisofsStageOptions(filename, isolabel, arch, isolinux), "bootiso-tree"))
 	p.AddStage(osbuild.NewImplantisomd5Stage(&osbuild.Implantisomd5StageOptions{Filename: filename}))
 
 	return p
@@ -1104,7 +1098,7 @@ func liveImagePipeline(inputPipelineName string, outputFilename string, pt *disk
 
 	inputName := "root-tree"
 	copyOptions, copyDevices, copyMounts := osbuild.GenCopyFSTreeOptions(inputName, inputPipelineName, outputFilename, pt)
-	copyInputs := osbuild.NewCopyStagePipelineTreeInputs(inputName, inputPipelineName)
+	copyInputs := osbuild.NewPipelineTreeInputs(inputName, inputPipelineName)
 	p.AddStage(osbuild.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
 
 	for _, stage := range osbuild.GenImageFinishStages(pt, outputFilename) {
@@ -1134,7 +1128,7 @@ func tarArchivePipeline(name, inputPipelineName string, tarOptions *osbuild.TarS
 	p := new(osbuild.Pipeline)
 	p.Name = name
 	p.Build = "name:build"
-	p.AddStage(osbuild.NewTarStage(tarOptions, osbuild.NewTarStagePipelineTreeInputs(inputPipelineName)))
+	p.AddStage(osbuild.NewTarStage(tarOptions, inputPipelineName))
 	return p
 }
 

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -216,7 +216,7 @@ func edgeInstallerPipelines(t *imageType, customizations *blueprint.Customizatio
 	kernelVer := rpmmd.GetVerStrFromPackageSpecListPanic(installerPackages, "kernel")
 	ostreeRepoPath := "/ostree/repo"
 	payloadStages := ostreePayloadStages(options, ostreeRepoPath)
-	kickstartOptions, err := osbuild.NewKickstartStageOptions(kspath, "", customizations.GetUsers(), customizations.GetGroups(), makeISORootPath(ostreeRepoPath), options.OSTree.Ref, "rhel")
+	kickstartOptions, err := osbuild.NewKickstartStageOptions(kspath, "", users.UsersFromBP(customizations.GetUsers()), users.GroupsFromBP(customizations.GetGroups()), makeISORootPath(ostreeRepoPath), options.OSTree.Ref, "rhel")
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func imageInstallerPipelines(t *imageType, customizations *blueprint.Customizati
 
 	tarPath := "/liveimg.tar"
 	tarPayloadStages := []*osbuild.Stage{osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: tarPath}, treePipeline.Name)}
-	kickstartOptions, err := osbuild.NewKickstartStageOptions(kspath, makeISORootPath(tarPath), customizations.GetUsers(), customizations.GetGroups(), "", "", "rhel")
+	kickstartOptions, err := osbuild.NewKickstartStageOptions(kspath, makeISORootPath(tarPath), users.UsersFromBP(customizations.GetUsers()), users.GroupsFromBP(customizations.GetGroups()), "", "", "rhel")
 	if err != nil {
 		return nil, err
 	}
@@ -449,17 +449,17 @@ func osPipeline(t *imageType,
 		// don't put users and groups in the payload of an installer
 		// add them via kickstart instead
 		if groups := c.GetGroups(); len(groups) > 0 {
-			p.AddStage(osbuild.NewGroupsStage(osbuild.NewGroupsStageOptions(groups)))
+			p.AddStage(osbuild.NewGroupsStage(osbuild.NewGroupsStageOptions(users.GroupsFromBP(groups))))
 		}
 
-		if userOptions, err := osbuild.NewUsersStageOptions(c.GetUsers(), false); err != nil {
+		if userOptions, err := osbuild.NewUsersStageOptions(users.UsersFromBP(c.GetUsers()), false); err != nil {
 			return nil, err
 		} else if userOptions != nil {
 			if t.rpmOstree {
 				// for ostree, writing the key during user creation is
 				// redundant and can cause issues so create users without keys
 				// and write them on first boot
-				userOptionsSansKeys, err := osbuild.NewUsersStageOptions(c.GetUsers(), true)
+				userOptionsSansKeys, err := osbuild.NewUsersStageOptions(users.UsersFromBP(c.GetUsers()), true)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -61,15 +61,17 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	isoTreePipeline := manifest.NewISOTree(m,
 		buildPipeline,
 		anacondaPipeline,
+		nil,
+		nil,
 		img.OSTreeCommit,
 		img.OSTreeURL,
 		img.OSTreeRef,
-		img.ISOLabelTempl)
+		"")
 	isoTreePipeline.Release = img.Release
 	isoTreePipeline.OSName = img.OSName
-	isoTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	isoTreePipeline.Users = img.Users
 	isoTreePipeline.Groups = img.Groups
+	isoTreePipeline.KSPath = "/ostree.ks"
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline)
 	isoPipeline.Filename = img.Filename

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -4,19 +4,19 @@ import (
 	"math/rand"
 
 	"github.com/osbuild/osbuild-composer/internal/artifact"
-	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/runner"
+	"github.com/osbuild/osbuild-composer/internal/users"
 )
 
 type OSTreeInstaller struct {
 	Base
 	Platform          platform.Platform
 	ExtraBasePackages rpmmd.PackageSet
-	Users             []blueprint.UserCustomization
-	Groups            []blueprint.GroupCustomization
+	Users             []users.User
+	Groups            []users.Group
 
 	ISOLabelTempl string
 	Product       string

--- a/internal/manifest/commit.go
+++ b/internal/manifest/commit.go
@@ -49,11 +49,6 @@ func (p *OSTreeCommit) serialize() osbuild.Pipeline {
 
 	pipeline.AddStage(osbuild.NewOSTreeInitStage(&osbuild.OSTreeInitStageOptions{Path: "/repo"}))
 
-	commitStageInput := new(osbuild.OSTreeCommitStageInput)
-	commitStageInput.Type = "org.osbuild.tree"
-	commitStageInput.Origin = "org.osbuild.pipeline"
-	commitStageInput.References = osbuild.OSTreeCommitStageReferences{"name:" + p.treePipeline.Name()}
-
 	var parent string
 	if p.treePipeline.OSTree.Parent != nil {
 		parent = p.treePipeline.OSTree.Parent.Checksum
@@ -64,7 +59,7 @@ func (p *OSTreeCommit) serialize() osbuild.Pipeline {
 			OSVersion: p.OSVersion,
 			Parent:    parent,
 		},
-		&osbuild.OSTreeCommitStageInputs{Tree: commitStageInput}),
+		p.treePipeline.Name()),
 	)
 
 	return pipeline

--- a/internal/manifest/commit_deployment.go
+++ b/internal/manifest/commit_deployment.go
@@ -93,17 +93,6 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 			OSName: p.osName,
 		},
 	))
-	pipeline.AddStage(osbuild.NewOSTreeConfigStage(
-		&osbuild.OSTreeConfigStageOptions{
-			Repo: repoPath,
-			Config: &osbuild.OSTreeConfig{
-				Sysroot: &osbuild.SysrootOptions{
-					ReadOnly:   common.BoolToPtr(true),
-					Bootloader: "none",
-				},
-			},
-		},
-	))
 	pipeline.AddStage(osbuild.NewMkdirStage(&osbuild.MkdirStageOptions{
 		Paths: []osbuild.Path{
 			{
@@ -155,6 +144,20 @@ func (p *OSTreeDeployment) serialize() osbuild.Pipeline {
 			},
 		},
 	))
+
+	configStage := osbuild.NewOSTreeConfigStage(
+		&osbuild.OSTreeConfigStageOptions{
+			Repo: repoPath,
+			Config: &osbuild.OSTreeConfig{
+				Sysroot: &osbuild.SysrootOptions{
+					ReadOnly:   common.BoolToPtr(true),
+					Bootloader: "none",
+				},
+			},
+		},
+	)
+	configStage.MountOSTree(p.osName, p.osTreeRef, 0)
+	pipeline.AddStage(configStage)
 
 	fstabOptions := osbuild.NewFSTabStageOptions(p.PartitionTable)
 	fstabStage := osbuild.NewFSTabStage(fstabOptions)

--- a/internal/manifest/efi_boot_tree.go
+++ b/internal/manifest/efi_boot_tree.go
@@ -1,0 +1,62 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/platform"
+)
+
+type EFIBootTree struct {
+	Base
+
+	Platform platform.Platform
+
+	anacondaPipeline *Anaconda
+
+	UEFIVendor string
+	ISOLabel   string
+	KSPath     string
+}
+
+func NewEFIBootTree(m *Manifest, buildPipeline *Build, anacondaPipeline *Anaconda) *EFIBootTree {
+	p := &EFIBootTree{
+		Base:             NewBase(m, "efiboot-tree", buildPipeline),
+		anacondaPipeline: anacondaPipeline,
+	}
+	buildPipeline.addDependent(p)
+	m.addPipeline(p)
+	return p
+}
+
+func (p *EFIBootTree) serialize() osbuild.Pipeline {
+	pipeline := p.Base.serialize()
+
+	arch := p.Platform.GetArch().String()
+	var architectures []string
+	if arch == distro.X86_64ArchName {
+		architectures = []string{"X64"}
+	} else if arch == distro.Aarch64ArchName {
+		architectures = []string{"AA64"}
+	} else {
+		panic("unsupported architecture")
+	}
+
+	grubOptions := &osbuild.GrubISOStageOptions{
+		Product: osbuild.Product{
+			Name:    p.anacondaPipeline.product,
+			Version: p.anacondaPipeline.version,
+		},
+		Kernel: osbuild.ISOKernel{
+			Dir:  "/images/pxeboot",
+			Opts: []string{fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", p.ISOLabel, p.KSPath)},
+		},
+		ISOLabel:      p.ISOLabel,
+		Architectures: architectures,
+		Vendor:        p.UEFIVendor,
+	}
+	grub2Stage := osbuild.NewGrubISOStage(grubOptions)
+	pipeline.AddStage(grub2Stage)
+	return pipeline
+}

--- a/internal/manifest/iso.go
+++ b/internal/manifest/iso.go
@@ -41,7 +41,7 @@ func (p *ISO) getBuildPackages() []string {
 func (p *ISO) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
-	pipeline.AddStage(osbuild.NewXorrisofsStage(xorrisofsStageOptions(p.Filename, p.treePipeline.isoLabel, p.ISOLinux), osbuild.NewXorrisofsStagePipelineTreeInputs(p.treePipeline.Name())))
+	pipeline.AddStage(osbuild.NewXorrisofsStage(xorrisofsStageOptions(p.Filename, p.treePipeline.isoLabel, p.ISOLinux), p.treePipeline.Name()))
 	pipeline.AddStage(osbuild.NewImplantisomd5Stage(&osbuild.Implantisomd5StageOptions{Filename: p.Filename}))
 
 	return pipeline

--- a/internal/manifest/iso_rootfs.go
+++ b/internal/manifest/iso_rootfs.go
@@ -1,0 +1,71 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/osbuild/osbuild-composer/internal/osbuild"
+)
+
+type ISORootfsImg struct {
+	Base
+
+	Size uint64
+
+	anacondaPipeline *Anaconda
+}
+
+func NewISORootfsImg(m *Manifest, buildPipeline *Build, anacondaPipeline *Anaconda) *ISORootfsImg {
+	p := &ISORootfsImg{
+		Base:             NewBase(m, "rootfs-image", buildPipeline),
+		anacondaPipeline: anacondaPipeline,
+	}
+	buildPipeline.addDependent(p)
+	m.addPipeline(p)
+	return p
+}
+
+func (p *ISORootfsImg) serialize() osbuild.Pipeline {
+	pipeline := p.Base.serialize()
+
+	pipeline.AddStage(osbuild.NewMkdirStage(&osbuild.MkdirStageOptions{
+		Paths: []osbuild.Path{
+			{
+				Path: "LiveOS",
+			},
+		},
+	}))
+	pipeline.AddStage(osbuild.NewTruncateStage(&osbuild.TruncateStageOptions{
+		Filename: "LiveOS/rootfs.img",
+		Size:     fmt.Sprintf("%d", p.Size),
+	}))
+
+	mkfsStageOptions := &osbuild.MkfsExt4StageOptions{
+		UUID:  "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+		Label: "Anaconda",
+	}
+	lodevice := osbuild.NewLoopbackDevice(
+		&osbuild.LoopbackDeviceOptions{
+			Filename: "LiveOS/rootfs.img",
+		},
+	)
+
+	devName := "device"
+	devices := osbuild.Devices{devName: *lodevice}
+	mkfsStage := osbuild.NewMkfsExt4Stage(mkfsStageOptions, devices)
+	pipeline.AddStage(mkfsStage)
+
+	inputName := "tree"
+	copyStageOptions := &osbuild.CopyStageOptions{
+		Paths: []osbuild.CopyStagePath{
+			{
+				From: fmt.Sprintf("input://%s/", inputName),
+				To:   fmt.Sprintf("mount://%s/", devName),
+			},
+		},
+	}
+	copyStageInputs := osbuild.NewPipelineTreeInputs(inputName, p.anacondaPipeline.Name())
+	copyStageMounts := &osbuild.Mounts{*osbuild.NewExt4Mount(devName, devName, "/")}
+	copyStage := osbuild.NewCopyStage(copyStageOptions, copyStageInputs, &devices, copyStageMounts)
+	pipeline.AddStage(copyStage)
+	return pipeline
+}

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
+	"github.com/osbuild/osbuild-composer/internal/users"
 )
 
 // An ISOTree represents a tree containing the anaconda installer,
@@ -18,8 +18,8 @@ type ISOTree struct {
 	// TODO: review optional and mandatory fields and their meaning
 	OSName  string
 	Release string
-	Users   []blueprint.UserCustomization
-	Groups  []blueprint.GroupCustomization
+	Users   []users.User
+	Groups  []users.Group
 
 	PartitionTable *disk.PartitionTable
 

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/disk"
-	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 )
 
@@ -183,48 +182,6 @@ func (p *ISOTree) serialize() osbuild.Pipeline {
 	}))
 
 	return pipeline
-}
-
-func bootISOMonoStageOptions(kernelVer, arch, vendor, product, osVersion, isolabel, kspath string) *osbuild.BootISOMonoStageOptions {
-	comprOptions := new(osbuild.FSCompressionOptions)
-	if bcj := osbuild.BCJOption(arch); bcj != "" {
-		comprOptions.BCJ = bcj
-	}
-	var architectures []string
-
-	if arch == distro.X86_64ArchName {
-		architectures = []string{"X64"}
-	} else if arch == distro.Aarch64ArchName {
-		architectures = []string{"AA64"}
-	} else {
-		panic("unsupported architecture")
-	}
-
-	return &osbuild.BootISOMonoStageOptions{
-		Product: osbuild.Product{
-			Name:    product,
-			Version: osVersion,
-		},
-		ISOLabel:   isolabel,
-		Kernel:     kernelVer,
-		KernelOpts: fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isolabel, kspath),
-		EFI: osbuild.EFI{
-			Architectures: architectures,
-			Vendor:        vendor,
-		},
-		ISOLinux: osbuild.ISOLinux{
-			Enabled: arch == distro.X86_64ArchName,
-			Debug:   false,
-		},
-		Templates: "99-generic",
-		RootFS: osbuild.RootFS{
-			Size: 9216,
-			Compression: osbuild.FSCompression{
-				Method:  "xz",
-				Options: comprOptions,
-			},
-		},
-	}
 }
 
 //makeISORootPath return a path that can be used to address files and folders in

--- a/internal/manifest/oci_container.go
+++ b/internal/manifest/oci_container.go
@@ -43,10 +43,7 @@ func (p *OCIContainer) serialize() osbuild.Pipeline {
 			ExposedPorts: p.ExposedPorts,
 		},
 	}
-	baseInput := new(osbuild.OCIArchiveStageInput)
-	baseInput.Type = "org.osbuild.tree"
-	baseInput.Origin = "org.osbuild.pipeline"
-	baseInput.References = []string{"name:" + p.treePipeline.Name()}
+	baseInput := osbuild.NewTreeInput("name:" + p.treePipeline.Name())
 	inputs := &osbuild.OCIArchiveStageInputs{Base: baseInput}
 	pipeline.AddStage(osbuild.NewOCIArchiveStage(options, inputs))
 

--- a/internal/manifest/raw.go
+++ b/internal/manifest/raw.go
@@ -48,7 +48,7 @@ func (p *RawImage) serialize() osbuild.Pipeline {
 
 	inputName := "root-tree"
 	copyOptions, copyDevices, copyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename, pt)
-	copyInputs := osbuild.NewCopyStagePipelineTreeInputs(inputName, p.treePipeline.Name())
+	copyInputs := osbuild.NewPipelineTreeInputs(inputName, p.treePipeline.Name())
 	pipeline.AddStage(osbuild.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
 
 	for _, stage := range osbuild.GenImageFinishStages(pt, p.Filename) {

--- a/internal/manifest/raw_ostree.go
+++ b/internal/manifest/raw_ostree.go
@@ -61,7 +61,7 @@ func (p *RawOSTreeImage) serialize() osbuild.Pipeline {
 
 	inputName := "root-tree"
 	copyOptions, copyDevices, copyMounts := osbuild.GenCopyFSTreeOptions(inputName, p.treePipeline.Name(), p.Filename, pt)
-	copyInputs := osbuild.NewCopyStagePipelineTreeInputs(inputName, p.treePipeline.Name())
+	copyInputs := osbuild.NewPipelineTreeInputs(inputName, p.treePipeline.Name())
 	pipeline.AddStage(osbuild.NewCopyStage(copyOptions, copyInputs, copyDevices, copyMounts))
 
 	for _, stage := range osbuild.GenImageFinishStages(pt, p.Filename) {

--- a/internal/manifest/tar.go
+++ b/internal/manifest/tar.go
@@ -36,12 +36,7 @@ func NewTar(m *Manifest,
 func (p *Tar) serialize() osbuild.Pipeline {
 	pipeline := p.Base.serialize()
 
-	tree := new(osbuild.TarStageInput)
-	tree.Type = "org.osbuild.tree"
-	tree.Origin = "org.osbuild.pipeline"
-	tree.References = []string{"name:" + p.inputPipeline.Name()}
-	tarStage := osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: p.Filename}, &osbuild.TarStageInputs{Tree: tree})
-
+	tarStage := osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: p.Filename}, p.inputPipeline.Name())
 	pipeline.AddStage(tarStage)
 
 	return pipeline

--- a/internal/osbuild/bootiso_stage.go
+++ b/internal/osbuild/bootiso_stage.go
@@ -62,22 +62,11 @@ func BCJOption(arch string) string {
 func (BootISOMonoStageOptions) isStageOptions() {}
 
 type BootISOMonoStageInputs struct {
-	RootFS *BootISOMonoStageInput `json:"rootfs"`
-	Kernel *BootISOMonoStageInput `json:"kernel,omitempty"`
+	RootFS *TreeInput `json:"rootfs"`
+	Kernel *TreeInput `json:"kernel,omitempty"`
 }
 
 func (BootISOMonoStageInputs) isStageInputs() {}
-
-type BootISOMonoStageInput struct {
-	inputCommon
-	References BootISOMonoStageReferences `json:"references"`
-}
-
-func (BootISOMonoStageInput) isStageInput() {}
-
-type BootISOMonoStageReferences []string
-
-func (BootISOMonoStageReferences) isReferences() {}
 
 // Assemble a file system tree for a bootable ISO
 func NewBootISOMonoStage(options *BootISOMonoStageOptions, inputs *BootISOMonoStageInputs) *Stage {
@@ -89,10 +78,7 @@ func NewBootISOMonoStage(options *BootISOMonoStageOptions, inputs *BootISOMonoSt
 }
 
 func NewBootISOMonoStagePipelineTreeInputs(pipeline string) *BootISOMonoStageInputs {
-	rootfsInput := new(BootISOMonoStageInput)
-	rootfsInput.Type = "org.osbuild.tree"
-	rootfsInput.Origin = "org.osbuild.pipeline"
-	rootfsInput.References = BootISOMonoStageReferences{"name:" + pipeline}
+	rootfsInput := NewTreeInput("name:" + pipeline)
 	return &BootISOMonoStageInputs{
 		RootFS: rootfsInput,
 	}

--- a/internal/osbuild/copy_stage.go
+++ b/internal/osbuild/copy_stage.go
@@ -21,57 +21,22 @@ type CopyStagePath struct {
 
 func (CopyStageOptions) isStageOptions() {}
 
-type CopyStageInputs map[string]CopyStageInput
-
-type CopyStageInput struct {
-	inputCommon
-	References CopyStageReferences `json:"references"`
-}
-
-func (CopyStageInputs) isStageInputs() {}
-
-type CopyStageReferences []string
-
-type CopyStageInputsNew interface {
-	isCopyStageInputs()
-}
-
-func (CopyStageInputs) isCopyStageInputs() {}
-
-func (CopyStageReferences) isReferences() {}
-
-func NewCopyStage(options *CopyStageOptions, inputs CopyStageInputsNew, devices *Devices, mounts *Mounts) *Stage {
-	var stageInputs Inputs
-	if inputs != nil {
-		stageInputs = inputs.(Inputs)
-	}
+func NewCopyStage(options *CopyStageOptions, inputs Inputs, devices *Devices, mounts *Mounts) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.copy",
 		Options: options,
-		Inputs:  stageInputs,
+		Inputs:  inputs,
 		Devices: *devices,
 		Mounts:  *mounts,
 	}
 }
 
-func NewCopyStageSimple(options *CopyStageOptions, inputs CopyStageInputsNew) *Stage {
-	var stageInputs Inputs
-	if inputs != nil {
-		stageInputs = inputs.(Inputs)
-	}
+func NewCopyStageSimple(options *CopyStageOptions, inputs Inputs) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.copy",
 		Options: options,
-		Inputs:  stageInputs,
+		Inputs:  inputs,
 	}
-}
-
-func NewCopyStagePipelineTreeInputs(inputName, inputPipeline string) *CopyStageInputs {
-	treeInput := CopyStageInput{}
-	treeInput.Type = "org.osbuild.tree"
-	treeInput.Origin = "org.osbuild.pipeline"
-	treeInput.References = []string{"name:" + inputPipeline}
-	return &CopyStageInputs{inputName: treeInput}
 }
 
 // GenCopyFSTreeOptions creates the options, inputs, devices, and mounts properties

--- a/internal/osbuild/copy_stage_test.go
+++ b/internal/osbuild/copy_stage_test.go
@@ -29,20 +29,20 @@ func TestNewCopyStage(t *testing.T) {
 		*NewBtrfsMount("root", "root", "/"),
 	}
 
-	treeInput := CopyStageInput{}
+	treeInput := TreeInput{}
 	treeInput.Type = "org.osbuild.tree"
 	treeInput.Origin = "org.osbuild.pipeline"
 	treeInput.References = []string{"name:input-pipeline"}
 	expectedStage := &Stage{
 		Type:    "org.osbuild.copy",
 		Options: &CopyStageOptions{paths},
-		Inputs:  &CopyStageInputs{"tree-input": treeInput},
+		Inputs:  &PipelineTreeInputs{"tree-input": treeInput},
 		Devices: devices,
 		Mounts:  mounts,
 	}
 	// convert to alias types
 	stageMounts := Mounts(mounts)
 	stageDevices := Devices(devices)
-	actualStage := NewCopyStage(&CopyStageOptions{paths}, &CopyStageInputs{"tree-input": treeInput}, &stageDevices, &stageMounts)
+	actualStage := NewCopyStage(&CopyStageOptions{paths}, NewPipelineTreeInputs("tree-input", "input-pipeline"), &stageDevices, &stageMounts)
 	assert.Equal(t, expectedStage, actualStage)
 }

--- a/internal/osbuild/files_input.go
+++ b/internal/osbuild/files_input.go
@@ -24,9 +24,6 @@ func NewFilesInputs(references FilesInputReferences) *FilesInputs {
 // inputs accepted by the XZ stage
 func (FilesInputs) isXzStageInputs() {}
 
-// inputs accepted by the Copy stage
-func (FilesInputs) isCopyStageInputs() {}
-
 // SPECIFIC INPUT STRUCTURE
 
 type FilesInput struct {

--- a/internal/osbuild/groups_stage.go
+++ b/internal/osbuild/groups_stage.go
@@ -1,7 +1,6 @@
 package osbuild
 
 import (
-	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/users"
 )
 
@@ -22,7 +21,7 @@ func NewGroupsStage(options *GroupsStageOptions) *Stage {
 	}
 }
 
-func NewGroupsStageOptions(groups []blueprint.GroupCustomization) *GroupsStageOptions {
+func NewGroupsStageOptions(groups []users.Group) *GroupsStageOptions {
 	options := GroupsStageOptions{
 		Groups: map[string]GroupsStageOptionsGroup{},
 	}

--- a/internal/osbuild/isolinux_stage.go
+++ b/internal/osbuild/isolinux_stage.go
@@ -1,0 +1,27 @@
+package osbuild
+
+type ISOLinuxStageOptions struct {
+	Product ISOLinuxProduct `json:"product"`
+	Kernel  ISOLinuxKernel  `json:"kernel"`
+}
+
+func (ISOLinuxStageOptions) isStageOptions() {}
+
+type ISOLinuxProduct struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type ISOLinuxKernel struct {
+	Dir string `json:"dir"`
+
+	Opts []string `json:"opts,omitempty"`
+}
+
+func NewISOLinuxStage(options *ISOLinuxStageOptions, inputPipeline string) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.isolinux",
+		Options: options,
+		Inputs:  NewPipelineTreeInputs("data", inputPipeline),
+	}
+}

--- a/internal/osbuild/kickstart_stage.go
+++ b/internal/osbuild/kickstart_stage.go
@@ -1,8 +1,6 @@
 package osbuild
 
-import (
-	"github.com/osbuild/osbuild-composer/internal/blueprint"
-)
+import "github.com/osbuild/osbuild-composer/internal/users"
 
 type KickstartStageOptions struct {
 	// Where to place the kickstart file
@@ -41,8 +39,8 @@ func NewKickstartStage(options *KickstartStageOptions) *Stage {
 func NewKickstartStageOptions(
 	path string,
 	imageURL string,
-	userCustomizations []blueprint.UserCustomization,
-	groupCustomizations []blueprint.GroupCustomization,
+	userCustomizations []users.User,
+	groupCustomizations []users.Group,
 	ostreeURL string,
 	ostreeRef string,
 	osName string) (*KickstartStageOptions, error) {

--- a/internal/osbuild/oci_archive_stage.go
+++ b/internal/osbuild/oci_archive_stage.go
@@ -34,23 +34,12 @@ func (OCIArchiveStageOptions) isStageOptions() {}
 
 type OCIArchiveStageInputs struct {
 	// Base layer for the container
-	Base *OCIArchiveStageInput `json:"base"`
+	Base *TreeInput `json:"base"`
 	// Additional layers in ascending order
-	Layers []OCIArchiveStageInput `json:",omitempty"`
+	Layers []TreeInput `json:",omitempty"`
 }
 
 func (OCIArchiveStageInputs) isStageInputs() {}
-
-type OCIArchiveStageInput struct {
-	inputCommon
-	References OCIArchiveStageReferences `json:"references"`
-}
-
-func (OCIArchiveStageInput) isStageInput() {}
-
-type OCIArchiveStageReferences []string
-
-func (OCIArchiveStageReferences) isReferences() {}
 
 // A new OCIArchiveStage to to assemble an OCI image archive
 func NewOCIArchiveStage(options *OCIArchiveStageOptions, inputs *OCIArchiveStageInputs) *Stage {
@@ -69,7 +58,7 @@ func (inputs *OCIArchiveStageInputs) MarshalJSON() ([]byte, error) {
 	}
 
 	layers := inputs.Layers
-	inputsMap := make(map[string]OCIArchiveStageInput, len(layers)+1)
+	inputsMap := make(map[string]TreeInput, len(layers)+1)
 	if inputs.Base != nil {
 		inputsMap["base"] = *inputs.Base
 	}
@@ -83,7 +72,7 @@ func (inputs *OCIArchiveStageInputs) MarshalJSON() ([]byte, error) {
 }
 
 // Get the sorted keys that match the pattern "layer.N" (for N > 0)
-func layerKeys(layers map[string]OCIArchiveStageInput) ([]string, error) {
+func layerKeys(layers map[string]TreeInput) ([]string, error) {
 	keys := make([]string, 0, len(layers))
 	for key := range layers {
 		re := regexp.MustCompile(`layer\.[1-9]\d*`)
@@ -110,7 +99,7 @@ func (inputs *OCIArchiveStageInputs) UnmarshalJSON(data []byte) error {
 		inputs = new(OCIArchiveStageInputs)
 	}
 
-	inputsMap := make(map[string]OCIArchiveStageInput)
+	inputsMap := make(map[string]TreeInput)
 
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
@@ -130,7 +119,7 @@ func (inputs *OCIArchiveStageInputs) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	inputs.Layers = make([]OCIArchiveStageInput, len(inputsMap)-1)
+	inputs.Layers = make([]TreeInput, len(inputsMap)-1)
 	for idx, key := range keys {
 		inputs.Layers[idx] = inputsMap[key]
 	}

--- a/internal/osbuild/oci_archive_stage_test.go
+++ b/internal/osbuild/oci_archive_stage_test.go
@@ -36,7 +36,7 @@ func TestOCIArchiveInputs(t *testing.T) {
 		}
 	}`
 	inputs := new(OCIArchiveStageInputs)
-	base := &OCIArchiveStageInput{
+	base := &TreeInput{
 		References: []string{
 			"name:container-tree",
 		},
@@ -44,14 +44,14 @@ func TestOCIArchiveInputs(t *testing.T) {
 	base.Type = "org.osbuild.oci-archive"
 	base.Origin = "org.osbuild.pipeline"
 
-	layer1 := OCIArchiveStageInput{
+	layer1 := TreeInput{
 		References: []string{
 			"name:container-ostree",
 		},
 	}
 	layer1.Type = "org.osbuild.tree"
 	layer1.Origin = "org.osbuild.pipeline"
-	layer2 := OCIArchiveStageInput{
+	layer2 := TreeInput{
 		References: []string{
 			"name:container-ostree2",
 		},
@@ -60,7 +60,7 @@ func TestOCIArchiveInputs(t *testing.T) {
 	layer2.Origin = "org.osbuild.pipeline"
 
 	inputs.Base = base
-	inputs.Layers = []OCIArchiveStageInput{layer1, layer2}
+	inputs.Layers = []TreeInput{layer1, layer2}
 
 	data, err := json.Marshal(inputs)
 	assert.NoError(t, err)

--- a/internal/osbuild/ostree_commit_stage.go
+++ b/internal/osbuild/ostree_commit_stage.go
@@ -13,30 +13,13 @@ type OSTreeCommitStageOptions struct {
 
 func (OSTreeCommitStageOptions) isStageOptions() {}
 
-type OSTreeCommitStageInput struct {
-	inputCommon
-	References OSTreeCommitStageReferences `json:"references"`
-}
-
-func (OSTreeCommitStageInput) isStageInput() {}
-
-type OSTreeCommitStageInputs struct {
-	Tree *OSTreeCommitStageInput `json:"tree"`
-}
-
-func (OSTreeCommitStageInputs) isStageInputs() {}
-
-type OSTreeCommitStageReferences []string
-
-func (OSTreeCommitStageReferences) isReferences() {}
-
 // The OSTreeCommitStage (org.osbuild.ostree.commit) describes how to assemble
 // a tree into an OSTree commit.
-func NewOSTreeCommitStage(options *OSTreeCommitStageOptions, inputs *OSTreeCommitStageInputs) *Stage {
+func NewOSTreeCommitStage(options *OSTreeCommitStageOptions, inputPipeline string) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.ostree.commit",
 		Options: options,
-		Inputs:  inputs,
+		Inputs:  NewPipelineTreeInputs("tree", inputPipeline),
 	}
 }
 

--- a/internal/osbuild/squashfs_stage.go
+++ b/internal/osbuild/squashfs_stage.go
@@ -1,0 +1,17 @@
+package osbuild
+
+type SquashfsStageOptions struct {
+	Filename string `json:"filename"`
+
+	Compression FSCompression `json:"compression"`
+}
+
+func (SquashfsStageOptions) isStageOptions() {}
+
+func NewSquashfsStage(options *SquashfsStageOptions, inputPipeline string) *Stage {
+	return &Stage{
+		Type:    "org.osbuild.squashfs",
+		Options: options,
+		Inputs:  NewPipelineTreeInputs("tree", inputPipeline),
+	}
+}

--- a/internal/osbuild/tar_stage.go
+++ b/internal/osbuild/tar_stage.go
@@ -84,26 +84,9 @@ func (o TarStageOptions) validate() error {
 	return nil
 }
 
-type TarStageInput struct {
-	inputCommon
-	References TarStageReferences `json:"references"`
-}
-
-func (TarStageInput) isStageInput() {}
-
-type TarStageInputs struct {
-	Tree *TarStageInput `json:"tree"`
-}
-
-func (TarStageInputs) isStageInputs() {}
-
-type TarStageReferences []string
-
-func (TarStageReferences) isReferences() {}
-
 // Assembles a tree into a tar archive. Compression is determined by the suffix
 // (i.e., --auto-compress is used).
-func NewTarStage(options *TarStageOptions, inputs *TarStageInputs) *Stage {
+func NewTarStage(options *TarStageOptions, inputPipeline string) *Stage {
 	if err := options.validate(); err != nil {
 		panic(err)
 	}
@@ -111,16 +94,6 @@ func NewTarStage(options *TarStageOptions, inputs *TarStageInputs) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.tar",
 		Options: options,
-		Inputs:  inputs,
-	}
-}
-
-func NewTarStagePipelineTreeInputs(pipeline string) *TarStageInputs {
-	tree := new(TarStageInput)
-	tree.Type = "org.osbuild.tree"
-	tree.Origin = "org.osbuild.pipeline"
-	tree.References = []string{"name:" + pipeline}
-	return &TarStageInputs{
-		Tree: tree,
+		Inputs:  NewPipelineTreeInputs("tree", inputPipeline),
 	}
 }

--- a/internal/osbuild/tar_stage_test.go
+++ b/internal/osbuild/tar_stage_test.go
@@ -8,13 +8,22 @@ import (
 
 func TestNewTarStage(t *testing.T) {
 	stageOptions := &TarStageOptions{Filename: "archive.tar.xz"}
-	stageInputs := &TarStageInputs{}
+	stageInputs := &PipelineTreeInputs{"tree": TreeInput{
+		inputCommon: inputCommon{
+			Type:   "org.osbuild.tree",
+			Origin: "org.osbuild.pipeline",
+		},
+		References: []string{
+			"name:pipeline33",
+		},
+	},
+	}
 	expectedStage := &Stage{
 		Type:    "org.osbuild.tar",
 		Options: stageOptions,
 		Inputs:  stageInputs,
 	}
-	actualStage := NewTarStage(stageOptions, stageInputs)
+	actualStage := NewTarStage(stageOptions, "pipeline33")
 	assert.Equal(t, expectedStage, actualStage)
 }
 
@@ -59,10 +68,10 @@ func TestTarStageOptionsValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.err {
 				assert.Errorf(t, tt.options.validate(), "%q didn't return an error [idx: %d]", tt.name, idx)
-				assert.Panics(t, func() { NewTarStage(&tt.options, &TarStageInputs{}) })
+				assert.Panics(t, func() { NewTarStage(&tt.options, "") })
 			} else {
 				assert.NoErrorf(t, tt.options.validate(), "%q returned an error [idx: %d]", tt.name, idx)
-				assert.NotPanics(t, func() { NewTarStage(&tt.options, &TarStageInputs{}) })
+				assert.NotPanics(t, func() { NewTarStage(&tt.options, "") })
 			}
 		})
 	}

--- a/internal/osbuild/tree_input.go
+++ b/internal/osbuild/tree_input.go
@@ -18,3 +18,13 @@ func NewTreeInput(reference string) *TreeInput {
 	input.References = []string{reference}
 	return input
 }
+
+type PipelineTreeInputs map[string]TreeInput
+
+func NewPipelineTreeInputs(name, pipeline string) *PipelineTreeInputs {
+	return &PipelineTreeInputs{
+		name: *NewTreeInput("name:" + pipeline),
+	}
+}
+
+func (PipelineTreeInputs) isStageInputs() {}

--- a/internal/osbuild/tree_input.go
+++ b/internal/osbuild/tree_input.go
@@ -3,13 +3,18 @@ package osbuild
 // Tree inputs
 type TreeInput struct {
 	inputCommon
+	References []string `json:"references"`
 }
 
 func (TreeInput) isInput() {}
 
-func NewTreeInput() *TreeInput {
+// NewTreeInput creates an org.osbuild.tree input for an osbuild stage.
+// The input is the final tree from a pipeline that should be referenced as
+// 'name:<pipelinename>' in the reference argument.
+func NewTreeInput(reference string) *TreeInput {
 	input := new(TreeInput)
 	input.Type = "org.osbuild.tree"
 	input.Origin = "org.osbuild.pipeline"
+	input.References = []string{reference}
 	return input
 }

--- a/internal/osbuild/users_stage.go
+++ b/internal/osbuild/users_stage.go
@@ -1,7 +1,6 @@
 package osbuild
 
 import (
-	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/crypt"
 	"github.com/osbuild/osbuild-composer/internal/users"
 )
@@ -30,7 +29,7 @@ func NewUsersStage(options *UsersStageOptions) *Stage {
 	}
 }
 
-func NewUsersStageOptions(userCustomizations []blueprint.UserCustomization, omitKey bool) (*UsersStageOptions, error) {
+func NewUsersStageOptions(userCustomizations []users.User, omitKey bool) (*UsersStageOptions, error) {
 	if len(userCustomizations) == 0 {
 		return nil, nil
 	}

--- a/internal/osbuild/users_stage_test.go
+++ b/internal/osbuild/users_stage_test.go
@@ -4,8 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/osbuild/osbuild-composer/internal/blueprint"
-
+	"github.com/osbuild/osbuild-composer/internal/users"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,20 +23,20 @@ func TestNewUsersStageOptionsPassword(t *testing.T) {
 	EmptyPass := ""
 	CryptPass := "$6$RWdHzrPfoM6BMuIP$gKYlBXQuJgP.G2j2twbOyxYjFDPUQw8Jp.gWe1WD/obX0RMyfgw5vt.Mn/tLLX4mQjaklSiIzoAW3HrVQRg4Q." // #nosec G101
 
-	users := []blueprint.UserCustomization{
-		blueprint.UserCustomization{
+	users := []users.User{
+		{
 			Name:     "bart",
 			Password: &Pass,
 		},
-		blueprint.UserCustomization{
+		{
 			Name:     "lisa",
 			Password: &CryptPass,
 		},
-		blueprint.UserCustomization{
+		{
 			Name:     "maggie",
 			Password: &EmptyPass,
 		},
-		blueprint.UserCustomization{
+		{
 			Name: "homer",
 		},
 	}

--- a/internal/osbuild/xorrisofs_stage.go
+++ b/internal/osbuild/xorrisofs_stage.go
@@ -30,36 +30,11 @@ type XorrisofsBoot struct {
 
 func (XorrisofsStageOptions) isStageOptions() {}
 
-type XorrisofsStageInputs struct {
-	Tree *XorrisofsStageInput `json:"tree"`
-}
-
-func (XorrisofsStageInputs) isStageInputs() {}
-
-type XorrisofsStageInput struct {
-	inputCommon
-	References XorrisofsStageReferences `json:"references"`
-}
-
-func (XorrisofsStageInput) isStageInput() {}
-
-type XorrisofsStageReferences []string
-
-func (XorrisofsStageReferences) isReferences() {}
-
 // Assembles a Rock Ridge enhanced ISO 9660 filesystem (iso)
-func NewXorrisofsStage(options *XorrisofsStageOptions, inputs *XorrisofsStageInputs) *Stage {
+func NewXorrisofsStage(options *XorrisofsStageOptions, inputPipeline string) *Stage {
 	return &Stage{
 		Type:    "org.osbuild.xorrisofs",
 		Options: options,
-		Inputs:  inputs,
+		Inputs:  NewPipelineTreeInputs("tree", inputPipeline),
 	}
-}
-
-func NewXorrisofsStagePipelineTreeInputs(pipeline string) *XorrisofsStageInputs {
-	input := new(XorrisofsStageInput)
-	input.Type = "org.osbuild.tree"
-	input.Origin = "org.osbuild.pipeline"
-	input.References = XorrisofsStageReferences{"name:" + pipeline}
-	return &XorrisofsStageInputs{Tree: input}
 }

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -569,7 +569,7 @@ sudo virt-install  --name="${IMAGE_KEY}-uefi"\
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
-                   --boot uefi,loader_ro=yes,loader_type=pflash,nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd,loader_secure=no \
+                   --boot uefi \
                    --nographics \
                    --noautoconsole \
                    --wait=-1 \

--- a/test/cases/ostree-ng.sh
+++ b/test/cases/ostree-ng.sh
@@ -559,6 +559,15 @@ sudo rm -f "$LIBVIRT_BIOS_IMAGE_PATH"
 ## Install, upgrade and test Edge image on UEFI VM
 ##
 ##################################################
+
+# Since virt-install 4.0.0, loader attribute can't be configured here,
+# otherwise it'll report "loader attribute 'readonly' cannot be specified
+# when firmware autoselection is enabled"
+if nvrGreaterOrEqual "virt-install" "4.0.0"; then
+    BOOT_UEFI_ARGS="uefi"
+else
+    BOOT_UEFI_ARGS="uefi,loader_ro=yes,loader_type=pflash,nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.fd,loader_secure=no"
+fi
 # Install ostree image via anaconda.
 greenprint "💿 Install ostree image via installer(ISO) on UEFI VM"
 sudo virt-install  --name="${IMAGE_KEY}-uefi"\
@@ -569,7 +578,7 @@ sudo virt-install  --name="${IMAGE_KEY}-uefi"\
                    --os-type linux \
                    --os-variant ${OS_VARIANT} \
                    --cdrom "/var/lib/libvirt/images/${ISO_FILENAME}" \
-                   --boot uefi \
+                   --boot "$BOOT_UEFI_ARGS" \
                    --nographics \
                    --noautoconsole \
                    --wait=-1 \

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -250,6 +250,25 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      when: (ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('37', '<')) or
+            (ansible_facts['distribution'] == 'CentOS') or (ansible_facts['distribution'] == 'RedHat')
+
+    # https://fedoraproject.org/wiki/Changes/Silverblue_Kinoite_readonly_sysroot
+    - name: /sysroot should be mount with ro permission since Fedora 37
+      block:
+        - assert:
+            that:
+              - result_sysroot_mount_status.stdout == "ro"
+            fail_msg: "/sysroot is not mounted with ro permission"
+            success_msg: "/sysroot is mounted with ro permission"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('37', '>=')
 
     # case: check /var mount point
     - name: check /var mount point
@@ -382,6 +401,8 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
+      when: (ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('37', '<')) or
+            (ansible_facts['distribution'] == 'CentOS') or (ansible_facts['distribution'] == 'RedHat')
 
     # case: check dmesg error and failed log
     - name: check dmesg output
@@ -514,8 +535,6 @@
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"
-      when: (ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_version'] is version('8.6', '>=')) or
-            (ansible_facts['distribution'] == 'CentOS')
       when: (ansible_facts['distribution'] == 'RedHat' and ansible_facts['distribution_version'] is version('8.6', '>=')) or
             (ansible_facts['distribution'] == 'CentOS') or
             (ansible_facts['distribution'] == 'Fedora' and ansible_facts['distribution_version'] is version('36', '>='))

--- a/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
@@ -9990,13 +9990,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "35"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-35-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.15.13-200.fc35.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.15.13-200.fc35.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10009,47 +10164,92 @@
                 "name": "Fedora",
                 "version": "35"
               },
-              "kernel": "5.15.13-200.fc35.aarch64",
-              "isolabel": "Fedora-35-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "aarch64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10073,6 +10273,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "aarch64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
@@ -10020,13 +10020,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "35"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-35-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.15.13-200.fc35.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.15.13-200.fc35.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10039,34 +10194,121 @@
                 "name": "Fedora",
                 "version": "35"
               },
-              "kernel": "5.15.13-200.fc35.aarch64",
-              "isolabel": "Fedora-35-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10102,29 +10344,6 @@
             "options": {
               "basearch": "aarch64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_35-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_raw_image-boot.json
@@ -1796,18 +1796,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -1832,7 +1820,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -1860,6 +1849,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -1970,7 +1984,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_35-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_installer-boot.json
@@ -10183,13 +10183,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "35"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-35-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.15.13-200.fc35.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.15.13-200.fc35.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10202,47 +10357,92 @@
                 "name": "Fedora",
                 "version": "35"
               },
-              "kernel": "5.15.13-200.fc35.x86_64",
-              "isolabel": "Fedora-35-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "x86_64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10266,6 +10466,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "x86_64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_35-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_installer_with_users-boot.json
@@ -10213,13 +10213,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "35"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-35-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.15.13-200.fc35.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.15.13-200.fc35.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10232,34 +10387,121 @@
                 "name": "Fedora",
                 "version": "35"
               },
-              "kernel": "5.15.13-200.fc35.x86_64",
-              "isolabel": "Fedora-35-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10295,29 +10537,6 @@
             "options": {
               "basearch": "x86_64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_35-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_raw_image-boot.json
@@ -1820,18 +1820,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -1856,7 +1844,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -1884,6 +1873,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -1994,7 +2008,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
@@ -10510,13 +10510,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "36"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-36-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.18.9-200.fc36.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.18.9-200.fc36.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10529,47 +10684,92 @@
                 "name": "Fedora",
                 "version": "36"
               },
-              "kernel": "5.18.9-200.fc36.aarch64",
-              "isolabel": "Fedora-36-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "aarch64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10593,6 +10793,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "aarch64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
@@ -10540,13 +10540,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "36"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-36-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.18.9-200.fc36.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.18.9-200.fc36.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10559,34 +10714,121 @@
                 "name": "Fedora",
                 "version": "36"
               },
-              "kernel": "5.18.9-200.fc36.aarch64",
-              "isolabel": "Fedora-36-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10622,29 +10864,6 @@
             "options": {
               "basearch": "aarch64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_36-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_raw_image-boot.json
@@ -2044,18 +2044,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -2080,7 +2068,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -2108,6 +2097,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -2218,7 +2232,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
@@ -10695,13 +10695,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "36"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-36-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.18.9-200.fc36.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.18.9-200.fc36.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10714,47 +10869,92 @@
                 "name": "Fedora",
                 "version": "36"
               },
-              "kernel": "5.18.9-200.fc36.x86_64",
-              "isolabel": "Fedora-36-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "x86_64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10778,6 +10978,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "x86_64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
@@ -10725,13 +10725,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "36"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-36-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.18.9-200.fc36.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.18.9-200.fc36.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10744,34 +10899,121 @@
                 "name": "Fedora",
                 "version": "36"
               },
-              "kernel": "5.18.9-200.fc36.x86_64",
-              "isolabel": "Fedora-36-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10807,29 +11049,6 @@
             "options": {
               "basearch": "x86_64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_36-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_raw_image-boot.json
@@ -2068,18 +2068,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -2104,7 +2092,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -2132,6 +2121,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -2242,7 +2256,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
@@ -10620,13 +10620,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "37"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-37-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.19.3-300.fc37.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.19.3-300.fc37.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10639,47 +10794,92 @@
                 "name": "Fedora",
                 "version": "37"
               },
-              "kernel": "5.19.3-300.fc37.aarch64",
-              "isolabel": "Fedora-37-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "aarch64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10703,6 +10903,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "aarch64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
@@ -10650,13 +10650,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "37"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-37-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.19.3-300.fc37.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.19.3-300.fc37.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10669,34 +10824,121 @@
                 "name": "Fedora",
                 "version": "37"
               },
-              "kernel": "5.19.3-300.fc37.aarch64",
-              "isolabel": "Fedora-37-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10732,29 +10974,6 @@
             "options": {
               "basearch": "aarch64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_37-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_raw_image-boot.json
@@ -2052,18 +2052,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -2088,7 +2076,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -2116,6 +2105,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -2226,7 +2240,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
@@ -10813,13 +10813,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "37"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-37-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.19.3-300.fc37.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.19.3-300.fc37.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10832,47 +10987,92 @@
                 "name": "Fedora",
                 "version": "37"
               },
-              "kernel": "5.19.3-300.fc37.x86_64",
-              "isolabel": "Fedora-37-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "x86_64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10896,6 +11096,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "x86_64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
@@ -10843,13 +10843,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "37"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-37-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-5.19.3-300.fc37.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-5.19.3-300.fc37.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10862,34 +11017,121 @@
                 "name": "Fedora",
                 "version": "37"
               },
-              "kernel": "5.19.3-300.fc37.x86_64",
-              "isolabel": "Fedora-37-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10925,29 +11167,6 @@
             "options": {
               "basearch": "x86_64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_37-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_raw_image-boot.json
@@ -2076,18 +2076,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -2112,7 +2100,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -2140,6 +2129,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -2250,7 +2264,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -10604,13 +10604,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "38"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-38-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-6.0.0-0.rc1.13.fc38.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-6.0.0-0.rc1.13.fc38.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10623,47 +10778,92 @@
                 "name": "Fedora",
                 "version": "38"
               },
-              "kernel": "6.0.0-0.rc1.13.fc38.aarch64",
-              "isolabel": "Fedora-38-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "aarch64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10687,6 +10887,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "aarch64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -10634,13 +10634,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "38"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-38-BaseOS-aarch64",
+              "architectures": [
+                "AA64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-6.0.0-0.rc1.13.fc38.aarch64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-6.0.0-0.rc1.13.fc38.aarch64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10653,34 +10808,121 @@
                 "name": "Fedora",
                 "version": "38"
               },
-              "kernel": "6.0.0-0.rc1.13.fc38.aarch64",
-              "isolabel": "Fedora-38-BaseOS-aarch64",
-              "efi": {
-                "architectures": [
-                  "AA64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": false
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "arm"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10716,29 +10958,6 @@
             "options": {
               "basearch": "aarch64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_38-aarch64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_raw_image-boot.json
@@ -2044,18 +2044,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -2080,7 +2068,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -2108,6 +2097,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -2218,7 +2232,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "uefi": {
                 "vendor": "fedora",
                 "install": true,

--- a/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
@@ -10789,13 +10789,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "38"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-38-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-6.0.0-0.rc1.13.fc38.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-6.0.0-0.rc1.13.fc38.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10808,47 +10963,92 @@
                 "name": "Fedora",
                 "version": "38"
               },
-              "kernel": "6.0.0-0.rc1.13.fc38.x86_64",
-              "isolabel": "Fedora-38-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/ostree.ks"
+                ]
               }
             }
           },
           {
-            "type": "org.osbuild.kickstart",
+            "type": "org.osbuild.truncate",
             "options": {
-              "path": "/osbuild.ks",
-              "ostree": {
-                "osname": "fedora",
-                "url": "file:///run/install/repo/ostree/repo",
-                "ref": "test/iot",
-                "gpg": false
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
               }
             }
           },
           {
-            "type": "org.osbuild.discinfo",
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
             "options": {
-              "basearch": "x86_64",
-              "release": "202010217.n.0"
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
             }
           },
           {
@@ -10872,6 +11072,25 @@
             },
             "options": {
               "repo": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.kickstart",
+            "options": {
+              "path": "/ostree.ks",
+              "ostree": {
+                "osname": "fedora",
+                "url": "file:///run/install/repo/ostree/repo",
+                "ref": "test/iot",
+                "gpg": false
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.discinfo",
+            "options": {
+              "basearch": "x86_64",
+              "release": "202010217.n.0"
             }
           }
         ]

--- a/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
@@ -10819,13 +10819,168 @@
         ]
       },
       {
+        "name": "rootfs-image",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "LiveOS"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "LiveOS/rootfs.img",
+              "size": "4294967296"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.ext4",
+            "options": {
+              "uuid": "2fe99653-f7ff-44fd-bea8-fa70107524fb",
+              "label": "Anaconda"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/",
+                  "to": "mount://device/"
+                }
+              ]
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "LiveOS/rootfs.img"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "device",
+                "type": "org.osbuild.ext4",
+                "source": "device",
+                "target": "/"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "efiboot-tree",
+        "build": "name:build",
+        "stages": [
+          {
+            "type": "org.osbuild.grub2.iso",
+            "options": {
+              "product": {
+                "name": "Fedora",
+                "version": "38"
+              },
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/ostree.ks"
+                ]
+              },
+              "isolabel": "Fedora-38-BaseOS-x86_64",
+              "architectures": [
+                "X64"
+              ],
+              "vendor": "fedora"
+            }
+          }
+        ]
+      },
+      {
         "name": "bootiso-tree",
         "build": "name:build",
         "stages": [
           {
-            "type": "org.osbuild.bootiso.mono",
+            "type": "org.osbuild.mkdir",
+            "options": {
+              "paths": [
+                {
+                  "path": "images"
+                },
+                {
+                  "path": "images/pxeboot"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
             "inputs": {
-              "rootfs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:anaconda-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://tree/boot/vmlinuz-6.0.0-0.rc1.13.fc38.x86_64",
+                  "to": "tree:///images/pxeboot/vmlinuz"
+                },
+                {
+                  "from": "input://tree/boot/initramfs-6.0.0-0.rc1.13.fc38.x86_64.img",
+                  "to": "tree:///images/pxeboot/initrd.img"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.squashfs",
+            "inputs": {
+              "tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:rootfs-image"
+                ]
+              }
+            },
+            "options": {
+              "filename": "images/install.img",
+              "compression": {
+                "method": "lz4"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.isolinux",
+            "inputs": {
+              "data": {
                 "type": "org.osbuild.tree",
                 "origin": "org.osbuild.pipeline",
                 "references": [
@@ -10838,34 +10993,121 @@
                 "name": "Fedora",
                 "version": "38"
               },
-              "kernel": "6.0.0-0.rc1.13.fc38.x86_64",
-              "isolabel": "Fedora-38-BaseOS-x86_64",
-              "efi": {
-                "architectures": [
-                  "X64"
-                ],
-                "vendor": "fedora"
-              },
-              "isolinux": {
-                "enabled": true
-              },
-              "kernel_opts": "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/osbuild.ks",
-              "templates": "99-generic",
-              "rootfs": {
-                "compression": {
-                  "method": "xz",
-                  "options": {
-                    "bcj": "x86"
-                  }
-                },
-                "size": 9216
+              "kernel": {
+                "dir": "/images/pxeboot",
+                "opts": [
+                  "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/ostree.ks"
+                ]
               }
+            }
+          },
+          {
+            "type": "org.osbuild.truncate",
+            "options": {
+              "filename": "images/efiboot.img",
+              "size": "20MB"
+            }
+          },
+          {
+            "type": "org.osbuild.mkfs.fat",
+            "options": {
+              "volid": "0194fdc2"
+            },
+            "devices": {
+              "device": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960,
+                  "lock": true
+                }
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/",
+                  "to": "mount://root/"
+                }
+              ]
+            },
+            "devices": {
+              "root": {
+                "type": "org.osbuild.loopback",
+                "options": {
+                  "filename": "images/efiboot.img",
+                  "size": 40960
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "root",
+                "type": "org.osbuild.fat",
+                "source": "root",
+                "target": "/"
+              }
+            ]
+          },
+          {
+            "type": "org.osbuild.copy",
+            "inputs": {
+              "root-tree": {
+                "type": "org.osbuild.tree",
+                "origin": "org.osbuild.pipeline",
+                "references": [
+                  "name:efiboot-tree"
+                ]
+              }
+            },
+            "options": {
+              "paths": [
+                {
+                  "from": "input://root-tree/EFI",
+                  "to": "tree:///"
+                }
+              ]
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.init",
+            "options": {
+              "path": "/ostree/repo"
+            }
+          },
+          {
+            "type": "org.osbuild.ostree.pull",
+            "inputs": {
+              "commits": {
+                "type": "org.osbuild.ostree",
+                "origin": "org.osbuild.source",
+                "references": {
+                  "test/iot": {
+                    "ref": "test/iot"
+                  }
+                }
+              }
+            },
+            "options": {
+              "repo": "/ostree/repo"
             }
           },
           {
             "type": "org.osbuild.kickstart",
             "options": {
-              "path": "/osbuild.ks",
+              "path": "/ostree.ks",
               "ostree": {
                 "osname": "fedora",
                 "url": "file:///run/install/repo/ostree/repo",
@@ -10901,29 +11143,6 @@
             "options": {
               "basearch": "x86_64",
               "release": "202010217.n.0"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.init",
-            "options": {
-              "path": "/ostree/repo"
-            }
-          },
-          {
-            "type": "org.osbuild.ostree.pull",
-            "inputs": {
-              "commits": {
-                "type": "org.osbuild.ostree",
-                "origin": "org.osbuild.source",
-                "references": {
-                  "test/iot": {
-                    "ref": "test/iot"
-                  }
-                }
-              }
-            },
-            "options": {
-              "repo": "/ostree/repo"
             }
           }
         ]

--- a/test/data/manifests/fedora_38-x86_64-iot_raw_image-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_raw_image-boot.json
@@ -2068,18 +2068,6 @@
             }
           },
           {
-            "type": "org.osbuild.ostree.config",
-            "options": {
-              "repo": "/ostree/repo",
-              "config": {
-                "sysroot": {
-                  "readonly": true,
-                  "bootloader": "none"
-                }
-              }
-            }
-          },
-          {
             "type": "org.osbuild.mkdir",
             "options": {
               "paths": [
@@ -2104,7 +2092,8 @@
                 "label": "root"
               },
               "kernel_opts": [
-                "modprobe.blacklist=vc4"
+                "modprobe.blacklist=vc4",
+                "rw"
               ]
             }
           },
@@ -2132,6 +2121,31 @@
                 "ref": "test/fedora/iot"
               }
             }
+          },
+          {
+            "type": "org.osbuild.ostree.config",
+            "options": {
+              "repo": "/ostree/repo",
+              "config": {
+                "sysroot": {
+                  "readonly": true,
+                  "bootloader": "none"
+                }
+              }
+            },
+            "mounts": [
+              {
+                "name": "ostree-test/fedora/iot",
+                "type": "org.osbuild.ostree.deployment",
+                "options": {
+                  "deployment": {
+                    "osname": "fedora-iot",
+                    "ref": "test/fedora/iot",
+                    "serial": 0
+                  }
+                }
+              }
+            ]
           },
           {
             "type": "org.osbuild.fstab",
@@ -2242,7 +2256,7 @@
             "options": {
               "root_fs_uuid": "6e4ff95f-f662-45ee-a82a-bdf44a2d0b75",
               "boot_fs_uuid": "0194fdc2-fa2f-4cc0-81d3-ff12045b73c8",
-              "kernel_opts": "modprobe.blacklist=vc4",
+              "kernel_opts": "modprobe.blacklist=vc4,rw",
               "legacy": "i386-pc",
               "uefi": {
                 "vendor": "fedora",


### PR DESCRIPTION
The Fedora IoT Installer image definition is updated to the more granular osbuild stages for creating a boot ISO and doesn't rely on `org.osbuild.bootiso.mono`.

Support for the following osbuild stages has been added:
- `org.osbuild.isolinux`
- `org.osbuild.squashfs`

The use `org.osbuild.tree` stage input type has been cleaned up.  It should be much easier to define this input now and it more accurately reflects the schemas in osbuild.  Similar changes to other input types should be made in future PRs.