### PR TITLE
worker: log error details on job failure

### DIFF
--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -170,6 +170,9 @@ func validateResult(result *worker.OSBuildJobResult, jobID string) {
 	logWithId := logrus.WithField("jobId", jobID)
 	if result.JobError != nil {
 		logWithId.Errorf("osbuild job failed: %s", result.JobError.Reason)
+		if result.JobError.Details != nil {
+			logWithId.Errorf("failure details : %v", result.JobError.Details)
+		}
 		return
 	}
 	// if the job failed, but the JobError is


### PR DESCRIPTION
Currently errors like clienterror 28 ("at least one target failed") have all the relevant information in the details, don't omit these details from the worker logs.

