### PR TITLE
dbjobqueue: Backoff after listener error

### DIFF
--- a/pkg/jobqueue/dbjobqueue/dbjobqueue.go
+++ b/pkg/jobqueue/dbjobqueue/dbjobqueue.go
@@ -226,6 +226,8 @@ func (q *DBJobQueue) listen(ctx context.Context, ready chan<- struct{}) {
 			// otherwise, just log the error and continue, there might just
 			// be a temporary networking issue
 			q.logger.Error(err, "Error waiting for notification on jobs channel")
+			// backoff to avoid log spam
+			time.Sleep(time.Millisecond * 500)
 			continue
 		}
 


### PR DESCRIPTION
The connection can be briefly interrupted for short periods of time, which is fine. To avoid spamming the logs with error messages, backoff for half a second.
