### PR TITLE
test: get correct CIV tag in azure.sh

### DIFF
--- a/test/cases/azure.sh
+++ b/test/cases/azure.sh
@@ -196,7 +196,15 @@ export BLOB_URL="https://$AZURE_STORAGE_ACCOUNT.blob.core.windows.net/$AZURE_CON
 
 greenprint "Pulling cloud-image-val container"
 
-CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:prod"
+if [[ "$CI_PROJECT_NAME" =~ "cloud-image-val" ]]; then
+  # If running on CIV, get dev container
+  TAG=${CI_COMMIT_REF_SLUG}
+else
+  # If not, get prod container
+  TAG="prod"
+fi
+
+CONTAINER_CLOUD_IMAGE_VAL="quay.io/cloudexperience/cloud-image-val-test:$TAG"
 
 sudo ${CONTAINER_RUNTIME} pull ${CONTAINER_CLOUD_IMAGE_VAL}
 


### PR DESCRIPTION
In order to run azure.sh inside CIV CI, we need to use the appropiate tag. This means getting `prod` tag when running in osbuild-composer and the pr tag when running in cloud-image-val


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/