### PR TITLE
Improvements to dbjobqueue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,27 +58,25 @@ jobs:
           - 5432:5432
     steps:
       # gpgme-devel is needed for container upload dependencies
-    - name: Install test dependencies
-      run: sudo apt-get install -y libgpgme-dev
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v3
-      with:
-        go-version: 1.16
-    - env:
-        PGUSER: postgres
-        PGPASSWORD: foobar
-        PGDATABASE: osbuildcomposer
-        PGHOST: localhost
-        PGPORT: 5432
-      run: |
-        WORKDIR=$(readlink -f pkg/jobqueue/dbjobqueue/schemas)
-        pushd $(mktemp -d)
-        go mod init temp
-        go get -u github.com/jackc/tern
-        go run github.com/jackc/tern migrate -m "$WORKDIR"
-        popd
-    - run: go test -tags=integration ./cmd/osbuild-composer-dbjobqueue-tests
-    - run: go test -tags=integration ./cmd/osbuild-service-maintenance
+      - name: Install test dependencies
+        run: sudo apt-get install -y libgpgme-dev
+      - uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.16
+
+      - name: Migrate jobqueue
+        run: |
+          go install github.com/jackc/tern@latest
+          make migrate-dbjobqueue
+
+      - name: Run dbjobqueue tests
+        run: go test -tags=integration ./cmd/osbuild-composer-dbjobqueue-tests
+
+      - name: Run service maintenance tests
+        run: go test -tags=integration ./cmd/osbuild-service-maintenance
 
   python-lint:
     name: "🐍 Lint (dnf-json)"

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,10 @@ build:
 	go test -c -tags=integration -o bin/osbuild-composer-maintenance-tests ./cmd/osbuild-service-maintenance/
 	go test -c -tags=integration -o bin/osbuild-composer-manifest-tests ./cmd/osbuild-composer-manifest-tests/
 
+.PHONY: migrate-dbjobqueue
+migrate-dbjobqueue:
+	tern migrate -c ./cmd/osbuild-composer-dbjobqueue-tests/tern.conf -m pkg/jobqueue/dbjobqueue/schemas/
+
 .PHONY: install
 install:
 	- mkdir -p /usr/libexec/osbuild-composer

--- a/cmd/osbuild-composer-dbjobqueue-tests/tern.conf
+++ b/cmd/osbuild-composer-dbjobqueue-tests/tern.conf
@@ -1,0 +1,7 @@
+[database]
+host = 127.0.0.1
+port = 5432
+database = osbuildcomposer
+user = postgres
+password = foobar
+version_table = public.schema_version

--- a/pkg/jobqueue/dbjobqueue/dbjobqueue.go
+++ b/pkg/jobqueue/dbjobqueue/dbjobqueue.go
@@ -18,9 +18,9 @@ import (
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
-	"github.com/osbuild/osbuild-composer/internal/common/slogger"
 	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
-	"github.com/sirupsen/logrus"
+	"github.com/osbuild/osbuild-composer/pkg/slogger"
+	"github.com/osbuild/osbuild-composer/pkg/slogger/logrus"
 )
 
 const (
@@ -105,7 +105,7 @@ const (
 )
 
 type DBJobQueue struct {
-	logger       jobqueue.SimpleLogger
+	logger       slogger.SimpleLogger
 	pool         *pgxpool.Pool
 	dequeuers    *dequeuers
 	stopListener func()
@@ -157,12 +157,12 @@ func (d *dequeuers) notifyAll() {
 type Config struct {
 	// Logger is used for all logging of the queue, when not provided, the stanard
 	// global logger (logrus) is used.
-	Logger jobqueue.SimpleLogger
+	Logger slogger.SimpleLogger
 }
 
 // New creates a new DBJobQueue object for `url` with default configuration.
 func New(url string) (*DBJobQueue, error) {
-	stdLogger := slogger.NewLogrusLogger(logrus.StandardLogger())
+	stdLogger := logrus.NewStandardLogrusLogger()
 	config := Config{
 		Logger: stdLogger,
 	}

--- a/pkg/jobqueue/jobqueue.go
+++ b/pkg/jobqueue/jobqueue.go
@@ -79,18 +79,6 @@ type JobQueue interface {
 	RefreshHeartbeat(token uuid.UUID)
 }
 
-// SimpleLogger provides a structured logging methods for the jobqueue library.
-type SimpleLogger interface {
-	// Info creates an info-level message and arbitrary amount of key-value string pairs which
-	// can be optionally mapped to fields by underlying implementations.
-	Info(msg string, args ...string)
-
-	// Error creates an error-level message and arbitrary amount of key-value string pairs which
-	// can be optionally mapped to fields by underlying implementations. The first error argument
-	// can be set to nil when no context error is available.
-	Error(err error, msg string, args ...string)
-}
-
 var (
 	ErrNotExist       = errors.New("job does not exist")
 	ErrNotPending     = errors.New("job is not pending")

--- a/pkg/slogger/logrus/logrus.go
+++ b/pkg/slogger/logrus/logrus.go
@@ -1,7 +1,7 @@
-package slogger
+package logrus
 
 import (
-	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
+	"github.com/osbuild/osbuild-composer/pkg/slogger"
 	"github.com/sirupsen/logrus"
 )
 
@@ -9,8 +9,12 @@ type simpleLogrus struct {
 	logger *logrus.Logger
 }
 
-func NewLogrusLogger(logger *logrus.Logger) jobqueue.SimpleLogger {
+func NewLogrusLogger(logger *logrus.Logger) slogger.SimpleLogger {
 	return &simpleLogrus{logger: logger}
+}
+
+func NewStandardLogrusLogger() slogger.SimpleLogger {
+	return NewLogrusLogger(logrus.StandardLogger())
 }
 
 func (s *simpleLogrus) log(level logrus.Level, err error, msg string, args ...string) {

--- a/pkg/slogger/logrus/logrus_test.go
+++ b/pkg/slogger/logrus/logrus_test.go
@@ -1,4 +1,4 @@
-package slogger
+package logrus
 
 import (
 	"bytes"

--- a/pkg/slogger/noop/noop.go
+++ b/pkg/slogger/noop/noop.go
@@ -1,13 +1,13 @@
-package slogger
+package noop
 
 import (
-	"github.com/osbuild/osbuild-composer/pkg/jobqueue"
+	"github.com/osbuild/osbuild-composer/pkg/slogger"
 )
 
 type noopLogger struct {
 }
 
-func NewNoopLogger() jobqueue.SimpleLogger {
+func NewNoopLogger() slogger.SimpleLogger {
 	return &noopLogger{}
 }
 

--- a/pkg/slogger/simple_logger.go
+++ b/pkg/slogger/simple_logger.go
@@ -1,0 +1,14 @@
+// Package slogger provide a simple logging interface with implementation for logrus.
+package slogger
+
+// SimpleLogger provides a structured logging methods for the jobqueue library.
+type SimpleLogger interface {
+	// Info creates an info-level message and arbitrary amount of key-value string pairs which
+	// can be optionally mapped to fields by underlying implementations.
+	Info(msg string, args ...string)
+
+	// Error creates an error-level message and arbitrary amount of key-value string pairs which
+	// can be optionally mapped to fields by underlying implementations. The first error argument
+	// can be set to nil when no context error is available.
+	Error(err error, msg string, args ...string)
+}


### PR DESCRIPTION
Couple of commits:

* Because slogger was imported from internal package, it was not possible to import jobqueue effectively. Go was erroring out, the change moves the simple logger package to pkg/ and also moves the interface into a separate file where it belongs. Both noop and logrus implementations were moved into own packages so it's now nice and clean - these can be imported without extra dependencies and the interface itself can be also imported without logrus dependency.
* Another small commit allows passing in an existing pgxpool so we can reuse the one we already have in our app. We migrated from database/sql to the native pgx last week.
* Finally, when I was testing this, I needed to create a migration for the tests so I am dropping a `Makefile` target to do that so others don't need to figure it out

Edit: Initially the PR had some changes around context passing, but this is worth looking into a separate PR I think.

Cheers!