### PR TITLE
Extend firewall customizations to add sources

### DIFF
--- a/Schutzfile
+++ b/Schutzfile
@@ -2,7 +2,7 @@
   "fedora-35": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     },
     "repos": [
@@ -79,7 +79,7 @@
   "fedora-36": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     },
     "repos": [
@@ -156,7 +156,7 @@
   "fedora-37": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     },
     "repos": [
@@ -233,21 +233,21 @@
   "rhel-8.4": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     }
   },
   "rhel-8.6": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     }
   },
   "rhel-8.7": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     },
     "repos": [
@@ -334,14 +334,14 @@
   "rhel-9.0": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     }
   },
   "rhel-9.1": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     },
     "repos": [
@@ -428,21 +428,21 @@
   "centos-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     }
   },
   "centos-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     }
   },
   "centos-stream-9": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     },
     "repos": [
@@ -488,7 +488,7 @@
   "centos-stream-8": {
     "dependencies": {
       "osbuild": {
-        "commit": "976fbe178ac66ee0ba64c983d754dc4672921958"
+        "commit": "24b116213ce6836f0aca310325ed037cedaaf616"
       }
     },
     "repos": [

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -74,6 +74,12 @@ type LocaleCustomization struct {
 type FirewallCustomization struct {
 	Ports    []string                       `json:"ports,omitempty" toml:"ports,omitempty"`
 	Services *FirewallServicesCustomization `json:"services,omitempty" toml:"services,omitempty"`
+	Sources  []FirewallSourceCustomization  `json:"sources,omitempty" toml:"sources,omitempty"`
+}
+
+type FirewallSourceCustomization struct {
+	Zone    string   `json:"zone,omitempty" toml:"zone,omitempty"`
+	Sources []string `json:"sources,omitempty" toml:"sources,omitempty"`
 }
 
 type FirewallServicesCustomization struct {
@@ -162,8 +168,8 @@ func (e *CustomizationError) Error() string {
 	return e.Message
 }
 
-//CheckCustomizations returns an error of type `CustomizationError`
-//if `c` has any customizations not specified in `allowed`
+// CheckCustomizations returns an error of type `CustomizationError`
+// if `c` has any customizations not specified in `allowed`
 func (c *Customizations) CheckAllowed(allowed ...string) error {
 	if c == nil {
 		return nil

--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -74,11 +74,11 @@ type LocaleCustomization struct {
 type FirewallCustomization struct {
 	Ports    []string                       `json:"ports,omitempty" toml:"ports,omitempty"`
 	Services *FirewallServicesCustomization `json:"services,omitempty" toml:"services,omitempty"`
-	Sources  []FirewallSourceCustomization  `json:"sources,omitempty" toml:"sources,omitempty"`
+	Zones    []FirewallZoneCustomization    `json:"zones,omitempty" toml:"zones,omitempty"`
 }
 
-type FirewallSourceCustomization struct {
-	Zone    string   `json:"zone,omitempty" toml:"zone,omitempty"`
+type FirewallZoneCustomization struct {
+	Name    *string  `json:"name,omitempty" toml:"name,omitempty"`
 	Sources []string `json:"sources,omitempty" toml:"sources,omitempty"`
 }
 

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -200,8 +200,8 @@ func tarPipelines(t *imageType, customizations *blueprint.Customizations, option
 	return pipelines, nil
 }
 
-//makeISORootPath return a path that can be used to address files and folders in
-//the root of the iso
+// makeISORootPath return a path that can be used to address files and folders in
+// the root of the iso
 func makeISORootPath(p string) string {
 	fullpath := path.Join("/run/install/repo", p)
 	return fmt.Sprintf("file://%s", fullpath)
@@ -497,11 +497,12 @@ func osPipeline(t *imageType,
 		// merge the user-provided firewall config with the default one
 		if fwStageOptions != nil {
 			fwStageOptions = &osbuild.FirewallStageOptions{
-				// Prefer the firewall ports and services settings provided
+				// Prefer the firewall ports, services and sources settings provided
 				// via BP customization.
 				Ports:            fwStageOptions.Ports,
 				EnabledServices:  fwStageOptions.EnabledServices,
 				DisabledServices: fwStageOptions.DisabledServices,
+				Sources:          fwStageOptions.Sources,
 				// Default zone can not be set using BP customizations, therefore
 				// default to the one provided in the default image configuration.
 				DefaultZone: firewallConfig.DefaultZone,

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -497,12 +497,12 @@ func osPipeline(t *imageType,
 		// merge the user-provided firewall config with the default one
 		if fwStageOptions != nil {
 			fwStageOptions = &osbuild.FirewallStageOptions{
-				// Prefer the firewall ports, services and sources settings provided
+				// Prefer the firewall ports, services and zone settings provided
 				// via BP customization.
 				Ports:            fwStageOptions.Ports,
 				EnabledServices:  fwStageOptions.EnabledServices,
 				DisabledServices: fwStageOptions.DisabledServices,
-				Sources:          fwStageOptions.Sources,
+				Zones:            fwStageOptions.Zones,
 				// Default zone can not be set using BP customizations, therefore
 				// default to the one provided in the default image configuration.
 				DefaultZone: firewallConfig.DefaultZone,

--- a/internal/distro/rhel8/stage_options.go
+++ b/internal/distro/rhel8/stage_options.go
@@ -76,11 +76,11 @@ func firewallStageOptions(firewall *blueprint.FirewallCustomization) *osbuild.Fi
 		options.DisabledServices = firewall.Services.Disabled
 	}
 
-	if len(firewall.Sources) != 0 {
-		for _, s := range firewall.Sources {
-			options.Sources = append(options.Sources, osbuild.FirewallSource{
-				Zone:    s.Zone,
-				Sources: s.Sources,
+	if len(firewall.Zones) != 0 {
+		for _, z := range firewall.Zones {
+			options.Zones = append(options.Zones, osbuild.FirewallZone{
+				Name:    *z.Name,
+				Sources: z.Sources,
 			})
 		}
 	}

--- a/internal/distro/rhel8/stage_options.go
+++ b/internal/distro/rhel8/stage_options.go
@@ -76,6 +76,15 @@ func firewallStageOptions(firewall *blueprint.FirewallCustomization) *osbuild.Fi
 		options.DisabledServices = firewall.Services.Disabled
 	}
 
+	if len(firewall.Sources) != 0 {
+		for _, s := range firewall.Sources {
+			options.Sources = append(options.Sources, osbuild.FirewallSource{
+				Zone:    s.Zone,
+				Sources: s.Sources,
+			})
+		}
+	}
+
 	return &options
 }
 

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -74,6 +74,14 @@ func osCustomizations(
 			options.EnabledServices = fw.Services.Enabled
 			options.DisabledServices = fw.Services.Disabled
 		}
+		if fw.Sources != nil {
+			for _, s := range fw.Sources {
+				options.Sources = append(options.Sources, osbuild.FirewallSource{
+					Zone:    s.Zone,
+					Sources: s.Sources,
+				})
+			}
+		}
 		osc.Firewall = &options
 	}
 

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -65,6 +65,7 @@ func osCustomizations(
 		osc.DefaultTarget = *imageConfig.DefaultTarget
 	}
 
+	osc.Firewall = imageConfig.Firewall
 	if fw := c.GetFirewall(); fw != nil {
 		options := osbuild.FirewallStageOptions{
 			Ports: fw.Ports,
@@ -74,11 +75,11 @@ func osCustomizations(
 			options.EnabledServices = fw.Services.Enabled
 			options.DisabledServices = fw.Services.Disabled
 		}
-		if fw.Sources != nil {
-			for _, s := range fw.Sources {
-				options.Sources = append(options.Sources, osbuild.FirewallSource{
-					Zone:    s.Zone,
-					Sources: s.Sources,
+		if fw.Zones != nil {
+			for _, z := range fw.Zones {
+				options.Zones = append(options.Zones, osbuild.FirewallZone{
+					Name:    *z.Name,
+					Sources: z.Sources,
 				})
 			}
 		}
@@ -163,7 +164,6 @@ func osCustomizations(
 	osc.RHSMConfig = imageConfig.RHSMConfig
 	osc.Subscription = options.Subscription
 	osc.WAAgentConfig = imageConfig.WAAgentConfig
-	osc.Firewall = imageConfig.Firewall
 	osc.UdevRules = imageConfig.UdevRules
 	osc.GCPGuestAgentConfig = imageConfig.GCPGuestAgentConfig
 

--- a/internal/osbuild/firewall_stage.go
+++ b/internal/osbuild/firewall_stage.go
@@ -1,19 +1,32 @@
 package osbuild
 
+import "fmt"
+
 type FirewallStageOptions struct {
-	Ports            []string         `json:"ports,omitempty"`
-	EnabledServices  []string         `json:"enabled_services,omitempty"`
-	DisabledServices []string         `json:"disabled_services,omitempty"`
-	DefaultZone      string           `json:"default_zone,omitempty"`
-	Sources          []FirewallSource `json:"sources,omitempty"`
+	Ports            []string       `json:"ports,omitempty"`
+	EnabledServices  []string       `json:"enabled_services,omitempty"`
+	DisabledServices []string       `json:"disabled_services,omitempty"`
+	DefaultZone      string         `json:"default_zone,omitempty"`
+	Zones            []FirewallZone `json:"zones,omitempty"`
 }
 
-type FirewallSource struct {
-	Zone    string   `json:"zone,omitempty"`
+type FirewallZone struct {
+	Name    string   `json:"name,omitempty"`
 	Sources []string `json:"sources,omitempty"`
 }
 
 func (FirewallStageOptions) isStageOptions() {}
+
+func (o FirewallStageOptions) validate() error {
+	if len(o.Zones) != 0 {
+		for _, fz := range o.Zones {
+			if fz.Name == "" || len(fz.Sources) == 0 {
+				return fmt.Errorf("items in firewall Zones cannot be empty, provide a non-empty 'Name' and a list of 'Sources'")
+			}
+		}
+	}
+	return nil
+}
 
 func NewFirewallStage(options *FirewallStageOptions) *Stage {
 	return &Stage{

--- a/internal/osbuild/firewall_stage.go
+++ b/internal/osbuild/firewall_stage.go
@@ -1,10 +1,16 @@
 package osbuild
 
 type FirewallStageOptions struct {
-	Ports            []string `json:"ports,omitempty"`
-	EnabledServices  []string `json:"enabled_services,omitempty"`
-	DisabledServices []string `json:"disabled_services,omitempty"`
-	DefaultZone      string   `json:"default_zone,omitempty"`
+	Ports            []string         `json:"ports,omitempty"`
+	EnabledServices  []string         `json:"enabled_services,omitempty"`
+	DisabledServices []string         `json:"disabled_services,omitempty"`
+	DefaultZone      string           `json:"default_zone,omitempty"`
+	Sources          []FirewallSource `json:"sources,omitempty"`
+}
+
+type FirewallSource struct {
+	Zone    string   `json:"zone,omitempty"`
+	Sources []string `json:"sources,omitempty"`
 }
 
 func (FirewallStageOptions) isStageOptions() {}

--- a/internal/osbuild/firewall_stage_test.go
+++ b/internal/osbuild/firewall_stage_test.go
@@ -14,3 +14,14 @@ func TestNewFirewallStage(t *testing.T) {
 	actualFirewall := NewFirewallStage(&FirewallStageOptions{})
 	assert.Equal(t, expectedFirewall, actualFirewall)
 }
+
+func TestFirewallStageZones_ValidateInvalid(t *testing.T) {
+	options := FirewallStageOptions{}
+	var sources []string
+	options.Zones = append(options.Zones, FirewallZone{
+		Name:    "",
+		Sources: sources,
+	})
+	assert := assert.New(t)
+	assert.Error(options.validate())
+}

--- a/test/cases/ostree.sh
+++ b/test/cases/ostree.sh
@@ -10,6 +10,9 @@ if [[ ${ID} == "rhel" ]] && ! sudo subscription-manager status; then
     source /usr/libexec/osbuild-composer-test/define-compose-url.sh
 fi
 
+# Set up variables.
+FIREWALL_FEATURE="false"
+
 # Provision the software under test.
 /usr/libexec/osbuild-composer-test/provision.sh none
 

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -8,6 +8,7 @@
     embeded_container: "false"
     total_counter: "0"
     failed_counter: "0"
+    firewall_feature: "false"
 
   tasks:
     # current target host's IP address

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -816,6 +816,33 @@
         - skip_rollback_test == "false"
         - result_rollback is succeeded
 
+    # case: checking firewall customizations
+    - name: Check applied firewall customizations
+      block:
+        - name: Ensure firewall customizations applied from blueprint in trusted zone
+          command: firewall-cmd --info-zone=trusted
+          register: result_trusted_zone
+          become: yes
+        - name: Ensure firewall customizations applied from blueprint in work zone
+          command: firewall-cmd --info-zone=work
+          register: result_work_zone
+          become: yes
+
+        - assert:
+            that:
+              - "'192.168.100.51' in result_trusted_zone.stdout"
+              - "'192.168.100.52' in result_work_zone.stdout"
+            fail_msg: "No firewall customizations found"
+            success_msg: "Firewall customizations added from blueprint"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: firewall_feature == "true"
+
     - assert:
         that:
           - failed_counter == "0"


### PR DESCRIPTION
~~Requires https://github.com/osbuild/osbuild/pull/1137~~ (see below)

This patch adds support to specify firewalld sources for zones

(will add tests asap)

Signed-off-by: Antonio Murdaca <runcom@linux.com>

---
osbuild-composer counterpart to osbuild/osbuild#1157.

Signed-off-by: Irene Diez <idiez@redhat.com>

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
