### PR TITLE
enable persistent logging on ostree images

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -697,6 +697,28 @@
             failed_counter: "{{ failed_counter | int + 1 }}"
       when: skip_rollback_test == "false"
 
+    - name: check journald has persistent logging
+      block:
+        - name: lsit boots
+          shell: journalctl --list-boots
+          register: result_list_boots
+
+        - assert:
+            that:
+              - result_list_boots.stdout_lines | length > 1
+            fail_msg: "journald hasn't persistent logging"
+            success_msg: "journald has persistent logging"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - skip_rollback_test == "false"
+        - result_rollback is succeeded
+
     # case: check ostree commit after rollback
     - name: check ostree commit after rollback
       block:


### PR DESCRIPTION
building a r4e image results in no persistent logging on the system (which is highly surprising). This is because journal isn't configured to do persistent logging nor /var/log/journal is in the ostree (which is a trigger for journald to start logging in persistent mode, yeah, this is also kind of surprising).
This patch makes ostree deploy create that directory too and I can verify logs is present on a booted r4e image installed via simplified installer.

coreos* images ship a postprocess script to enable the config option instead https://pagure.io/workstation-ostree-config/blob/main/f/fedora-common-ostree.yaml#_100

cc @cgwalters

Signed-off-by: Antonio Murdaca <runcom@linux.com>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
