### PR TITLE
Use FDO AIO server for testing

### DIFF
--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -46,24 +46,19 @@
     - set_fact:
         checking_stage: "{{ result_stage.stdout }}"
 
-    # case: check /boot/device-credentials exists
-    # simplified installer installed Edge system ONLY
-    - name: check /boot/device-credentials exists
-      stat:
-        path: /boot/device-credentials
-      register: stat_result
-
-    - name: check commit deployed and built
+    - name: wait for FDO onboarding
       block:
-        - assert:
-            that:
-              - stat_result.stat.exists
-            fail_msg: "/boot/device-credentials does not exist"
-            success_msg: "/boot/device-credentials exists"
+        - wait_for:
+            path:  "/etc/device-credentials"
+            delay: 10
+            timeout: 600
+            state: present
+            msg: "FDO onboarding credentials not created"
       always:
         - set_fact:
             total_counter: "{{ total_counter | int + 1 }}"
       rescue:
+        # TODO: gather fdo-client-linuxapp.service logs
         - name: failed count + 1
           set_fact:
             failed_counter: "{{ failed_counter | int + 1 }}"


### PR DESCRIPTION
waiting for our CD to deliver aio images https://github.com/fedora-iot/fido-device-onboard-rs/pull/335 then changing the tag to something other than latest and updating the name of the image to just `aio`

Signed-off-by: Antonio Murdaca <runcom@linux.com>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
