### PR TITLE
rhel9+rhel8/pipelines: add systemd_journald_stage

### DIFF
--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -1007,6 +1007,17 @@ func ostreeDeployPipeline(
 			},
 		},
 	))
+
+	p.AddStage(osbuild.NewSystemdJournaldStage(
+		&osbuild.SystemdJournaldStageOptions{
+			Filename: "10-persistent.conf",
+			Config: osbuild.SystemdJournaldConfigDropin{
+				Journal: osbuild.SystemdJournaldConfigJournalSection{
+					Storage: common.StringToPtr("persistent"),
+				},
+			},
+		},
+	))
 	return p
 }
 

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -1003,6 +1003,17 @@ func ostreeDeployPipeline(
 			},
 		},
 	))
+
+	p.AddStage(osbuild.NewSystemdJournaldStage(
+		&osbuild.SystemdJournaldStageOptions{
+			Filename: "10-persistent.conf",
+			Config: osbuild.SystemdJournaldConfigDropin{
+				Journal: osbuild.SystemdJournaldConfigJournalSection{
+					Storage: common.StringToPtr("persistent"),
+				},
+			},
+		},
+	))
 	return p
 }
 

--- a/internal/osbuild/systemd_journald_stage.go
+++ b/internal/osbuild/systemd_journald_stage.go
@@ -1,0 +1,64 @@
+package osbuild
+
+import (
+	"fmt"
+)
+
+type SystemdJournaldStageOptions struct {
+	Filename string                      `json:"filename"`
+	Config   SystemdJournaldConfigDropin `json:"config"`
+}
+
+func (SystemdJournaldStageOptions) isStageOptions() {}
+
+func (o SystemdJournaldStageOptions) validate() error {
+	if o.Config.Journal == (SystemdJournaldConfigJournalSection{}) {
+		return fmt.Errorf("the 'Journal' section is required")
+	}
+	if o.Config.Journal.Storage == nil && o.Config.Journal.Compress == nil && o.Config.Journal.SplitMode == nil && o.Config.Journal.MaxFileSec == nil && o.Config.Journal.MaxRetentionSec == nil && o.Config.Journal.SyncIntervalSec == nil && o.Config.Journal.Audit == nil {
+		return fmt.Errorf("at least one 'Journal' section must be specified")
+	}
+	return nil
+}
+
+func NewSystemdJournaldStage(options *SystemdJournaldStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+	return &Stage{
+		Type:    "org.osbuild.systemd-journald",
+		Options: options,
+	}
+}
+
+type SystemdJournaldConfigDropin struct {
+	Journal SystemdJournaldConfigJournalSection `json:"Journal"`
+}
+
+// 'Journal' configuration section, at least one option must be specified
+type SystemdJournaldConfigJournalSection struct {
+	// Controls where to store journal data.
+	Storage *string `json:"Storage,omitempty"`
+
+	// Sets whether the data objects stored in the journal should be
+	// compressed or not. Can also take threshold values.
+	Compress *string `json:"Compress,omitempty"`
+
+	// Splits journal files per user or to a single file.
+	SplitMode *string `json:"SplitMode,omitempty"`
+
+	// Max time to store entries in a single file. By default seconds, may be
+	// sufixed with units (year, month, week, day, h, m) to override this.
+	MaxFileSec *string `json:"MaxFileSec,omitempty"`
+
+	// Maximum time to store journal entries. By default seconds, may be sufixed
+	// with units (year, month, week, day, h, m) to override this.
+	MaxRetentionSec *string `json:"MaxRetentionSec,omitempty"`
+
+	// Timeout before synchronizing journal files to disk. Minimum 0.
+	SyncIntervalSec *int `json:"SyncIntervalSec,omitempty"`
+
+	// Enables/Disables kernel auditing on start-up, leaves it as is if
+	// unspecified.
+	Audit *string `json:"Audit,omitempty"`
+}

--- a/internal/osbuild/systemd_journald_stage_test.go
+++ b/internal/osbuild/systemd_journald_stage_test.go
@@ -1,0 +1,54 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSystemdJournalStage(t *testing.T) {
+	options := &SystemdJournaldStageOptions{
+		Filename: "journald-config.conf",
+		Config: SystemdJournaldConfigDropin{
+			Journal: SystemdJournaldConfigJournalSection{
+				Storage:    common.StringToPtr("persistent"),
+				Compress:   common.StringToPtr("yes"),
+				MaxFileSec: common.StringToPtr("10day"),
+				Audit:      common.StringToPtr("yes"),
+			},
+		}}
+	expectedStage := &Stage{
+		Type:    "org.osbuild.systemd-journald",
+		Options: options,
+	}
+	actualStage := NewSystemdJournaldStage(options)
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestSystemdJournaldStage_ValidateInvalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		options SystemdJournaldStageOptions
+	}{
+		{
+			name:    "empty-options",
+			options: SystemdJournaldStageOptions{},
+		},
+		{
+			name: "no-journal-section-options",
+			options: SystemdJournaldStageOptions{
+				Filename: "10-some-file.conf",
+				Config: SystemdJournaldConfigDropin{
+					Journal: SystemdJournaldConfigJournalSection{},
+				},
+			},
+		},
+	}
+	for idx, te := range tests {
+		t.Run(te.name, func(t *testing.T) {
+			assert.Errorf(t, te.options.validate(), "%q didn't return an error [idx: %d]", te.name, idx)
+			assert.Panics(t, func() { NewSystemdJournaldStage(&te.options) })
+		})
+	}
+}

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -692,6 +692,28 @@
             failed_counter: "{{ failed_counter | int + 1 }}"
       when: skip_rollback_test == "false"
 
+    - name: check journald has persistent logging
+      block:
+        - name: lsit boots
+          shell: journalctl --list-boots
+          register: result_list_boots
+
+        - assert:
+            that:
+              - result_list_boots.stdout_lines | length > 1
+            fail_msg: "journald hasn't persistent logging"
+            success_msg: "journald has persistent logging"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - skip_rollback_test == "false"
+        - result_rollback is succeeded
+
     # case: check ostree commit after rollback
     - name: check ostree commit after rollback
       block:

--- a/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_raw_image-boot.json
@@ -2576,6 +2576,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -10031,6 +10042,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -33,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -2614,6 +2615,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -16977,6 +16989,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_raw_image-boot.json
@@ -2625,6 +2625,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -10184,6 +10195,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -33,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -2679,6 +2680,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -17291,6 +17303,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_raw_image-boot.json
@@ -2490,6 +2490,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -8652,6 +8663,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
@@ -33,6 +33,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -2536,6 +2537,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -15562,6 +15574,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_raw_image-boot.json
@@ -2554,6 +2554,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -8833,6 +8844,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
@@ -39,6 +39,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -2600,6 +2601,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -15859,6 +15871,5 @@
         "check_gpg": true
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_raw_image-boot.json
@@ -1094,6 +1094,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -7905,6 +7916,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
@@ -31,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -1112,6 +1113,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -12721,6 +12733,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_raw_image-boot.json
@@ -1113,6 +1113,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -8022,6 +8033,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
@@ -31,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -1137,6 +1138,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -12951,6 +12963,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_raw_image-boot.json
@@ -1094,6 +1094,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -7905,6 +7916,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -31,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -1112,6 +1113,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -12721,6 +12733,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_raw_image-boot.json
@@ -1113,6 +1113,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -8022,6 +8033,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -31,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -1137,6 +1138,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -12951,6 +12963,5 @@
         "checksum": "sha256:340b3c65becfca3d39f2afeed9659505a33ee870270c4d115d9fefe8929ff806"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_raw_image-boot.json
@@ -1091,6 +1091,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },

--- a/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
@@ -1112,6 +1112,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },

--- a/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_raw_image-boot.json
@@ -1110,6 +1110,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },

--- a/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
@@ -1137,6 +1137,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },

--- a/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_raw_image-boot.json
@@ -1063,6 +1063,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -6714,6 +6725,5 @@
         "checksum": "sha256:d8e32be18055e46f26dece63f46d45738405618bf8b03c976c876c0c2cf2e4ed"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
@@ -31,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -1084,6 +1085,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -11512,6 +11524,5 @@
         "checksum": "sha256:d8e32be18055e46f26dece63f46d45738405618bf8b03c976c876c0c2cf2e4ed"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_raw_image-boot.json
@@ -1085,6 +1085,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },
@@ -6846,6 +6857,5 @@
         "checksum": "sha256:5ce0b29210f80ae4f1e44f0ca9ef44b806f1268ce3309c43a5f1fcda005c3344"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
@@ -31,6 +31,7 @@
       }
     }
   },
+  "no-image-info": true,
   "manifest": {
     "version": "2",
     "pipelines": [
@@ -1106,6 +1107,17 @@
               "deployment": {
                 "osname": "redhat",
                 "ref": "test/edge"
+              }
+            }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
               }
             }
           }
@@ -11723,6 +11735,5 @@
         "checksum": "sha256:5ce0b29210f80ae4f1e44f0ca9ef44b806f1268ce3309c43a5f1fcda005c3344"
       }
     ]
-  },
-  "no-image-info": true
+  }
 }

--- a/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_raw_image-boot.json
@@ -2674,6 +2674,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },

--- a/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
@@ -2723,6 +2723,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },

--- a/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_raw_image-boot.json
@@ -2723,6 +2723,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },

--- a/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
@@ -2772,6 +2772,17 @@
                 "ref": "test/edge"
               }
             }
+          },
+          {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
           }
         ]
       },


### PR DESCRIPTION
~~Adds the `systemd.journald-storage` stage to the `ostreeDeployPipeline` with the persistent option set. This stores the journald logs on disk.~~

Adds the `systemd-journald` stage (linked to osbuild/osbuild#1143). This allows to configure the config file of the same name.

Cherry-picked Antonio's (@runcom) commit which was made into a PR #3056 , so when/if this PR is merged we can close that one.

Signed-off-by: Irene Diez <idiez@redhat.com>


This pull request includes:

- [x] adequate testing for the new functionality or fixed issue: provided tests for the stage and more testing is done at #3056 
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

