### PR TITLE
check FDO onboarding creates users

### DIFF
--- a/schutzbot/deploy.sh
+++ b/schutzbot/deploy.sh
@@ -92,6 +92,7 @@ echo -e "fastestmirror=1" | sudo tee -a /etc/dnf/dnf.conf
 
 # TODO: include this in the jenkins runner (and split test/target machines out)
 sudo dnf -y install jq
+sudo pip install yq
 
 # fallback for gitlab
 GIT_COMMIT="${GIT_COMMIT:-${CI_COMMIT_SHA}}"

--- a/test/cases/ostree-simplified-installer.sh
+++ b/test/cases/ostree-simplified-installer.sh
@@ -291,6 +291,7 @@ sudo podman run -v "$PWD"/aio/:/aio:z \
 
 # TODO: tweak config aio/configs/serviceinfo_api_server.yml to test basic FDO functionalities
 #       like adding user/key/pwd, re-encryption, files, commands etc etc
+sudo yq -iy '.service_info.initial_user |= {username: "testuser", sshkeys: ["testkey1", "testkey2"]}' aio/configs/serviceinfo_api_server.yml
 
 greenprint "🔧 Prepare fdo AIO manufacturing DIUN"
 DIUN_PUB_KEY_ROOT_CERTS=$(sudo cat aio/keys/diun_cert.pem)

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -64,6 +64,39 @@
             failed_counter: "{{ failed_counter | int + 1 }}"
       when: fdo_credential == "true"
 
+    - name: Check that the testuser FDO user is present
+      block:
+        - getent:
+            database: passwd
+            key: testuser
+            fail_key: true
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: fdo_credential == "true"
+
+    - name: Check that testuser's ssh keys are present
+      block:
+        - lineinfile:
+            path: /home/testuser/.ssh/authorized_keys
+            line: "testkey1"
+            state: present
+          check_mode: yes
+          register: presence
+          failed_when: (presence is changed) or (presence is failed)
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when: fdo_credential == "true"
+
     # case: check ostree commit correctly updated
     - name: get deployed ostree commit
       shell: rpm-ostree status --json | jq -r '.deployments[0].checksum'


### PR DESCRIPTION
Build on top of https://github.com/osbuild/osbuild-composer/pull/3068 to setup FDO to create a user and check it exists after onbording.

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
