### PR TITLE
schutzbot/update_github_status: fix release fast-forwarding

### DIFF
--- a/schutzbot/update_github_status.sh
+++ b/schutzbot/update_github_status.sh
@@ -42,7 +42,10 @@ curl \
 
 # ff release branch on github if this ran on main
 if [ "$CI_COMMIT_BRANCH" = "main" ] && [ "$GITHUB_NEW_STATE" = "success" ]; then
-    git remote add github "https://${SCHUTZBOT_LOGIN#*:}@github.com/osbuild/osbuild-composer.git"
+    if [ ! -d "release-ff-clone" ]; then
+        git clone --bare "https://${SCHUTZBOT_LOGIN#*:}@github.com/osbuild/osbuild-composer.git" release-ff-clone
+    fi
+    git -C release-ff-clone fetch origin
     # || true to ignore non fast-forwards
-    git push github "${CI_COMMIT_SHA}:refs/heads/release" || true
+    git -C release-ff-clone push origin "${CI_COMMIT_SHA}:refs/heads/release" || true
 fi


### PR DESCRIPTION
The checkout in the working directory is a shallow clone with gitlab as a remote. As a result fast-forwarding failed due to not recognizing the remote release branch as an ancestor of $CI_COMMIT_SHA.

This clones (with `--bare`) the github remote in a separate directory. It should not be necessary to remove the release-ff-clone directory each time, simply fetch if it already exists.

