### PR TITLE
osbuild: add masked services to systemd stage

### DIFF
--- a/internal/osbuild/systemd_stage.go
+++ b/internal/osbuild/systemd_stage.go
@@ -3,6 +3,7 @@ package osbuild
 type SystemdStageOptions struct {
 	EnabledServices  []string `json:"enabled_services,omitempty"`
 	DisabledServices []string `json:"disabled_services,omitempty"`
+	MaskedServices   []string `json:"masked_services,omitempty"`
 	DefaultTarget    string   `json:"default_target,omitempty"`
 }
 


### PR DESCRIPTION
The feature was included in the osbuild stage and was never added to composer.