### PR TITLE
spec: Fix ownership of the dnf-json rpmmd files

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -350,6 +350,12 @@ The dnf-json binary used by osbuild-composer and the workers.
 %files dnf-json
 %{_libexecdir}/osbuild-composer/dnf-json
 
+%post dnf-json
+# Fix ownership of the rpmmd cache files from previous versions where it was owned by root:root
+if [ -e /var/cache/osbuild-composer/rpmmd ]; then
+    chown -f -R --from root:root _osbuild-composer:_osbuild-composer /var/cache/osbuild-composer/rpmmd
+fi
+
 %if %{with tests} || 0%{?rhel}
 
 %package tests


### PR DESCRIPTION
dnf-json previously ran as a service, and the
/var/cache/osbuild-composer/rpmmd directory and files were owned by root. As a script called from osbuild-composer those directories and files need to be owned by _osbuild-composer:_osbuild-composer, otherwise it will not be able to depsolve after an upgrade from the previous implementation.

This can be worked around by removing the
/var/cache/osbuild-composer/rpmmd directory and restarting the service or rebooting.

Fixes #3079


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
