### PR TITLE
simplified-installer: do not mandate FDO section in simplified provisioning

### DIFF
--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -380,3 +380,7 @@ func (c *Customizations) GetOpenSCAP() *OpenSCAPCustomization {
 	}
 	return c.OpenSCAP
 }
+
+func (f *FDOCustomization) HasFDO() bool {
+	return f != nil
+}

--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -606,24 +606,24 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 			if customizations.GetInstallationDevice() == "" {
 				return fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
 			}
-			if customizations.GetFDO() == nil {
-				return fmt.Errorf("boot ISO image type %q requires specifying FDO configuration to install to", t.name)
-			}
-			if customizations.GetFDO().ManufacturingServerURL == "" {
-				return fmt.Errorf("boot ISO image type %q requires specifying FDO.ManufacturingServerURL configuration to install to", t.name)
-			}
-			var diunSet int
-			if customizations.GetFDO().DiunPubKeyHash != "" {
-				diunSet++
-			}
-			if customizations.GetFDO().DiunPubKeyInsecure != "" {
-				diunSet++
-			}
-			if customizations.GetFDO().DiunPubKeyRootCerts != "" {
-				diunSet++
-			}
-			if diunSet != 1 {
-				return fmt.Errorf("boot ISO image type %q requires specifying one of [FDO.DiunPubKeyHash,FDO.DiunPubKeyInsecure,FDO.DiunPubKeyRootCerts] configuration to install to", t.name)
+			//making fdo optional so that simplified installer can be composed w/o the FDO section in the blueprint
+			if customizations.GetFDO() != nil {
+				if customizations.GetFDO().ManufacturingServerURL == "" {
+					return fmt.Errorf("boot ISO image type %q requires specifying FDO.ManufacturingServerURL configuration to install to", t.name)
+				}
+				var diunSet int
+				if customizations.GetFDO().DiunPubKeyHash != "" {
+					diunSet++
+				}
+				if customizations.GetFDO().DiunPubKeyInsecure != "" {
+					diunSet++
+				}
+				if customizations.GetFDO().DiunPubKeyRootCerts != "" {
+					diunSet++
+				}
+				if diunSet != 1 {
+					return fmt.Errorf("boot ISO image type %q requires specifying one of [FDO.DiunPubKeyHash,FDO.DiunPubKeyInsecure,FDO.DiunPubKeyRootCerts] configuration to install to", t.name)
+				}
 			}
 		} else if t.name == "edge-installer" {
 			allowed := []string{"User", "Group"}

--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -899,7 +899,7 @@ func simplifiedInstallerTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.
 		"coreos-installer",
 		"fdo",
 	})
-	if fdo.DiunPubKeyRootCerts != "" {
+	if fdo.HasFDO() && fdo.DiunPubKeyRootCerts != "" {
 		p.AddStage(osbuild.NewFDOStageForRootCerts(fdo.DiunPubKeyRootCerts))
 		dracutStageOptions.Install = []string{"/fdo_diun_pub_key_root_certs.pem"}
 	}

--- a/internal/distro/rhel8/stage_options.go
+++ b/internal/distro/rhel8/stage_options.go
@@ -236,17 +236,18 @@ func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVers
 		Vendor:        vendor,
 	}
 
-	grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.manufacturing_server_url="+fdo.ManufacturingServerURL)
-	if fdo.DiunPubKeyInsecure != "" {
-		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_insecure="+fdo.DiunPubKeyInsecure)
+	if fdo.HasFDO() {
+		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.manufacturing_server_url="+fdo.ManufacturingServerURL)
+		if fdo.DiunPubKeyInsecure != "" {
+			grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_insecure="+fdo.DiunPubKeyInsecure)
+		}
+		if fdo.DiunPubKeyHash != "" {
+			grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_hash="+fdo.DiunPubKeyHash)
+		}
+		if fdo.DiunPubKeyRootCerts != "" {
+			grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_root_certs=/fdo_diun_pub_key_root_certs.pem")
+		}
 	}
-	if fdo.DiunPubKeyHash != "" {
-		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_hash="+fdo.DiunPubKeyHash)
-	}
-	if fdo.DiunPubKeyRootCerts != "" {
-		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_root_certs=/fdo_diun_pub_key_root_certs.pem")
-	}
-
 	return grubISOStageOptions
 }
 

--- a/internal/distro/rhel9/distro.go
+++ b/internal/distro/rhel9/distro.go
@@ -572,24 +572,24 @@ func (t *imageType) checkOptions(customizations *blueprint.Customizations, optio
 			if customizations.GetInstallationDevice() == "" {
 				return fmt.Errorf("boot ISO image type %q requires specifying an installation device to install to", t.name)
 			}
-			if customizations.GetFDO() == nil {
-				return fmt.Errorf("boot ISO image type %q requires specifying FDO configuration to install to", t.name)
-			}
-			if customizations.GetFDO().ManufacturingServerURL == "" {
-				return fmt.Errorf("boot ISO image type %q requires specifying FDO.ManufacturingServerURL configuration to install to", t.name)
-			}
-			var diunSet int
-			if customizations.GetFDO().DiunPubKeyHash != "" {
-				diunSet++
-			}
-			if customizations.GetFDO().DiunPubKeyInsecure != "" {
-				diunSet++
-			}
-			if customizations.GetFDO().DiunPubKeyRootCerts != "" {
-				diunSet++
-			}
-			if diunSet != 1 {
-				return fmt.Errorf("boot ISO image type %q requires specifying one of [FDO.DiunPubKeyHash,FDO.DiunPubKeyInsecure,FDO.DiunPubKeyRootCerts] configuration to install to", t.name)
+			//making fdo optional so that simplified installer can be composed w/o the FDO section in the blueprint
+			if customizations.GetFDO() != nil {
+				if customizations.GetFDO().ManufacturingServerURL == "" {
+					return fmt.Errorf("boot ISO image type %q requires specifying FDO.ManufacturingServerURL configuration to install to", t.name)
+				}
+				var diunSet int
+				if customizations.GetFDO().DiunPubKeyHash != "" {
+					diunSet++
+				}
+				if customizations.GetFDO().DiunPubKeyInsecure != "" {
+					diunSet++
+				}
+				if customizations.GetFDO().DiunPubKeyRootCerts != "" {
+					diunSet++
+				}
+				if diunSet != 1 {
+					return fmt.Errorf("boot ISO image type %q requires specifying one of [FDO.DiunPubKeyHash,FDO.DiunPubKeyInsecure,FDO.DiunPubKeyRootCerts] configuration to install to", t.name)
+				}
 			}
 		} else if t.name == "edge-installer" {
 			allowed := []string{"User", "Group"}

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -898,7 +898,7 @@ func simplifiedInstallerTreePipeline(repos []rpmmd.RepoConfig, packages []rpmmd.
 		"coreos-installer",
 		"fdo",
 	})
-	if fdo.DiunPubKeyRootCerts != "" {
+	if fdo.HasFDO() && fdo.DiunPubKeyRootCerts != "" {
 		p.AddStage(osbuild.NewFDOStageForRootCerts(fdo.DiunPubKeyRootCerts))
 		dracutStageOptions.Install = []string{"/fdo_diun_pub_key_root_certs.pem"}
 	}

--- a/internal/distro/rhel9/stage_options.go
+++ b/internal/distro/rhel9/stage_options.go
@@ -235,16 +235,17 @@ func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVers
 		Architectures: architectures,
 		Vendor:        vendor,
 	}
-
-	grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.manufacturing_server_url="+fdo.ManufacturingServerURL)
-	if fdo.DiunPubKeyInsecure != "" {
-		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_insecure="+fdo.DiunPubKeyInsecure)
-	}
-	if fdo.DiunPubKeyHash != "" {
-		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_hash="+fdo.DiunPubKeyHash)
-	}
-	if fdo.DiunPubKeyRootCerts != "" {
-		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_root_certs=/fdo_diun_pub_key_root_certs.pem")
+	if fdo.HasFDO() {
+		grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.manufacturing_server_url="+fdo.ManufacturingServerURL)
+		if fdo.DiunPubKeyInsecure != "" {
+			grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_insecure="+fdo.DiunPubKeyInsecure)
+		}
+		if fdo.DiunPubKeyHash != "" {
+			grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_hash="+fdo.DiunPubKeyHash)
+		}
+		if fdo.DiunPubKeyRootCerts != "" {
+			grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.diun_pub_key_root_certs=/fdo_diun_pub_key_root_certs.pem")
+		}
 	}
 
 	return grubISOStageOptions


### PR DESCRIPTION
This pull request includes changes so that:
 - simplified installer iso can be build without mentioning FDO section in the blueprint.
 - change done for rhel8 and rhel9 distros.
 - test case added for this use case in test/case/ostree-simplified-installer.sh
 
- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
