### PR TITLE
internal/cloudapi: add ostree options for all otree image types

### DIFF
--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -289,18 +289,19 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 
 		var ostreeOptions *ostree.RequestParams
 		// assume it's an ostree image if the type has a default ostree ref
-		if imageType.OSTreeRef() != "" && ir.Ostree != nil {
+		if imageType.OSTreeRef() != "" {
 			ostreeOptions = &ostree.RequestParams{}
-			if ir.Ostree.Ref != nil {
-				ostreeOptions.Ref = *ir.Ostree.Ref
+			if ir.Ostree != nil {
+				if ir.Ostree.Ref != nil {
+					ostreeOptions.Ref = *ir.Ostree.Ref
+				}
+				if ir.Ostree.Url != nil {
+					ostreeOptions.URL = *ir.Ostree.Url
+				}
+				if ir.Ostree.Parent != nil {
+					ostreeOptions.Parent = *ir.Ostree.Parent
+				}
 			}
-			if ir.Ostree.Url != nil {
-				ostreeOptions.URL = *ir.Ostree.Url
-			}
-			if ir.Ostree.Parent != nil {
-				ostreeOptions.Parent = *ir.Ostree.Parent
-			}
-
 			if ostreeOptions.Ref == "" {
 				ostreeOptions.Ref = imageType.OSTreeRef()
 			}

--- a/internal/cloudapi/v2/v2_test.go
+++ b/internal/cloudapi/v2/v2_test.go
@@ -713,7 +713,7 @@ func TestComposeDependencyError(t *testing.T) {
 		"distribution": "%s",
 		"image_request":{
 			"architecture": "%s",
-			"image_type": "aws",
+			"image_type": "edge-commit",
                         "ostree": {
                                 "url": "somerepo.org",
                                 "ref": "test"

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -57,8 +57,9 @@ const (
 	TestArch2Name = "test_arch2"
 	TestArch3Name = "test_arch3"
 
-	TestImageTypeName  = "test_type"
-	TestImageType2Name = "test_type2"
+	TestImageTypeName   = "test_type"
+	TestImageType2Name  = "test_type2"
+	TestImageTypeOSTree = "test_ostree_type"
 
 	// added for cloudapi tests
 	TestImageTypeAmi            = "ami"
@@ -175,7 +176,10 @@ func (t *TestImageType) MIMEType() string {
 }
 
 func (t *TestImageType) OSTreeRef() string {
-	return t.architecture.distribution.OSTreeRef()
+	if t.name == TestImageTypeEdgeCommit || t.name == TestImageTypeEdgeInstaller || t.name == TestImageTypeOSTree {
+		return t.architecture.distribution.OSTreeRef()
+	}
+	return ""
 }
 
 func (t *TestImageType) Size(size uint64) uint64 {
@@ -322,7 +326,11 @@ func newTestDistro(name, modulePlatformID, releasever string) *TestDistro {
 		name: TestImageTypeGce,
 	}
 
-	ta1.addImageTypes(it1)
+	it11 := TestImageType{
+		name: TestImageTypeOSTree,
+	}
+
+	ta1.addImageTypes(it1, it11)
 	ta2.addImageTypes(it1, it2)
 	ta3.addImageTypes(it3, it4, it5, it6, it7, it8, it9, it10)
 


### PR DESCRIPTION
b01792d9dd8db737369dce28addb083391d192e6 broke this behaviour. All ostree image types should have an ostree resolve job.
