### PR TITLE
Fix loading cross distro compose results

### DIFF
--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/distro/fedora"
+	"github.com/osbuild/osbuild-composer/internal/distroregistry"
 	"github.com/osbuild/osbuild-composer/internal/dnfjson"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/store"
@@ -142,7 +143,8 @@ func main() {
 	}
 	rpmmdCache := path.Join(homeDir, ".cache/osbuild-composer/rpmmd")
 
-	s := store.New(&cwd, a, nil)
+	dr, _ := distroregistry.New(d, nil)
+	s := store.New(&cwd, dr, nil)
 	if s == nil {
 		panic("could not create store")
 	}

--- a/internal/distro/test_distro/distro.go
+++ b/internal/distro/test_distro/distro.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
+	"github.com/osbuild/osbuild-composer/internal/distroregistry"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 )
@@ -342,6 +343,18 @@ func newTestDistro(name, modulePlatformID, releasever string) *TestDistro {
 // New returns new instance of TestDistro named "test-distro".
 func New() *TestDistro {
 	return newTestDistro(TestDistroName, TestDistroModulePlatformID, TestDistroReleasever)
+}
+
+func NewRegistry() *distroregistry.Registry {
+	td := New()
+	registry, err := distroregistry.New(td, td)
+	if err != nil {
+		panic(err)
+	}
+
+	// Override the host's architecture name with the test's name
+	registry.SetHostArchName(TestArchName)
+	return registry
 }
 
 // New2 returns new instance of TestDistro named "test-distro-2".

--- a/internal/distroregistry/distroregistry.go
+++ b/internal/distroregistry/distroregistry.go
@@ -40,14 +40,16 @@ type supportedDistro struct {
 }
 
 type Registry struct {
-	distros    map[string]distro.Distro
-	hostDistro distro.Distro
+	distros      map[string]distro.Distro
+	hostDistro   distro.Distro
+	hostArchName string
 }
 
 func New(hostDistro distro.Distro, distros ...distro.Distro) (*Registry, error) {
 	reg := &Registry{
-		distros:    make(map[string]distro.Distro),
-		hostDistro: hostDistro,
+		distros:      make(map[string]distro.Distro),
+		hostDistro:   hostDistro,
+		hostArchName: common.CurrentArch(),
 	}
 	for _, d := range distros {
 		name := d.Name()
@@ -135,4 +137,14 @@ func mangleHostDistroName(name string, isBeta, isStream bool) string {
 // is e.g. a Beta or a Stream.
 func (r *Registry) FromHost() distro.Distro {
 	return r.hostDistro
+}
+
+// HostArchName returns the host's arch name
+func (r *Registry) HostArchName() string {
+	return r.hostArchName
+}
+
+// SetHostArchName can be used to override the host's arch name for testing
+func (r *Registry) SetHostArchName(name string) {
+	r.hostArchName = name
 }

--- a/internal/store/fixtures.go
+++ b/internal/store/fixtures.go
@@ -41,7 +41,8 @@ func FixtureBase() *Store {
 		},
 	}
 
-	d := test_distro.New()
+	dr := test_distro.NewRegistry()
+	d := dr.FromHost()
 	arch, err := d.GetArch(test_distro.TestArchName)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get architecture %s for a test distro: %v", test_distro.TestArchName, err))
@@ -54,7 +55,8 @@ func FixtureBase() *Store {
 	if err != nil {
 		panic(fmt.Sprintf("failed to create a manifest: %v", err))
 	}
-	s := New(nil, arch, nil)
+
+	s := New(nil, dr, nil)
 
 	pkgs := []rpmmd.PackageSpec{
 		{
@@ -176,7 +178,8 @@ func FixtureFinished() *Store {
 		},
 	}
 
-	d := test_distro.New()
+	dr := test_distro.NewRegistry()
+	d := dr.FromHost()
 	arch, err := d.GetArch(test_distro.TestArchName)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get architecture %s for a test distro: %v", test_distro.TestArchName, err))
@@ -189,7 +192,8 @@ func FixtureFinished() *Store {
 	if err != nil {
 		panic(fmt.Sprintf("failed to create a manifest: %v", err))
 	}
-	s := New(nil, arch, nil)
+
+	s := New(nil, dr, nil)
 
 	pkgs := []rpmmd.PackageSpec{
 		{
@@ -272,13 +276,14 @@ func FixtureEmpty() *Store {
 		Customizations: nil,
 	}
 
-	d := test_distro.New()
-	arch, err := d.GetArch(test_distro.TestArchName)
+	dr := test_distro.NewRegistry()
+	d := dr.FromHost()
+	_, err := d.GetArch(test_distro.TestArchName)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get architecture %s for a test distro: %v", test_distro.TestArchName, err))
 	}
 
-	s := New(nil, arch, nil)
+	s := New(nil, dr, nil)
 
 	s.blueprints[bName] = b
 
@@ -310,13 +315,14 @@ func FixtureOldChanges() *Store {
 		Customizations: nil,
 	}
 
-	d := test_distro.New()
-	arch, err := d.GetArch(test_distro.TestArchName)
+	dr := test_distro.NewRegistry()
+	d := dr.FromHost()
+	_, err := d.GetArch(test_distro.TestArchName)
 	if err != nil {
 		panic(fmt.Sprintf("failed to get architecture %s for a test distro: %v", test_distro.TestArchName, err))
 	}
 
-	s := New(nil, arch, nil)
+	s := New(nil, dr, nil)
 
 	s.PushBlueprint(b, "Initial commit")
 	b.Version = "0.0.1"

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/osbuild/osbuild-composer/internal/blueprint"
 	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/distroregistry"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
 	"github.com/osbuild/osbuild-composer/internal/target"
 
@@ -79,7 +80,7 @@ func (e *NoLocalTargetError) Error() string {
 	return e.message
 }
 
-func New(stateDir *string, arch distro.Arch, log *log.Logger) *Store {
+func New(stateDir *string, dr *distroregistry.Registry, log *log.Logger) *Store {
 	var storeStruct storeV0
 	var db *jsondb.JSONDatabase
 
@@ -91,7 +92,7 @@ func New(stateDir *string, arch distro.Arch, log *log.Logger) *Store {
 		}
 	}
 
-	store := newStoreFromV0(storeStruct, arch, log)
+	store := newStoreFromV0(storeStruct, dr, log)
 
 	store.stateDir = stateDir
 	store.db = db

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -133,10 +133,11 @@ func (suite *storeTest) SetupSuite() {
 //setup before each test
 func (suite *storeTest) SetupTest() {
 	distro := test_distro.New()
-	arch, err := distro.GetArch(test_distro.TestArchName)
+	_, err := distro.GetArch(test_distro.TestArchName)
 	suite.NoError(err)
 	suite.dir = suite.T().TempDir()
-	suite.myStore = New(&suite.dir, arch, nil)
+	dr := test_distro.NewRegistry()
+	suite.myStore = New(&suite.dir, dr, nil)
 }
 
 func (suite *storeTest) TestRandomSHA1String() {

--- a/internal/weldr/api.go
+++ b/internal/weldr/api.go
@@ -164,13 +164,12 @@ func New(repoPaths []string, stateDir string, solver *dnfjson.BaseSolver, dr *di
 		return nil, fmt.Errorf("error loading repository definitions: %v", err)
 	}
 
-	var hostArch distro.Arch
 	hostDistro := dr.GetDistro(hostDistroName)
 	if hostDistro != nil {
 		// get canonical distro name if the host distro is supported
 		hostDistroName = hostDistro.Name()
 
-		hostArch, err = hostDistro.GetArch(archName)
+		_, err = hostDistro.GetArch(archName)
 		if err != nil {
 			return nil, fmt.Errorf("Host distro does not support host architecture: %v", err)
 		}
@@ -185,7 +184,7 @@ func New(repoPaths []string, stateDir string, solver *dnfjson.BaseSolver, dr *di
 		log.Printf("host distro %q is not supported: only cross-distro builds are available", hostDistroName)
 	}
 
-	store := store.New(&stateDir, hostArch, logger)
+	store := store.New(&stateDir, dr, logger)
 	compatOutputDir := path.Join(stateDir, "outputs")
 
 	api := &API{


### PR DESCRIPTION
Fixes a problem with the store load not being able to load composes for other distros when the image type isn't supported on the host distro.

This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
