### PR TITLE
tools/provision.sh: copy RHEL repo overrides using wildcard

### DIFF
--- a/tools/provision.sh
+++ b/tools/provision.sh
@@ -140,11 +140,7 @@ else # AUTH_METHOD_NONE
     # Copy all fedora repo overrides
     sudo cp -a /usr/share/tests/osbuild-composer/repositories/{fedora,centos}-*.json "$REPODIR"
     # Copy RHEL point release repos
-    sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-85.json "$REPODIR"
-    sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-86.json "$REPODIR"
-    sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-87.json "$REPODIR"
-    sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-90.json "$REPODIR"
-    sudo cp /usr/share/tests/osbuild-composer/repositories/rhel-91.json "$REPODIR"
+    sudo cp -a /usr/share/tests/osbuild-composer/repositories/rhel-*.json "$REPODIR"
 
     # override source repositories to consume content from the nightly compose
     if [ "${NIGHTLY:=false}" == "true" ]; then


### PR DESCRIPTION
Don't list specific RHEL repos which should be copied over to the repo overrides directory, but instead copy all of them, similar to how it's done for Fedora and CentOS Stream. This is less error prone when support for a new RHEL release is added to composer.

This was forgotten as part of enabling RHEL 8.8 and 9.2.


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
