### PR TITLE
Create and add Journald stage to rhel8/9 pipeline

### DIFF
--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -664,6 +664,19 @@ func osPipeline(t *imageType,
 		}))
 	}
 
+	if t.rpmOstree {
+		p.AddStage(osbuild.NewSystemdJournaldStage(
+			&osbuild.SystemdJournaldStageOptions{
+				Filename: "10-persistent.conf",
+				Config: osbuild.SystemdJournaldConfigDropin{
+					Journal: osbuild.SystemdJournaldConfigJournalSection{
+						Storage: osbuild.StoragePresistent,
+					},
+				},
+			},
+		))
+	}
+
 	// Relabel the tree, unless the `NoSElinux` flag is explicitly set to `true`
 	if imageConfig.NoSElinux == nil || imageConfig.NoSElinux != nil && !*imageConfig.NoSElinux {
 		p.AddStage(osbuild.NewSELinuxStage(selinuxStageOptions(false)))

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -530,6 +530,18 @@ func (p *OS) serialize() osbuild.Pipeline {
 		}))
 	}
 
+	if p.OSTreeRef != "" {
+		pipeline.AddStage(osbuild.NewSystemdJournaldStage(
+			&osbuild.SystemdJournaldStageOptions{
+				Filename: "10-persistent.conf",
+				Config: osbuild.SystemdJournaldConfigDropin{
+					Journal: osbuild.SystemdJournaldConfigJournalSection{
+						Storage: osbuild.StoragePresistent,
+					},
+				},
+			}))
+	}
+
 	if p.SElinux != "" {
 		pipeline.AddStage(osbuild.NewSELinuxStage(&osbuild.SELinuxStageOptions{
 			FileContexts: fmt.Sprintf("etc/selinux/%s/contexts/files/file_contexts", p.SElinux),

--- a/internal/osbuild/systemd_journald_stage.go
+++ b/internal/osbuild/systemd_journald_stage.go
@@ -1,0 +1,92 @@
+package osbuild
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const configFilenameRegex = "^[a-zA-Z0-9_\\.-]{1,250}\\.conf$"
+
+type SystemdJournaldStageOptions struct {
+	Filename string                      `json:"filename"`
+	Config   SystemdJournaldConfigDropin `json:"config"`
+}
+
+func (SystemdJournaldStageOptions) isStageOptions() {}
+
+func (o SystemdJournaldStageOptions) validate() error {
+	filenameRegex := regexp.MustCompile(configFilenameRegex)
+	if !filenameRegex.MatchString(o.Filename) {
+		return fmt.Errorf("filename %q doesn't conform to schema (%s)", o.Filename, repoFilenameRegex)
+	}
+	if o.Config.Journal == (SystemdJournaldConfigJournalSection{}) {
+		return fmt.Errorf("the 'Journal' section is required")
+	}
+
+	return nil
+}
+
+func NewSystemdJournaldStage(options *SystemdJournaldStageOptions) *Stage {
+	if err := options.validate(); err != nil {
+		panic(err)
+	}
+	return &Stage{
+		Type:    "org.osbuild.systemd-journald",
+		Options: options,
+	}
+}
+
+type SystemdJournaldConfigDropin struct {
+	Journal SystemdJournaldConfigJournalSection `json:"Journal"`
+}
+
+type ConfigStorage string
+
+const (
+	StorageVolatile   ConfigStorage = "volatile"
+	StoragePresistent ConfigStorage = "persistent"
+	StorageAuto       ConfigStorage = "auto"
+	StorageNone       ConfigStorage = "none"
+)
+
+type ConfigSplitMode string
+
+const (
+	SplitUuid ConfigSplitMode = "uuid"
+	SplitNone ConfigSplitMode = "none"
+)
+
+type ConfigAudit string
+
+const (
+	AuditYes ConfigAudit = "yes"
+	AuditNo  ConfigAudit = "no"
+)
+
+// 'Journal' configuration section, at least one option must be specified
+type SystemdJournaldConfigJournalSection struct {
+	// Controls where to store journal data.
+	Storage ConfigStorage `json:"Storage,omitempty"`
+
+	// Sets whether the data objects stored in the journal should be
+	// compressed or not. Can also take threshold values.
+	Compress string `json:"Compress,omitempty"`
+
+	// Splits journal files per user or to a single file.
+	SplitMode ConfigSplitMode `json:"SplitMode,omitempty"`
+
+	// Max time to store entries in a single file. By default seconds, may be
+	// sufixed with units (year, month, week, day, h, m) to override this.
+	MaxFileSec string `json:"MaxFileSec,omitempty"`
+
+	// Maximum time to store journal entries. By default seconds, may be sufixed
+	// with units (year, month, week, day, h, m) to override this.
+	MaxRetentionSec string `json:"MaxRetentionSec,omitempty"`
+
+	// Timeout before synchronizing journal files to disk. Minimum 0.
+	SyncIntervalSec int `json:"SyncIntervalSec,omitempty"`
+
+	// Enables/Disables kernel auditing on start-up, leaves it as is if
+	// unspecified.
+	Audit ConfigAudit `json:"Audit,omitempty"`
+}

--- a/internal/osbuild/systemd_journald_stage_test.go
+++ b/internal/osbuild/systemd_journald_stage_test.go
@@ -1,0 +1,70 @@
+package osbuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSystemdJournalStage(t *testing.T) {
+	options := &SystemdJournaldStageOptions{
+		Filename: "journald-config.conf",
+		Config: SystemdJournaldConfigDropin{
+			Journal: SystemdJournaldConfigJournalSection{
+				Storage:    StoragePresistent,
+				Compress:   "yes",
+				MaxFileSec: "10day",
+				Audit:      AuditYes,
+			},
+		}}
+	expectedStage := &Stage{
+		Type:    "org.osbuild.systemd-journald",
+		Options: options,
+	}
+	actualStage := NewSystemdJournaldStage(options)
+	assert.Equal(t, expectedStage, actualStage)
+}
+
+func TestSystemdJournaldStage_ValidateInvalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		options SystemdJournaldStageOptions
+	}{
+		{
+			name:    "empty-options",
+			options: SystemdJournaldStageOptions{},
+		},
+		{
+			name: "no-journal-section-options",
+			options: SystemdJournaldStageOptions{
+				Filename: "10-some-file.conf",
+				Config: SystemdJournaldConfigDropin{
+					Journal: SystemdJournaldConfigJournalSection{},
+				},
+			},
+		},
+	}
+	for idx, te := range tests {
+		t.Run(te.name, func(t *testing.T) {
+			assert.Errorf(t, te.options.validate(), "%q didn't return an error [idx: %d]", te.name, idx)
+			assert.Panics(t, func() { NewSystemdJournaldStage(&te.options) })
+		})
+	}
+}
+
+func TestInvalidFilename(t *testing.T) {
+	options := &SystemdJournaldStageOptions{
+		Filename: "invalid-filename",
+		Config: SystemdJournaldConfigDropin{
+			Journal: SystemdJournaldConfigJournalSection{
+				Storage:    StoragePresistent,
+				Compress:   "yes",
+				MaxFileSec: "10day",
+				Audit:      AuditYes,
+			},
+		},
+	}
+
+	assert.Errorf(t, options.validate(), "test didn't return any error ")
+	assert.Panics(t, func() { NewSystemdJournaldStage(options) })
+}

--- a/test/data/ansible/check_ostree.yaml
+++ b/test/data/ansible/check_ostree.yaml
@@ -699,6 +699,28 @@
             failed_counter: "{{ failed_counter | int + 1 }}"
       when: skip_rollback_test == "false"
 
+    - name: check journald has persistent logging
+      block:
+        - name: lsit boots
+          shell: journalctl --list-boots
+          register: result_list_boots
+
+        - assert:
+            that:
+              - result_list_boots.stdout_lines | length > 1
+            fail_msg: "journald hasn't persistent logging"
+            success_msg: "journald has persistent logging"
+      always:
+        - set_fact:
+            total_counter: "{{ total_counter | int + 1 }}"
+      rescue:
+        - name: failed count + 1
+          set_fact:
+            failed_counter: "{{ failed_counter | int + 1 }}"
+      when:
+        - skip_rollback_test == "false"
+        - result_rollback is succeeded
+
     # case: check ostree commit after rollback
     - name: check ostree commit after rollback
       block:

--- a/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit-boot.json
@@ -5030,6 +5030,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_commit_with_container-boot.json
@@ -5287,6 +5287,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_container-boot.json
@@ -5030,6 +5030,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit-boot.json
@@ -5214,6 +5214,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_rt-boot.json
@@ -5205,6 +5205,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_commit_with_container-boot.json
@@ -5471,6 +5471,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_container-boot.json
@@ -5214,6 +5214,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit-boot.json
@@ -4304,6 +4304,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_commit_with_container-boot.json
@@ -4537,6 +4537,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_9-aarch64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_container-boot.json
@@ -4304,6 +4304,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit-boot.json
@@ -4520,6 +4520,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_rt-boot.json
@@ -4687,6 +4687,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_commit_with_container-boot.json
@@ -4753,6 +4753,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/centos_9-x86_64-edge_container-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_container-boot.json
@@ -4520,6 +4520,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_35-aarch64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_commit-boot.json
@@ -5167,6 +5167,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_35-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_commit_with_container-boot.json
@@ -5392,6 +5392,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_35-aarch64-iot_container-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_container-boot.json
@@ -5167,6 +5167,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_35-x86_64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_commit-boot.json
@@ -5279,6 +5279,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_35-x86_64-iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_commit_debug-boot.json
@@ -5286,6 +5286,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_35-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_commit_with_container-boot.json
@@ -5504,6 +5504,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_35-x86_64-iot_container-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_container-boot.json
@@ -5279,6 +5279,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_36-aarch64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_commit-boot.json
@@ -5399,6 +5399,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_commit_with_container-boot.json
@@ -5448,6 +5448,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_36-aarch64-iot_container-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_container-boot.json
@@ -5399,6 +5399,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_36-x86_64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_commit-boot.json
@@ -5519,6 +5519,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_36-x86_64-iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_commit_debug-boot.json
@@ -5526,6 +5526,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_commit_with_container-boot.json
@@ -5568,6 +5568,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_36-x86_64-iot_container-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_container-boot.json
@@ -5519,6 +5519,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_37-aarch64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_commit-boot.json
@@ -5469,6 +5469,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_commit_with_container-boot.json
@@ -5518,6 +5518,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_37-aarch64-iot_container-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_container-boot.json
@@ -5469,6 +5469,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_37-x86_64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_commit-boot.json
@@ -5589,6 +5589,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_37-x86_64-iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_commit_debug-boot.json
@@ -5596,6 +5596,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_commit_with_container-boot.json
@@ -5638,6 +5638,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_37-x86_64-iot_container-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_container-boot.json
@@ -5589,6 +5589,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_38-aarch64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_commit-boot.json
@@ -5301,6 +5301,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_commit_with_container-boot.json
@@ -5350,6 +5350,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_38-aarch64-iot_container-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_container-boot.json
@@ -5301,6 +5301,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_38-x86_64-iot_commit-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_commit-boot.json
@@ -5405,6 +5405,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_38-x86_64-iot_commit_debug-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_commit_debug-boot.json
@@ -5412,6 +5412,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_commit_with_container-boot.json
@@ -5454,6 +5454,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/fedora_38-x86_64-iot_container-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_container-boot.json
@@ -5405,6 +5405,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
@@ -1966,6 +1966,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
@@ -2088,6 +2088,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
@@ -1966,6 +1966,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
@@ -2045,6 +2045,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
@@ -2121,6 +2121,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
@@ -2167,6 +2167,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
@@ -2035,6 +2035,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit-boot.json
@@ -2030,6 +2030,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
@@ -2095,6 +2095,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_container-boot.json
@@ -2030,6 +2030,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit-boot.json
@@ -2109,6 +2109,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_rt-boot.json
@@ -2185,6 +2185,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
@@ -2174,6 +2174,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_container-boot.json
@@ -2099,6 +2099,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
@@ -1971,6 +1971,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
@@ -2105,6 +2105,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
@@ -1971,6 +1971,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
@@ -2050,6 +2050,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
@@ -2123,6 +2123,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
@@ -2184,6 +2184,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
@@ -2040,6 +2040,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
@@ -1966,6 +1966,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
@@ -2088,6 +2088,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
@@ -1966,6 +1966,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
@@ -2045,6 +2045,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
@@ -2121,6 +2121,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
@@ -2167,6 +2167,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
@@ -2035,6 +2035,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
@@ -1969,6 +1969,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
@@ -2091,6 +2091,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
@@ -1969,6 +1969,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
@@ -2048,6 +2048,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
@@ -2121,6 +2121,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
@@ -2170,6 +2170,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
@@ -2038,6 +2038,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
@@ -1969,6 +1969,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
@@ -2091,6 +2091,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
@@ -1969,6 +1969,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
@@ -2048,6 +2048,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
@@ -2118,6 +2118,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
@@ -2170,6 +2170,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
@@ -2038,6 +2038,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -1689,6 +1689,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
@@ -1802,6 +1802,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
@@ -1689,6 +1689,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -1777,6 +1777,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -1946,6 +1946,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
@@ -1890,6 +1890,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
@@ -1767,6 +1767,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
@@ -4496,6 +4496,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
@@ -4545,6 +4545,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
@@ -4496,6 +4496,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
@@ -4707,6 +4707,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
@@ -5138,6 +5138,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
@@ -4756,6 +4756,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
@@ -4696,6 +4696,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
@@ -4496,6 +4496,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
@@ -4545,6 +4545,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
@@ -4496,6 +4496,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
@@ -4707,6 +4707,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
@@ -5138,6 +5138,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
@@ -4756,6 +4756,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
@@ -4696,6 +4696,17 @@
             }
           },
           {
+            "type": "org.osbuild.systemd-journald",
+            "options": {
+              "filename": "10-persistent.conf",
+              "config": {
+                "Journal": {
+                  "Storage": "persistent"
+                }
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"


### PR DESCRIPTION
This pull request includes:
Adds the systemd-journald stage (linked to https://github.com/osbuild/osbuild/pull/1143). This allows to configure the config file of the same name.
Continuation from PR https://github.com/osbuild/osbuild-composer/pull/3069

 adequate testing for the new functionality or fixed issue
 adequate documentation informing people about the change such as
 submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as

opened this as accidentally closed: #3104 
