### PR TITLE
Use go install instead of deprecated go get

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,8 +74,8 @@ jobs:
         WORKDIR=$(readlink -f pkg/jobqueue/dbjobqueue/schemas)
         pushd $(mktemp -d)
         go mod init temp
-        go get -u github.com/jackc/tern
-        go run github.com/jackc/tern migrate -m "$WORKDIR"
+        go install github.com/jackc/tern@latest
+        $(go env GOPATH)/bin/tern migrate -m "$WORKDIR"
         popd
     - run: go test -tags=integration ./cmd/osbuild-composer-dbjobqueue-tests
     - run: go test -tags=integration ./cmd/osbuild-service-maintenance

--- a/distribution/Dockerfile-ubi
+++ b/distribution/Dockerfile-ubi
@@ -10,7 +10,7 @@ ENV GOFLAGS=-mod=vendor
 RUN go install ./cmd/osbuild-composer/
 
 FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder2
-RUN go get -u github.com/jackc/tern
+RUN go install github.com/jackc/tern@latest
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf install python3 python3-dnf

--- a/test/cases/api.sh
+++ b/test/cases/api.sh
@@ -126,9 +126,9 @@ sudo ${CONTAINER_RUNTIME} logs osbuild-composer-db
 pushd "$(mktemp -d)"
 sudo dnf install -y go
 go mod init temp
-go get github.com/jackc/tern
+go install github.com/jackc/tern@latest
 PGUSER=postgres PGPASSWORD=foobar PGDATABASE=osbuildcomposer PGHOST=localhost PGPORT=5432 \
-      go run github.com/jackc/tern migrate -m /usr/share/tests/osbuild-composer/schemas
+    "$(go env GOPATH)"/bin/tern migrate -m /usr/share/tests/osbuild-composer/schemas
 popd
 
 cat <<EOF | sudo tee "/etc/osbuild-composer/osbuild-composer.toml"

--- a/tools/prepare-source.sh
+++ b/tools/prepare-source.sh
@@ -6,8 +6,8 @@ GO_VERSION=1.16.12
 GO_BINARY=$(go env GOPATH)/bin/go$GO_VERSION
 
 # this is the official way to get a different version of golang
-# see https://golang.org/doc/install#extra_versions
-go get golang.org/dl/go$GO_VERSION
+# see https://go.dev/doc/manage-install
+go install golang.org/dl/go$GO_VERSION@latest
 $GO_BINARY download
 
 # ensure that go.mod and go.sum are up to date, ...


### PR DESCRIPTION
In go 1.18 'go install' needs to be used to install an executable. See https://go.dev/doc/go-get-install-deprecation and
https://go.dev/doc/manage-install


This pull request includes:

- [X] adequate testing for the new functionality or fixed issue
- [X] adequate documentation informing people about the change such as
