### PR TITLE
docker-compose: remove unavailable `--dnf-json`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,6 @@ services:
       [
         "python3",
         "/opt/entrypoint.py",
-        "--dnf-json",
         "--weldr-api",
         "--remote-worker-api",
         "--composer-api",


### PR DESCRIPTION
This removes the not-available `--dnf-json` argument in the `docker-compose.yml` file and closes #3063. 