### PR TITLE
simplified-installer: add 5 seconds grub timeout

### DIFF
--- a/internal/distro/rhel8/pipelines.go
+++ b/internal/distro/rhel8/pipelines.go
@@ -880,11 +880,13 @@ func simplifiedInstallerBootISOTreePipeline(archivePipelineName, kver string, rn
 	return p
 }
 
+const SIMPLIFIED_INSTALLER_GRUB_TIMEOUT = 5
+
 func simplifiedInstallerEFIBootTreePipeline(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel string, fdo *blueprint.FDOCustomization) *osbuild.Pipeline {
 	p := new(osbuild.Pipeline)
 	p.Name = "efiboot-tree"
 	p.Build = "name:build"
-	p.AddStage(osbuild.NewGrubISOStage(grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel, fdo)))
+	p.AddStage(osbuild.NewGrubISOStage(grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel, SIMPLIFIED_INSTALLER_GRUB_TIMEOUT, fdo)))
 	return p
 }
 

--- a/internal/distro/rhel8/stage_options.go
+++ b/internal/distro/rhel8/stage_options.go
@@ -206,7 +206,7 @@ func bootISOMonoStageOptions(kernelVer, arch, vendor, product, osVersion, isolab
 	}
 }
 
-func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel string, fdo *blueprint.FDOCustomization) *osbuild.GrubISOStageOptions {
+func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel string, timeout int, fdo *blueprint.FDOCustomization) *osbuild.GrubISOStageOptions {
 	var architectures []string
 
 	if arch == distro.X86_64ArchName {
@@ -235,6 +235,8 @@ func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVers
 		Architectures: architectures,
 		Vendor:        vendor,
 	}
+
+	grubISOStageOptions.Config = &osbuild.GRUB2Config{Timeout: timeout}
 
 	grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.manufacturing_server_url="+fdo.ManufacturingServerURL)
 	if fdo.DiunPubKeyInsecure != "" {

--- a/internal/distro/rhel9/pipelines.go
+++ b/internal/distro/rhel9/pipelines.go
@@ -879,11 +879,13 @@ func simplifiedInstallerBootISOTreePipeline(archivePipelineName, kver string, rn
 	return p
 }
 
+const SIMPLIFIED_INSTALLER_GRUB_TIMEOUT = 5
+
 func simplifiedInstallerEFIBootTreePipeline(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel string, fdo *blueprint.FDOCustomization) *osbuild.Pipeline {
 	p := new(osbuild.Pipeline)
 	p.Name = "efiboot-tree"
 	p.Build = "name:build"
-	p.AddStage(osbuild.NewGrubISOStage(grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel, fdo)))
+	p.AddStage(osbuild.NewGrubISOStage(grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel, SIMPLIFIED_INSTALLER_GRUB_TIMEOUT, fdo)))
 	return p
 }
 

--- a/internal/distro/rhel9/stage_options.go
+++ b/internal/distro/rhel9/stage_options.go
@@ -206,7 +206,7 @@ func bootISOMonoStageOptions(kernelVer, arch, vendor, product, osVersion, isolab
 	}
 }
 
-func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel string, fdo *blueprint.FDOCustomization) *osbuild.GrubISOStageOptions {
+func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVersion, isolabel string, timeout int, fdo *blueprint.FDOCustomization) *osbuild.GrubISOStageOptions {
 	var architectures []string
 
 	if arch == distro.X86_64ArchName {
@@ -235,6 +235,8 @@ func grubISOStageOptions(installDevice, kernelVer, arch, vendor, product, osVers
 		Architectures: architectures,
 		Vendor:        vendor,
 	}
+
+	grubISOStageOptions.Config = &osbuild.GRUB2Config{Timeout: timeout}
 
 	grubISOStageOptions.Kernel.Opts = append(grubISOStageOptions.Kernel.Opts, "fdo.manufacturing_server_url="+fdo.ManufacturingServerURL)
 	if fdo.DiunPubKeyInsecure != "" {

--- a/internal/osbuild/grub_iso_stage.go
+++ b/internal/osbuild/grub_iso_stage.go
@@ -10,6 +10,8 @@ type GrubISOStageOptions struct {
 	Architectures []string `json:"architectures,omitempty"`
 
 	Vendor string `json:"vendor,omitempty"`
+
+	Config *GRUB2Config `json:"config,omitempty"`
 }
 
 func (GrubISOStageOptions) isStageOptions() {}

--- a/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-aarch64-edge_simplified_installer-boot.json
@@ -5801,7 +5801,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "centos"
+              "vendor": "centos",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_8-x86_64-edge_simplified_installer-boot.json
@@ -5942,7 +5942,10 @@
                 "IA32",
                 "X64"
               ],
-              "vendor": "centos"
+              "vendor": "centos",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_simplified_installer-boot.json
@@ -5758,7 +5758,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "centos"
+              "vendor": "centos",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_simplified_installer-boot.json
@@ -5898,7 +5898,10 @@
               "architectures": [
                 "X64"
               ],
-              "vendor": "centos"
+              "vendor": "centos",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_simplified_installer-boot.json
@@ -2551,7 +2551,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_simplified_installer-boot.json
@@ -2622,7 +2622,10 @@
                 "IA32",
                 "X64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_simplified_installer-boot.json
@@ -2551,7 +2551,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_simplified_installer-boot.json
@@ -2622,7 +2622,10 @@
                 "IA32",
                 "X64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_simplified_installer-boot.json
@@ -2548,7 +2548,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_simplified_installer-boot.json
@@ -2619,7 +2619,10 @@
                 "IA32",
                 "X64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_simplified_installer-boot.json
@@ -2548,7 +2548,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_simplified_installer-boot.json
@@ -2619,7 +2619,10 @@
                 "IA32",
                 "X64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_simplified_installer-boot.json
@@ -2578,7 +2578,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_simplified_installer-boot.json
@@ -2645,7 +2645,10 @@
               "architectures": [
                 "X64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_simplified_installer-boot.json
@@ -5942,7 +5942,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_simplified_installer-boot.json
@@ -6058,7 +6058,10 @@
               "architectures": [
                 "X64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_simplified_installer-boot.json
@@ -5942,7 +5942,10 @@
               "architectures": [
                 "AA64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]

--- a/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_simplified_installer-boot.json
@@ -6058,7 +6058,10 @@
               "architectures": [
                 "X64"
               ],
-              "vendor": "redhat"
+              "vendor": "redhat",
+              "config": {
+                "timeout": 5
+              }
             }
           }
         ]


### PR DESCRIPTION
Leverage the new option in the grub2.iso stage basically and set a sane timeout

~~Depends on https://github.com/osbuild/osbuild/pull/1175~~

Signed-off-by: Antonio Murdaca <antoniomurdaca@gmail.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
