### PR TITLE
Fix iot-installer build via the cloud API

### DIFF
--- a/internal/distro/fedora/distro.go
+++ b/internal/distro/fedora/distro.go
@@ -561,6 +561,7 @@ func (t *imageType) PackageSets(bp blueprint.Blueprint, options distro.ImageOpti
 	if err != nil {
 		// TODO: handle manifest initialization errors more gracefully, we
 		// refuse to initialize manifests with invalid config.
+		logrus.Errorf("Initializing the manifest failed for %s (%s/%s): %v", t.Name(), t.arch.distro.Name(), t.arch.Name(), err)
 		return nil
 	}
 

--- a/internal/distro/fedora/distro_test.go
+++ b/internal/distro/fedora/distro_test.go
@@ -730,3 +730,24 @@ func TestDistro_CustomUsrPartitionNotLargeEnough(t *testing.T) {
 		}
 	}
 }
+
+func TestIotInstallerWithoutOStreeRefs(t *testing.T) {
+	// Regression test for https://github.com/osbuild/osbuild-composer/issues/3125
+
+	// TODO: Remove when the ugly workaround is gone
+	d := fedora.NewF38()
+	arch, err := d.GetArch("x86_64")
+	require.NoError(t, err)
+
+	imgType, err := arch.GetImageType("iot-installer")
+	require.NoError(t, err)
+
+	bp := blueprint.Blueprint{
+		Name: "fish",
+	}
+	err = bp.Initialize()
+	require.NoError(t, err)
+
+	sets := imgType.PackageSets(bp, distro.ImageOptions{}, nil)
+	require.NotZero(t, len(sets))
+}


### PR DESCRIPTION
8fdd1587997dbf091dd69a426bb44ef1c9abcfd1 modified the Cloud API to resolve
ostree commits using a separate job. This change caused the API handler
to call PackageSets without any ostree options (because they are not resolved
yet).

Unfortunately, the new implementation of PackageSets initializes the manifest.
The initialization checks the options and if the type is iot-installer and
it doesn't have the fetch checksum for IoT, it just returns an error.

To work around this (we need an initialized manifest to create the chains),
this commit just gives the initialization method a dummy checksum. The ostree
options currently don't have any effect on the package sets, so this should
be fine.

In order to make this workaround at least slightly sane, a warning is printed,
there's a new test just for this behaviour and a long comment to remember to
delete these lines.

Fixes #3125 

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
