### PR TITLE
diff-manifests.sh: Use shared_lib for greenprint and redprint

### DIFF
--- a/test/cases/diff-manifests.sh
+++ b/test/cases/diff-manifests.sh
@@ -1,11 +1,8 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-# Colorful timestamped output.
-function greenprint {
-    echo -e "\033[1;32m[$(date -Isecond)] ${1}\033[0m"
-}
+# NOTE: This script is executed differently in .gitlab-ci.yml so use a relative path
+source ./test/cases/shared_lib.sh
 
 function revert_to_head {
    git checkout "$head"


### PR DESCRIPTION
This pull request includes none of these:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/


Simple fix for missing redprint when diff-manifests.sh fails :)
