### PR TITLE
RHEL-8/9 EC2 image definitions fixes

### DIFF
--- a/internal/distro/rhel8/distro.go
+++ b/internal/distro/rhel8/distro.go
@@ -1109,6 +1109,13 @@ func newDistro(distroName string) distro.Distro {
 					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
 				},
 			},
+			// COMPOSER-1807
+			{
+				Filename: "blacklist-amdgpu.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
+				},
+			},
 		},
 		DracutConf: []*osbuild.DracutConfStageOptions{
 			{

--- a/internal/distro/rhel9/distro.go
+++ b/internal/distro/rhel9/distro.go
@@ -1041,6 +1041,13 @@ func newDistro(distroName string) distro.Distro {
 					osbuild.NewModprobeConfigCmdBlacklist("nouveau"),
 				},
 			},
+			// COMPOSER-1807
+			{
+				Filename: "blacklist-amdgpu.conf",
+				Commands: osbuild.ModprobeConfigCmdList{
+					osbuild.NewModprobeConfigCmdBlacklist("amdgpu"),
+				},
+			},
 		},
 		DracutConf: []*osbuild.DracutConfStageOptions{
 			{

--- a/internal/distro/rhel9/sap.go
+++ b/internal/distro/rhel9/sap.go
@@ -155,5 +155,22 @@ func SapPackageSet(t *imageType) rpmmd.PackageSet {
 			// RHBZ#1961168
 			"libnsl",
 		},
+		Exclude: []string{
+			// COMPOSER-1829
+			"firewalld",
+			"iwl1000-firmware",
+			"iwl100-firmware",
+			"iwl105-firmware",
+			"iwl135-firmware",
+			"iwl2000-firmware",
+			"iwl2030-firmware",
+			"iwl3160-firmware",
+			"iwl5000-firmware",
+			"iwl5150-firmware",
+			"iwl6000g2a-firmware",
+			"iwl6000g2b-firmware",
+			"iwl6050-firmware",
+			"iwl7260-firmware",
+		},
 	}
 }

--- a/test/data/manifests/centos_8-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_8-aarch64-ami-boot.json
@@ -5345,6 +5345,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/centos_8-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_8-x86_64-ami-boot.json
@@ -5151,6 +5151,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/centos_9-aarch64-ami-boot.json
+++ b/test/data/manifests/centos_9-aarch64-ami-boot.json
@@ -5049,6 +5049,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/centos_9-x86_64-ami-boot.json
+++ b/test/data/manifests/centos_9-x86_64-ami-boot.json
@@ -4889,6 +4889,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -2198,6 +2198,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_8-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ec2-boot.json
@@ -2214,6 +2214,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -2133,6 +2133,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_8-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2-boot.json
@@ -2151,6 +2151,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
@@ -2684,6 +2684,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
@@ -3422,6 +3422,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -2231,6 +2231,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_84-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ec2-boot.json
@@ -2247,6 +2247,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -2163,6 +2163,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_84-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2-boot.json
@@ -2181,6 +2181,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
@@ -2717,6 +2717,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
@@ -3368,6 +3368,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -2195,6 +2195,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -2211,6 +2211,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -2124,6 +2124,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -2141,6 +2141,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -2673,6 +2673,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -2198,6 +2198,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -2214,6 +2214,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -2133,6 +2133,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -2151,6 +2151,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -2684,6 +2684,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -3422,6 +3422,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_87-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ami-boot.json
@@ -2195,6 +2195,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_87-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ec2-boot.json
@@ -2201,6 +2201,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_87-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ami-boot.json
@@ -2133,6 +2133,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_87-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2-boot.json
@@ -2141,6 +2141,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
@@ -2674,6 +2674,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
@@ -3382,6 +3382,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_88-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-ami-boot.json
@@ -2195,6 +2195,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_88-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-ec2-boot.json
@@ -2201,6 +2201,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_88-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ami-boot.json
@@ -2133,6 +2133,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_88-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2-boot.json
@@ -2141,6 +2141,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_88-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2_ha-boot.json
@@ -2674,6 +2674,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_88-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2_sap-boot.json
@@ -3382,6 +3382,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -2080,6 +2080,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -2099,6 +2099,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -2026,6 +2026,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -2047,6 +2047,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -2619,6 +2619,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -3485,6 +3485,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -1069,12 +1069,6 @@
                     "id": "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81"
                   },
                   {
-                    "id": "sha256:7b738903b5a814568894b08e43b837c8e9af7bae834deb3bd8c1c2b6a5abf513"
-                  },
-                  {
-                    "id": "sha256:0aff62a3cac644b279baf297cddc0102166b3cb41acc4a1a52ea28556d3a9a4c"
-                  },
-                  {
                     "id": "sha256:d4b490f97fec6df68d467e74eeac7f26210757973175d344d989804e4f1a3629"
                   },
                   {
@@ -1201,12 +1195,6 @@
                     "id": "sha256:f73e5b5ba910b317cfce9991fd51a4b3262806369492753c70d1780a72d3ad62"
                   },
                   {
-                    "id": "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c"
-                  },
-                  {
-                    "id": "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d"
-                  },
-                  {
                     "id": "sha256:2882e59e2bd1f0fe8e51a99e4338f053d361ffc039cd423e141daa65da3e93b3"
                   },
                   {
@@ -1229,45 +1217,6 @@
                   },
                   {
                     "id": "sha256:b97fdc6512ba9406c92d9eda661f06c30b9d929ec78e437d32490ee4f06738b5"
-                  },
-                  {
-                    "id": "sha256:01939e7ae8b55ea022e463a1a19b395fea414ab1756400481c7393288acc2487"
-                  },
-                  {
-                    "id": "sha256:5d5d28f8506343379b2ecd7e5d3d03032631bee662a91fd014beede70556c431"
-                  },
-                  {
-                    "id": "sha256:08b61941b090d825ba27290d425a96a83ebab213186b80b4556c150dea09ae34"
-                  },
-                  {
-                    "id": "sha256:e58fae3c2f1e1523c5b4967fe59e6e623b7b9fa4a3efb7b4219feb1a62ea748f"
-                  },
-                  {
-                    "id": "sha256:370ffccab77689dcabda535306dd18274742026e59d2330ee2d07c479cfc0dc6"
-                  },
-                  {
-                    "id": "sha256:4900de5fe7cf57df87d84d84a35e2031bb0668494c12da6d26c617f0d23f060d"
-                  },
-                  {
-                    "id": "sha256:540efc56851bf6ac1170d51a584d7659789296d0fc2ee8fb97d83c9f408119c9"
-                  },
-                  {
-                    "id": "sha256:6accd8521cabe36f2f22a33396cae27b6bd5374731828b78da695c06cc8624ae"
-                  },
-                  {
-                    "id": "sha256:eb6cfc3b08cc7aa504beea4b298bd49691a06c2917d5e60ebf39da030285b74c"
-                  },
-                  {
-                    "id": "sha256:8b19d50d04beddd3ae853619b541a66d4f57e4df6d31a79563417a20c658d25c"
-                  },
-                  {
-                    "id": "sha256:42f48e6c3cde8ef2efba2489ce075fd9744cad131c66fce7d3f66199641df12e"
-                  },
-                  {
-                    "id": "sha256:f8405090fb3e392da790f5a58bb0a8bb535fe531105ee2133dce4ed4fa50d352"
-                  },
-                  {
-                    "id": "sha256:4dbae3cd048aca496d94e979b233fe7a5ee7126a476aeba828bf02dd6e316215"
                   },
                   {
                     "id": "sha256:4e9aec51ee46d7265d6edd1245b5d5ab5e8336dc2a4ca17f2cace2ce8bae3761"
@@ -1888,9 +1837,6 @@
                     "id": "sha256:30a3b8b08eafb81232ae7758eaef2ba2eef8e2ada837571fee0aaaa874de1f15"
                   },
                   {
-                    "id": "sha256:b6ba64260d2c4bdcb5b2b5ac5f54ee8640c4c714dcce5b33aaad351dff8c4b89"
-                  },
-                  {
                     "id": "sha256:a6fd1db30750fefdb6b2ddb91731c4e59c25ca9ee1c18530ebfe41f7158a66b4"
                   },
                   {
@@ -1925,9 +1871,6 @@
                   },
                   {
                     "id": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac"
-                  },
-                  {
-                    "id": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
                   },
                   {
                     "id": "sha256:947cd909d714ac798e930dc3e3d268c3b9c98556c8d55d9af9a8ca7e0949145b"
@@ -2627,9 +2570,6 @@
                   },
                   {
                     "id": "sha256:b26d88e03ef525396261ff5453178d9a27cdb8d9c39bbcef585d771a2fd19716"
-                  },
-                  {
-                    "id": "sha256:86f913b51ec66a03003d2a19e8a6195fdafa37d01bfd66e268d95b198d7779f6"
                   },
                   {
                     "id": "sha256:21eb2f4481898f6de999b37c3dee2763ed6d530cf5a5147acad2da48871beae5"
@@ -3948,9 +3888,6 @@
           "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm"
           },
-          "sha256:01939e7ae8b55ea022e463a1a19b395fea414ab1756400481c7393288acc2487": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl100-firmware-39.31.5.1-124.el9.noarch.rpm"
-          },
           "sha256:01a2cf54d7bf8a8be11eff59e72d599450aad9ade0cce9e7f1d234461f514e6a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/bind-license-9.16.23-1.el9.noarch.rpm"
           },
@@ -4029,9 +3966,6 @@
           "sha256:088cacedbce4a2476cf6e527da0dfbc48ffb0a75eebb5566f9dc7df4833e5a62": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libluksmeta-9-12.el9.x86_64.rpm"
           },
-          "sha256:08b61941b090d825ba27290d425a96a83ebab213186b80b4556c150dea09ae34": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl105-firmware-18.168.6.1-124.el9.noarch.rpm"
-          },
           "sha256:08e49ed019a40004c53f5d8092c1d50fa4f382bf98f1c4dc5ed9ca9eda28f9bb": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/NetworkManager-config-server-1.36.0-0.7.el9.noarch.rpm"
           },
@@ -4043,9 +3977,6 @@
           },
           "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm"
-          },
-          "sha256:0aff62a3cac644b279baf297cddc0102166b3cb41acc4a1a52ea28556d3a9a4c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/firewalld-filesystem-1.0.0-4.el9.noarch.rpm"
           },
           "sha256:0b29cfb06051c12254c742e90cfa1df78ddc7234b267aef2d81264adb229bbd7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/dmidecode-3.3-6.el9.x86_64.rpm"
@@ -4064,9 +3995,6 @@
           },
           "sha256:0c8f8e301f75c77a24821cc9170596a799edb33c1bf58b6490aa97c8ed7d5996": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/gmp-6.2.0-10.el9.x86_64.rpm"
-          },
-          "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/ipset-7.11-6.el9.x86_64.rpm"
           },
           "sha256:0cd5b0bd07a3b6caf9b83ead1e06b4b3ddddda26980785060bfe3064dab86935": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bpftool-5.14.0-55.el9.x86_64.rpm"
@@ -4464,9 +4392,6 @@
           "sha256:36cfec9784c3ff2a2e4d329766be8642226f5f27c4d03c96f047ead1779462db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/binutils-gold-2.35.2-17.el9.x86_64.rpm"
           },
-          "sha256:370ffccab77689dcabda535306dd18274742026e59d2330ee2d07c479cfc0dc6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl2000-firmware-18.168.6.1-124.el9.noarch.rpm"
-          },
           "sha256:372a5cfa95d2edb67435b0386029501ff5254bca91430b6d6e8e446582ba258a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/sqlite-libs-3.34.1-5.el9.x86_64.rpm"
           },
@@ -4578,9 +4503,6 @@
           "sha256:42e7addb96958b293571949829378c054d6a1a762dccb78d5a777f8c531fc811": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libpng-1.6.37-12.el9.x86_64.rpm"
           },
-          "sha256:42f48e6c3cde8ef2efba2489ce075fd9744cad131c66fce7d3f66199641df12e": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl6000g2b-firmware-18.168.6.1-124.el9.noarch.rpm"
-          },
           "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm"
           },
@@ -4646,9 +4568,6 @@
           },
           "sha256:48fab790ff21ac1418e2cb5477515189070d8f1a397972f9d094cb46501be22b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/urw-base35-c059-fonts-20200910-6.el9.noarch.rpm"
-          },
-          "sha256:4900de5fe7cf57df87d84d84a35e2031bb0668494c12da6d26c617f0d23f060d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl2030-firmware-18.168.6.1-124.el9.noarch.rpm"
           },
           "sha256:490b09cbcfad309490ca20974df5052f719ab8f864a3a9efdc395230e6c5326e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-netaddr-0.8.0-5.el9.noarch.rpm"
@@ -4734,9 +4653,6 @@
           "sha256:4da11286bb79e5b384e611328bb12ba654de4b0ad0548faf5a33572f6e9f9b8a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/cloud-init-21.1-16.el9.noarch.rpm"
           },
-          "sha256:4dbae3cd048aca496d94e979b233fe7a5ee7126a476aeba828bf02dd6e316215": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl7260-firmware-25.30.13.0-124.el9.noarch.rpm"
-          },
           "sha256:4dbba39a63fecb36ae944e066e797ad2ac55293dbcbc1d77a30e914ec60b9cb1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/NetworkManager-cloud-setup-1.36.0-0.7.el9.x86_64.rpm"
           },
@@ -4784,9 +4700,6 @@
           },
           "sha256:540c5783ee9aa3a5b9519e8b7a62d8aca4f314f90e11e014d27bba4e805d9bf6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-lvm-2.25-11.el9.x86_64.rpm"
-          },
-          "sha256:540efc56851bf6ac1170d51a584d7659789296d0fc2ee8fb97d83c9f408119c9": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl3160-firmware-25.30.13.0-124.el9.noarch.rpm"
           },
           "sha256:544a21926b873ff59ad9c053c9385def305bb21c4b9ebe9bddc1fdc289f1d067": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libisofs-1.5.4-3.el9.x86_64.rpm"
@@ -4871,9 +4784,6 @@
           },
           "sha256:5d4428aacbb423d864cc9441af737926fa4813836deb969618ab9f66e10e908c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/poppler-21.01.0-12.el9.x86_64.rpm"
-          },
-          "sha256:5d5d28f8506343379b2ecd7e5d3d03032631bee662a91fd014beede70556c431": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl1000-firmware-39.31.5.1-124.el9.noarch.rpm"
           },
           "sha256:5d71f94610c217a25972a15b2b3bdcd3937f82331614e02cf9949b3e0d4b1973": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/totem-pl-parser-3.26.6-2.el9.x86_64.rpm"
@@ -5012,9 +4922,6 @@
           },
           "sha256:6a943fdeeb5175e620b68504242a7ce13113e7893ebdab4218a13481582cfc47": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/cyrus-sasl-plain-2.1.27-17.el9.x86_64.rpm"
-          },
-          "sha256:6accd8521cabe36f2f22a33396cae27b6bd5374731828b78da695c06cc8624ae": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl5000-firmware-8.83.5.1_1-124.el9.noarch.rpm"
           },
           "sha256:6b0419dade394fbfa8b1f67cfb6e7a7a180db6a2eb583b9fa369e447d1936997": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/git-core-doc-2.31.1-2.el9.2.noarch.rpm"
@@ -5202,9 +5109,6 @@
           "sha256:7b4d475adb465ba577d1989c21fe5715f9be277189195fe0d28fe92cbfa80731": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/ncurses-6.2-8.20210508.el9.x86_64.rpm"
           },
-          "sha256:7b738903b5a814568894b08e43b837c8e9af7bae834deb3bd8c1c2b6a5abf513": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/firewalld-1.0.0-4.el9.noarch.rpm"
-          },
           "sha256:7b8444e355c1e8dc7177506b629e2beb9dabc13a6e3e8ed9b786c4e321f36f68": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/libdhash-0.5.0-51.el9.x86_64.rpm"
           },
@@ -5298,9 +5202,6 @@
           "sha256:86d1533dd9531354f266b8c434e5ceadc94b9c3d249f3e43d16813acabff39e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-pysocks-1.7.1-10.el9.noarch.rpm"
           },
-          "sha256:86f913b51ec66a03003d2a19e8a6195fdafa37d01bfd66e268d95b198d7779f6": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libcap-ng-python3-0.8.2-6.el9.x86_64.rpm"
-          },
           "sha256:8743d4eab6e262efbe770232eb34c3fb5f0c304531b97cc95442ed6c7c8e2909": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libblockdev-loop-2.25-11.el9.x86_64.rpm"
           },
@@ -5360,9 +5261,6 @@
           },
           "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/perl-constant-1.33-461.el9.noarch.rpm"
-          },
-          "sha256:8b19d50d04beddd3ae853619b541a66d4f57e4df6d31a79563417a20c658d25c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl6000g2a-firmware-18.168.6.1-124.el9.noarch.rpm"
           },
           "sha256:8bba35b018036fedcb5629454386a3162e3c2bc74efe6a0283b921933c537b32": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/yum-utils-4.0.24-2.el9.noarch.rpm"
@@ -5787,9 +5685,6 @@
           "sha256:b60e10439f180c9fd95d1fdeb3265ddfc088b50098d3c3b389e81ad0e3c8d7de": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libgs-9.54.0-4.el9.x86_64.rpm"
           },
-          "sha256:b6ba64260d2c4bdcb5b2b5ac5f54ee8640c4c714dcce5b33aaad351dff8c4b89": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-firewall-1.0.0-4.el9.noarch.rpm"
-          },
           "sha256:b7138ec10750c522099bba1fc20878dfe3b710975fe08813958fe1e6184a532b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/PackageKit-glib-1.2.4-2.el9.x86_64.rpm"
           },
@@ -5964,9 +5859,6 @@
           "sha256:c6e3129b65ce1aa18ce3b4283219c9c9ccfc0587ff17c227340aa0eafc21df07": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/chrony-4.1-3.el9.x86_64.rpm"
           },
-          "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/ipset-libs-7.11-6.el9.x86_64.rpm"
-          },
           "sha256:c746c3e534fa6616b62525a89cc8ab1014e5acfac31b1012823b5f1e9031181c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-3.9.10-1.el9.x86_64.rpm"
           },
@@ -5981,9 +5873,6 @@
           },
           "sha256:c8b4130984ea24231da37cc07fe7be90ea75d04016fda23d18a16e9a4b8435d6": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/openssl-3.0.1-5.el9.x86_64.rpm"
-          },
-          "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-nftables-0.9.8-10.el9.x86_64.rpm"
           },
           "sha256:c958920cafeaf333863381edc26ac5844823f73be6985b6d48c88efd90390c08": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-ptyprocess-0.6.0-12.el9.noarch.rpm"
@@ -6252,9 +6141,6 @@
           "sha256:e55d976682d6f8ea1937719fb97f130a506312000ad831a18fea5722c5bd253f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/snappy-1.1.8-8.el9.x86_64.rpm"
           },
-          "sha256:e58fae3c2f1e1523c5b4967fe59e6e623b7b9fa4a3efb7b4219feb1a62ea748f": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl135-firmware-18.168.6.1-124.el9.noarch.rpm"
-          },
           "sha256:e5d8869dbc34672bb6bc94e00045f659b7d2415172cd27ee9f949e1769f71bb8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/passwd-0.80-12.el9.x86_64.rpm"
           },
@@ -6308,9 +6194,6 @@
           },
           "sha256:eb412729844495d81f36b1bdaa24736070d197d0b7f2fe38736b6022cc84013d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/python3-kickstart-3.32.2-2.el9.noarch.rpm"
-          },
-          "sha256:eb6cfc3b08cc7aa504beea4b298bd49691a06c2917d5e60ebf39da030285b74c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl5150-firmware-8.24.2.2-124.el9.noarch.rpm"
           },
           "sha256:eb8973df11266ce57f1db004883df3f14690c17646992c2d977f81cd6ba560f7": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/gdisk-1.0.7-5.el9.x86_64.rpm"
@@ -6446,9 +6329,6 @@
           },
           "sha256:f835cc738fa003147087d68427c407e17c08587156ae961d641b2dfcee1fe7af": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/bash-5.1.8-2.el9.x86_64.rpm"
-          },
-          "sha256:f8405090fb3e392da790f5a58bb0a8bb535fe531105ee2133dce4ed4fa50d352": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl6050-firmware-41.28.5.1-124.el9.noarch.rpm"
           },
           "sha256:f84294afdeaddb4f44243b80e3b32cf65a5aff76e5b7528f4810657c90559181": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/NetworkManager-team-1.36.0-0.7.el9.x86_64.rpm"
@@ -9396,24 +9276,6 @@
         "checksum": "sha256:1aa1d059f7696ae397f8746d8d4fe5ead73bac461f53cce01b92db73fbd2fa81"
       },
       {
-        "name": "firewalld",
-        "epoch": 0,
-        "version": "1.0.0",
-        "release": "4.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/firewalld-1.0.0-4.el9.noarch.rpm",
-        "checksum": "sha256:7b738903b5a814568894b08e43b837c8e9af7bae834deb3bd8c1c2b6a5abf513"
-      },
-      {
-        "name": "firewalld-filesystem",
-        "epoch": 0,
-        "version": "1.0.0",
-        "release": "4.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/firewalld-filesystem-1.0.0-4.el9.noarch.rpm",
-        "checksum": "sha256:0aff62a3cac644b279baf297cddc0102166b3cb41acc4a1a52ea28556d3a9a4c"
-      },
-      {
         "name": "fonts-filesystem",
         "epoch": 1,
         "version": "2.0.5",
@@ -9792,24 +9654,6 @@
         "checksum": "sha256:f73e5b5ba910b317cfce9991fd51a4b3262806369492753c70d1780a72d3ad62"
       },
       {
-        "name": "ipset",
-        "epoch": 0,
-        "version": "7.11",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/ipset-7.11-6.el9.x86_64.rpm",
-        "checksum": "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c"
-      },
-      {
-        "name": "ipset-libs",
-        "epoch": 0,
-        "version": "7.11",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/ipset-libs-7.11-6.el9.x86_64.rpm",
-        "checksum": "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d"
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.7",
@@ -9880,123 +9724,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/isns-utils-libs-0.101-4.el9.x86_64.rpm",
         "checksum": "sha256:b97fdc6512ba9406c92d9eda661f06c30b9d929ec78e437d32490ee4f06738b5"
-      },
-      {
-        "name": "iwl100-firmware",
-        "epoch": 0,
-        "version": "39.31.5.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl100-firmware-39.31.5.1-124.el9.noarch.rpm",
-        "checksum": "sha256:01939e7ae8b55ea022e463a1a19b395fea414ab1756400481c7393288acc2487"
-      },
-      {
-        "name": "iwl1000-firmware",
-        "epoch": 1,
-        "version": "39.31.5.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl1000-firmware-39.31.5.1-124.el9.noarch.rpm",
-        "checksum": "sha256:5d5d28f8506343379b2ecd7e5d3d03032631bee662a91fd014beede70556c431"
-      },
-      {
-        "name": "iwl105-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl105-firmware-18.168.6.1-124.el9.noarch.rpm",
-        "checksum": "sha256:08b61941b090d825ba27290d425a96a83ebab213186b80b4556c150dea09ae34"
-      },
-      {
-        "name": "iwl135-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl135-firmware-18.168.6.1-124.el9.noarch.rpm",
-        "checksum": "sha256:e58fae3c2f1e1523c5b4967fe59e6e623b7b9fa4a3efb7b4219feb1a62ea748f"
-      },
-      {
-        "name": "iwl2000-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl2000-firmware-18.168.6.1-124.el9.noarch.rpm",
-        "checksum": "sha256:370ffccab77689dcabda535306dd18274742026e59d2330ee2d07c479cfc0dc6"
-      },
-      {
-        "name": "iwl2030-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl2030-firmware-18.168.6.1-124.el9.noarch.rpm",
-        "checksum": "sha256:4900de5fe7cf57df87d84d84a35e2031bb0668494c12da6d26c617f0d23f060d"
-      },
-      {
-        "name": "iwl3160-firmware",
-        "epoch": 1,
-        "version": "25.30.13.0",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl3160-firmware-25.30.13.0-124.el9.noarch.rpm",
-        "checksum": "sha256:540efc56851bf6ac1170d51a584d7659789296d0fc2ee8fb97d83c9f408119c9"
-      },
-      {
-        "name": "iwl5000-firmware",
-        "epoch": 0,
-        "version": "8.83.5.1_1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl5000-firmware-8.83.5.1_1-124.el9.noarch.rpm",
-        "checksum": "sha256:6accd8521cabe36f2f22a33396cae27b6bd5374731828b78da695c06cc8624ae"
-      },
-      {
-        "name": "iwl5150-firmware",
-        "epoch": 0,
-        "version": "8.24.2.2",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl5150-firmware-8.24.2.2-124.el9.noarch.rpm",
-        "checksum": "sha256:eb6cfc3b08cc7aa504beea4b298bd49691a06c2917d5e60ebf39da030285b74c"
-      },
-      {
-        "name": "iwl6000g2a-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl6000g2a-firmware-18.168.6.1-124.el9.noarch.rpm",
-        "checksum": "sha256:8b19d50d04beddd3ae853619b541a66d4f57e4df6d31a79563417a20c658d25c"
-      },
-      {
-        "name": "iwl6000g2b-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl6000g2b-firmware-18.168.6.1-124.el9.noarch.rpm",
-        "checksum": "sha256:42f48e6c3cde8ef2efba2489ce075fd9744cad131c66fce7d3f66199641df12e"
-      },
-      {
-        "name": "iwl6050-firmware",
-        "epoch": 0,
-        "version": "41.28.5.1",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl6050-firmware-41.28.5.1-124.el9.noarch.rpm",
-        "checksum": "sha256:f8405090fb3e392da790f5a58bb0a8bb535fe531105ee2133dce4ed4fa50d352"
-      },
-      {
-        "name": "iwl7260-firmware",
-        "epoch": 1,
-        "version": "25.30.13.0",
-        "release": "124.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/iwl7260-firmware-25.30.13.0-124.el9.noarch.rpm",
-        "checksum": "sha256:4dbae3cd048aca496d94e979b233fe7a5ee7126a476aeba828bf02dd6e316215"
       },
       {
         "name": "jansson",
@@ -11853,15 +11580,6 @@
         "checksum": "sha256:30a3b8b08eafb81232ae7758eaef2ba2eef8e2ada837571fee0aaaa874de1f15"
       },
       {
-        "name": "python3-firewall",
-        "epoch": 0,
-        "version": "1.0.0",
-        "release": "4.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-firewall-1.0.0-4.el9.noarch.rpm",
-        "checksum": "sha256:b6ba64260d2c4bdcb5b2b5ac5f54ee8640c4c714dcce5b33aaad351dff8c4b89"
-      },
-      {
         "name": "python3-gobject-base",
         "epoch": 0,
         "version": "3.40.1",
@@ -11968,15 +11686,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm",
         "checksum": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac"
-      },
-      {
-        "name": "python3-nftables",
-        "epoch": 1,
-        "version": "0.9.8",
-        "release": "10.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.0-20220208/Packages/python3-nftables-0.9.8-10.el9.x86_64.rpm",
-        "checksum": "sha256:c8ce8d404b24fc632a072349de3c2f132694798e58f06fc470360abb4c3c578b"
       },
       {
         "name": "python3-perf",
@@ -14074,15 +13783,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libcanberra-gtk3-0.30-26.el9.x86_64.rpm",
         "checksum": "sha256:b26d88e03ef525396261ff5453178d9a27cdb8d9c39bbcef585d771a2fd19716"
-      },
-      {
-        "name": "libcap-ng-python3",
-        "epoch": 0,
-        "version": "0.8.2",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.0-20220208/Packages/libcap-ng-python3-0.8.2-6.el9.x86_64.rpm",
-        "checksum": "sha256:86f913b51ec66a03003d2a19e8a6195fdafa37d01bfd66e268d95b198d7779f6"
       },
       {
         "name": "libdatrie",

--- a/test/data/manifests/rhel_91-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ami-boot.json
@@ -5219,6 +5219,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_91-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ec2-boot.json
@@ -5268,6 +5268,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_91-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ami-boot.json
@@ -5051,6 +5051,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_91-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2-boot.json
@@ -5102,6 +5102,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
@@ -6546,6 +6546,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -9136,6 +9136,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -2710,22 +2710,6 @@
                     }
                   },
                   {
-                    "id": "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:469bef28b5aa084cfc430c135b215af5bf6e2632e4e4f33819d789665ab540a0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d4b490f97fec6df68d467e74eeac7f26210757973175d344d989804e4f1a3629",
                     "options": {
                       "metadata": {
@@ -3086,22 +3070,6 @@
                     }
                   },
                   {
-                    "id": "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:dbe2c1c7ab6355590dfa7642d53a7e1933ff96ada640769253bdf177183901ba",
                     "options": {
                       "metadata": {
@@ -3159,110 +3127,6 @@
                   },
                   {
                     "id": "sha256:b97fdc6512ba9406c92d9eda661f06c30b9d929ec78e437d32490ee4f06738b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:899ffa89ed6e72b237ef9f2f9fffce283e878dff4d12b12afd0f942e1a2b2101",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c62995f724d8d4d269e0585dfb6fff0b881fc7f8765ff63d52bc315dff83a4d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ae6761e91cd860b4c6fae7421a6631e074f181de3d5e629f381f4e83a4f3523",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21ceaf55f5726f7edfecc4e1dd8672ba2609c1107e735e20a10a7aa74059c2e4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a22f5396dc6efc0ba2c8110338b2b3212fb2cbdb6f9e4bb817e7b5b0fddcde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ef40799584612faace9085293822e7c37ca3640b18057992f7a8aa75ac08bc4c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c05af0e379ec32aafb12872ca346bb83c1608130f7abdf9ef3ecac6811425369",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1bec0165c2c6351f2db73b3cda9ecfdae77dd61a79a37b499511941b19f04f7d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:39cdbcc70f716592fd398f1885e05aaa7ae9ebc9d46d1774bfd090ae4f756096",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d3084f2b9aa415d219f2812da0de1e5800415927dffbb7785bd4f1a2ccc30a4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d7691f79363d560c06bb4f70466487e83b4b7a8ef1a5d298c38683c65ea23cc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5a93097e08e847b113105a170132f74d91cf7143d2772fc73f78526ee32f32d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:047751bcc89389360d7375733b64d27bd251da11a257d82f98eaeb204a943d15",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4950,14 +4814,6 @@
                     }
                   },
                   {
-                    "id": "sha256:284f8e549fd6ad678f0a12def81fd5f6b177e6583d843e7069b2b780130e3fe0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e",
                     "options": {
                       "metadata": {
@@ -5055,14 +4911,6 @@
                   },
                   {
                     "id": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d00b18500ba10c9545b52ffe443a68abcb30b44a583dabf26a72e70357b75a2d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6975,14 +6823,6 @@
                   },
                   {
                     "id": "sha256:b26d88e03ef525396261ff5453178d9a27cdb8d9c39bbcef585d771a2fd19716",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:104cfea85cd346eec207c99f537e927de8c22816ef7d5196c4ede389ec045607",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -9617,9 +9457,6 @@
           "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-podlators-4.14-460.el9.noarch.rpm"
           },
-          "sha256:047751bcc89389360d7375733b64d27bd251da11a257d82f98eaeb204a943d15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl7260-firmware-25.30.13.0-127.el9.noarch.rpm"
-          },
           "sha256:05372e66ce337a73f29f5839b7504f23b05104fad900fc2556901b27a7ee4752": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libXft-2.3.3-8.el9.x86_64.rpm"
           },
@@ -9671,9 +9508,6 @@
           "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm"
           },
-          "sha256:0ae6761e91cd860b4c6fae7421a6631e074f181de3d5e629f381f4e83a4f3523": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl105-firmware-18.168.6.1-127.el9.noarch.rpm"
-          },
           "sha256:0b68c7111e169dd9d0073a3c48275bc2514c278d037495bf5ff9c41dbb7c8768": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/yum-utils-4.1.0-3.el9.noarch.rpm"
           },
@@ -9688,9 +9522,6 @@
           },
           "sha256:0c8f8e301f75c77a24821cc9170596a799edb33c1bf58b6490aa97c8ed7d5996": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/gmp-6.2.0-10.el9.x86_64.rpm"
-          },
-          "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ipset-7.11-6.el9.x86_64.rpm"
           },
           "sha256:0d450719ca6a0d6e56df2cd462a233ad537d238a5af7d6b6551d733320204968": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/lm_sensors-libs-3.6.0-10.el9.x86_64.rpm"
@@ -9727,9 +9558,6 @@
           },
           "sha256:0fd96e53e678f92418c859d8fb95087dd989c7eacb399157768be0daef08cf8f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-gpg-1.15.1-6.el9.x86_64.rpm"
-          },
-          "sha256:104cfea85cd346eec207c99f537e927de8c22816ef7d5196c4ede389ec045607": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libcap-ng-python3-0.8.2-7.el9.x86_64.rpm"
           },
           "sha256:10b7e7b592a318fa73f37306b469c140175a1177b987f0041ec2c5b2e110953b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/lorax-templates-rhel-9.0-35.el9.noarch.rpm"
@@ -9809,9 +9637,6 @@
           "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
-          "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
-          },
           "sha256:17d14b94f4236d52cf37d75bcef928c82845ddbf573780914da30ff607474ef8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/sssd-ldap-2.7.3-4.el9.x86_64.rpm"
           },
@@ -9848,14 +9673,8 @@
           "sha256:1bc121f166b99cc69d69ad7c7373bd9cd113ce2fe06b1c4ac501e51ac5f045f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libvorbis-1.3.7-5.el9.x86_64.rpm"
           },
-          "sha256:1bec0165c2c6351f2db73b3cda9ecfdae77dd61a79a37b499511941b19f04f7d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl5000-firmware-8.83.5.1_1-127.el9.noarch.rpm"
-          },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
-          },
-          "sha256:1d3084f2b9aa415d219f2812da0de1e5800415927dffbb7785bd4f1a2ccc30a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl6000g2a-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:1dbf74402369c919d0db84ff0545de0d040ea93d159cd16963ed4ea17b5f1f96": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/dnf-data-4.12.0-4.el9.noarch.rpm"
@@ -9892,9 +9711,6 @@
           },
           "sha256:219825121d761bf163e746f0ca424e4dfe071aece87c22ccd632abcf78ab4920": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-inotify-0.9.6-25.el9.noarch.rpm"
-          },
-          "sha256:21ceaf55f5726f7edfecc4e1dd8672ba2609c1107e735e20a10a7aa74059c2e4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl135-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:21d6b644bb88b1ae63341701ab4782b4df3b36a0e1a44ca4e05499a1b5ce2f22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/initscripts-10.11.5-1.el9.x86_64.rpm"
@@ -9973,9 +9789,6 @@
           },
           "sha256:27ca0c4ad90b12aa0285a750caffc2cf554450111b07c815b214c15f051df90a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/PackageKit-gtk3-module-1.2.4-2.el9.x86_64.rpm"
-          },
-          "sha256:284f8e549fd6ad678f0a12def81fd5f6b177e6583d843e7069b2b780130e3fe0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-firewall-1.1.1-3.el9.noarch.rpm"
           },
           "sha256:289d4e53a6d59ba84dffc9ad5f8312bf9c14dc7528556e1a0e94c71428ead7e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libthai-0.1.28-8.el9.x86_64.rpm"
@@ -10148,9 +9961,6 @@
           "sha256:39ada507d193a14f8ee3d5226966dca1b5a6e9b591a1a4b11a059445596db7e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/linux-firmware-whence-20220708-127.el9.noarch.rpm"
           },
-          "sha256:39cdbcc70f716592fd398f1885e05aaa7ae9ebc9d46d1774bfd090ae4f756096": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl5150-firmware-8.24.2.2-127.el9.noarch.rpm"
-          },
           "sha256:39d6fe73373ae5692e510b7c6219ad1ffadad0f1bc59cb7095faf6e095811768": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-libcomps-0.1.18-1.el9.x86_64.rpm"
           },
@@ -10304,9 +10114,6 @@
           "sha256:46837f640f3bef9667f09fa46b85e0eb6b93c5acc92fb38371edabfcadad02db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/urw-base35-bookman-fonts-20200910-6.el9.noarch.rpm"
           },
-          "sha256:469bef28b5aa084cfc430c135b215af5bf6e2632e4e4f33819d789665ab540a0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-filesystem-1.1.1-3.el9.noarch.rpm"
-          },
           "sha256:46b32ee80acc1e9ae772434ea1e32f4c0aa4b26647e512123f86dcc206a00325": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/pkgconf-m4-1.7.3-9.el9.noarch.rpm"
           },
@@ -10384,9 +10191,6 @@
           },
           "sha256:4c30037d7b80ee8355345bb8aab4af619e97cbb2a4cd5936dedf03fd7be72517": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/realmd-0.17.0-9.el9.x86_64.rpm"
-          },
-          "sha256:4c62995f724d8d4d269e0585dfb6fff0b881fc7f8765ff63d52bc315dff83a4d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl1000-firmware-39.31.5.1-127.el9.noarch.rpm"
           },
           "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-File-stat-1.09-479.el9.noarch.rpm"
@@ -10523,9 +10327,6 @@
           "sha256:5a43c616c3f06fbba7d45ea4cdd87ca58cc46102908e089a14604de5d55a0393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/redhat-logos-90.4-1.el9.x86_64.rpm"
           },
-          "sha256:5a93097e08e847b113105a170132f74d91cf7143d2772fc73f78526ee32f32d7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl6050-firmware-41.28.5.1-127.el9.noarch.rpm"
-          },
           "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm"
           },
@@ -10585,9 +10386,6 @@
           },
           "sha256:61998ac3bf97ca81d88e4e75bcf9ccfe82212802f66979dca2599e1569ce43d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/mtr-0.94-4.el9.x86_64.rpm"
-          },
-          "sha256:61a22f5396dc6efc0ba2c8110338b2b3212fb2cbdb6f9e4bb817e7b5b0fddcde": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl2000-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:623a7df9745c80a1eda3c68f02f54692f398c74a504c27d66cba6a1568475b01": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/kexec-tools-2.0.24-5.el9.x86_64.rpm"
@@ -11062,9 +10860,6 @@
           },
           "sha256:88f1d788f4e3324e450831e01e2d319b8336b0f4f9dcc297c9fd17560cbfe74f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/langpacks-core-en-3.0-16.el9.noarch.rpm"
-          },
-          "sha256:899ffa89ed6e72b237ef9f2f9fffce283e878dff4d12b12afd0f942e1a2b2101": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl100-firmware-39.31.5.1-127.el9.noarch.rpm"
           },
           "sha256:89bd456fd7968d9f60291b9543c80ae190338162da328b11f07b5dec2f3d8edf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/libnl3-cli-3.7.0-1.el9.x86_64.rpm"
@@ -11669,9 +11464,6 @@
           "sha256:c03849c4132fa3836d4e6957c2dfa48e0e0226097698fb7dbb29759926c7820c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/webkit2gtk3-jsc-2.36.7-1.el9.x86_64.rpm"
           },
-          "sha256:c05af0e379ec32aafb12872ca346bb83c1608130f7abdf9ef3ecac6811425369": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl3160-firmware-25.30.13.0-127.el9.noarch.rpm"
-          },
           "sha256:c0bc12c29b9da0f5208816f6a88723524ecf8d49e06d4f5e1569d23970cc7955": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/mesa-libGL-22.1.5-2.el9.x86_64.rpm"
           },
@@ -11740,9 +11532,6 @@
           },
           "sha256:c5c3a4558e0eb53a4fd0bc0760e1988779d06c26deb52e135bda1597d86a02f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/adobe-mappings-cmap-deprecated-20171205-12.el9.noarch.rpm"
-          },
-          "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ipset-libs-7.11-6.el9.x86_64.rpm"
           },
           "sha256:c7932a07194f88d7f58a2dd45b67aa7f817e4cdcaaf45d2f5c0ab1cba3a3e565": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.x86_64.rpm"
@@ -11843,9 +11632,6 @@
           "sha256:cfb5e8fddaed92b1b22c957183d0ea626a4468f42a46dae4e68a795cb8c20393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.noarch.rpm"
           },
-          "sha256:d00b18500ba10c9545b52ffe443a68abcb30b44a583dabf26a72e70357b75a2d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-nftables-1.0.4-2.el9.x86_64.rpm"
-          },
           "sha256:d02fbf0c285ba741968358ca1b8a2af93973fc03b1e0235ae967928b0e525a04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/iso-codes-4.6.0-3.el9.noarch.rpm"
           },
@@ -11929,9 +11715,6 @@
           },
           "sha256:d763e4d9e98fd3aac3db1828ed0de1f4b5ff46c939a207597db05fe60af52832": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/cloud-utils-growpart-0.31-10.el9.x86_64.rpm"
-          },
-          "sha256:d7691f79363d560c06bb4f70466487e83b4b7a8ef1a5d298c38683c65ea23cc8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl6000g2b-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:d7700be670043322bd376781019b348011642bcf776b453ee35dc860bbe888e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/criu-libs-3.17-4.el9.x86_64.rpm"
@@ -12160,9 +11943,6 @@
           },
           "sha256:ef1259f83ec0e6bfdf6d88c6ae294b1b4149d887a722671a28654b7468afeab1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libXxf86vm-1.1.4-18.el9.x86_64.rpm"
-          },
-          "sha256:ef40799584612faace9085293822e7c37ca3640b18057992f7a8aa75ac08bc4c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl2030-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
@@ -15521,26 +15301,6 @@
         "check_gpg": true
       },
       {
-        "name": "firewalld",
-        "epoch": 0,
-        "version": "1.1.1",
-        "release": "3.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-1.1.1-3.el9.noarch.rpm",
-        "checksum": "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885",
-        "check_gpg": true
-      },
-      {
-        "name": "firewalld-filesystem",
-        "epoch": 0,
-        "version": "1.1.1",
-        "release": "3.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/firewalld-filesystem-1.1.1-3.el9.noarch.rpm",
-        "checksum": "sha256:469bef28b5aa084cfc430c135b215af5bf6e2632e4e4f33819d789665ab540a0",
-        "check_gpg": true
-      },
-      {
         "name": "fonts-filesystem",
         "epoch": 1,
         "version": "2.0.5",
@@ -15991,26 +15751,6 @@
         "check_gpg": true
       },
       {
-        "name": "ipset",
-        "epoch": 0,
-        "version": "7.11",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ipset-7.11-6.el9.x86_64.rpm",
-        "checksum": "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c",
-        "check_gpg": true
-      },
-      {
-        "name": "ipset-libs",
-        "epoch": 0,
-        "version": "7.11",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/ipset-libs-7.11-6.el9.x86_64.rpm",
-        "checksum": "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.8",
@@ -16088,136 +15828,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/isns-utils-libs-0.101-4.el9.x86_64.rpm",
         "checksum": "sha256:b97fdc6512ba9406c92d9eda661f06c30b9d929ec78e437d32490ee4f06738b5",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl100-firmware",
-        "epoch": 0,
-        "version": "39.31.5.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl100-firmware-39.31.5.1-127.el9.noarch.rpm",
-        "checksum": "sha256:899ffa89ed6e72b237ef9f2f9fffce283e878dff4d12b12afd0f942e1a2b2101",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl1000-firmware",
-        "epoch": 1,
-        "version": "39.31.5.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl1000-firmware-39.31.5.1-127.el9.noarch.rpm",
-        "checksum": "sha256:4c62995f724d8d4d269e0585dfb6fff0b881fc7f8765ff63d52bc315dff83a4d",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl105-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl105-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:0ae6761e91cd860b4c6fae7421a6631e074f181de3d5e629f381f4e83a4f3523",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl135-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl135-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:21ceaf55f5726f7edfecc4e1dd8672ba2609c1107e735e20a10a7aa74059c2e4",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl2000-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl2000-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:61a22f5396dc6efc0ba2c8110338b2b3212fb2cbdb6f9e4bb817e7b5b0fddcde",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl2030-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl2030-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:ef40799584612faace9085293822e7c37ca3640b18057992f7a8aa75ac08bc4c",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl3160-firmware",
-        "epoch": 1,
-        "version": "25.30.13.0",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl3160-firmware-25.30.13.0-127.el9.noarch.rpm",
-        "checksum": "sha256:c05af0e379ec32aafb12872ca346bb83c1608130f7abdf9ef3ecac6811425369",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl5000-firmware",
-        "epoch": 0,
-        "version": "8.83.5.1_1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl5000-firmware-8.83.5.1_1-127.el9.noarch.rpm",
-        "checksum": "sha256:1bec0165c2c6351f2db73b3cda9ecfdae77dd61a79a37b499511941b19f04f7d",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl5150-firmware",
-        "epoch": 0,
-        "version": "8.24.2.2",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl5150-firmware-8.24.2.2-127.el9.noarch.rpm",
-        "checksum": "sha256:39cdbcc70f716592fd398f1885e05aaa7ae9ebc9d46d1774bfd090ae4f756096",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl6000g2a-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl6000g2a-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:1d3084f2b9aa415d219f2812da0de1e5800415927dffbb7785bd4f1a2ccc30a4",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl6000g2b-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl6000g2b-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:d7691f79363d560c06bb4f70466487e83b4b7a8ef1a5d298c38683c65ea23cc8",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl6050-firmware",
-        "epoch": 0,
-        "version": "41.28.5.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl6050-firmware-41.28.5.1-127.el9.noarch.rpm",
-        "checksum": "sha256:5a93097e08e847b113105a170132f74d91cf7143d2772fc73f78526ee32f32d7",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl7260-firmware",
-        "epoch": 1,
-        "version": "25.30.13.0",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/iwl7260-firmware-25.30.13.0-127.el9.noarch.rpm",
-        "checksum": "sha256:047751bcc89389360d7375733b64d27bd251da11a257d82f98eaeb204a943d15",
         "check_gpg": true
       },
       {
@@ -18321,16 +17931,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-firewall",
-        "epoch": 0,
-        "version": "1.1.1",
-        "release": "3.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-firewall-1.1.1-3.el9.noarch.rpm",
-        "checksum": "sha256:284f8e549fd6ad678f0a12def81fd5f6b177e6583d843e7069b2b780130e3fe0",
-        "check_gpg": true
-      },
-      {
         "name": "python3-gobject-base",
         "epoch": 0,
         "version": "3.40.1",
@@ -18458,16 +18058,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm",
         "checksum": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-nftables",
-        "epoch": 1,
-        "version": "1.0.4",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.1-20221015/Packages/python3-nftables-1.0.4-2.el9.x86_64.rpm",
-        "checksum": "sha256:d00b18500ba10c9545b52ffe443a68abcb30b44a583dabf26a72e70357b75a2d",
         "check_gpg": true
       },
       {
@@ -20858,16 +20448,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libcanberra-gtk3-0.30-26.el9.x86_64.rpm",
         "checksum": "sha256:b26d88e03ef525396261ff5453178d9a27cdb8d9c39bbcef585d771a2fd19716",
-        "check_gpg": true
-      },
-      {
-        "name": "libcap-ng-python3",
-        "epoch": 0,
-        "version": "0.8.2",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.1-20221015/Packages/libcap-ng-python3-0.8.2-7.el9.x86_64.rpm",
-        "checksum": "sha256:104cfea85cd346eec207c99f537e927de8c22816ef7d5196c4ede389ec045607",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-ami-boot.json
@@ -5219,6 +5219,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_92-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-ec2-boot.json
@@ -5268,6 +5268,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_92-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ami-boot.json
@@ -5051,6 +5051,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_92-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2-boot.json
@@ -5102,6 +5102,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
@@ -6546,6 +6546,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",

--- a/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
@@ -2710,22 +2710,6 @@
                     }
                   },
                   {
-                    "id": "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:469bef28b5aa084cfc430c135b215af5bf6e2632e4e4f33819d789665ab540a0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:d4b490f97fec6df68d467e74eeac7f26210757973175d344d989804e4f1a3629",
                     "options": {
                       "metadata": {
@@ -3086,22 +3070,6 @@
                     }
                   },
                   {
-                    "id": "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:dbe2c1c7ab6355590dfa7642d53a7e1933ff96ada640769253bdf177183901ba",
                     "options": {
                       "metadata": {
@@ -3159,110 +3127,6 @@
                   },
                   {
                     "id": "sha256:b97fdc6512ba9406c92d9eda661f06c30b9d929ec78e437d32490ee4f06738b5",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:899ffa89ed6e72b237ef9f2f9fffce283e878dff4d12b12afd0f942e1a2b2101",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:4c62995f724d8d4d269e0585dfb6fff0b881fc7f8765ff63d52bc315dff83a4d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:0ae6761e91cd860b4c6fae7421a6631e074f181de3d5e629f381f4e83a4f3523",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:21ceaf55f5726f7edfecc4e1dd8672ba2609c1107e735e20a10a7aa74059c2e4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:61a22f5396dc6efc0ba2c8110338b2b3212fb2cbdb6f9e4bb817e7b5b0fddcde",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:ef40799584612faace9085293822e7c37ca3640b18057992f7a8aa75ac08bc4c",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:c05af0e379ec32aafb12872ca346bb83c1608130f7abdf9ef3ecac6811425369",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1bec0165c2c6351f2db73b3cda9ecfdae77dd61a79a37b499511941b19f04f7d",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:39cdbcc70f716592fd398f1885e05aaa7ae9ebc9d46d1774bfd090ae4f756096",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:1d3084f2b9aa415d219f2812da0de1e5800415927dffbb7785bd4f1a2ccc30a4",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d7691f79363d560c06bb4f70466487e83b4b7a8ef1a5d298c38683c65ea23cc8",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:5a93097e08e847b113105a170132f74d91cf7143d2772fc73f78526ee32f32d7",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:047751bcc89389360d7375733b64d27bd251da11a257d82f98eaeb204a943d15",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -4950,14 +4814,6 @@
                     }
                   },
                   {
-                    "id": "sha256:284f8e549fd6ad678f0a12def81fd5f6b177e6583d843e7069b2b780130e3fe0",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
                     "id": "sha256:85912dbd3c57a6b5186b911498a7e7528865e24376ce7b1b6c05751929f97f7e",
                     "options": {
                       "metadata": {
@@ -5055,14 +4911,6 @@
                   },
                   {
                     "id": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:d00b18500ba10c9545b52ffe443a68abcb30b44a583dabf26a72e70357b75a2d",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -6975,14 +6823,6 @@
                   },
                   {
                     "id": "sha256:b26d88e03ef525396261ff5453178d9a27cdb8d9c39bbcef585d771a2fd19716",
-                    "options": {
-                      "metadata": {
-                        "rpm.check_gpg": true
-                      }
-                    }
-                  },
-                  {
-                    "id": "sha256:104cfea85cd346eec207c99f537e927de8c22816ef7d5196c4ede389ec045607",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -9620,9 +9460,6 @@
           "sha256:0410b58c4da6a03fab75b4f01aa4ea98406fb1050a13850b9be199a4e25dabee": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/kernel-tools-libs-5.14.0-177.el9.x86_64.rpm"
           },
-          "sha256:047751bcc89389360d7375733b64d27bd251da11a257d82f98eaeb204a943d15": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl7260-firmware-25.30.13.0-127.el9.noarch.rpm"
-          },
           "sha256:05372e66ce337a73f29f5839b7504f23b05104fad900fc2556901b27a7ee4752": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/libXft-2.3.3-8.el9.x86_64.rpm"
           },
@@ -9668,9 +9505,6 @@
           "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm"
           },
-          "sha256:0ae6761e91cd860b4c6fae7421a6631e074f181de3d5e629f381f4e83a4f3523": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl105-firmware-18.168.6.1-127.el9.noarch.rpm"
-          },
           "sha256:0b68c7111e169dd9d0073a3c48275bc2514c278d037495bf5ff9c41dbb7c8768": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/yum-utils-4.1.0-3.el9.noarch.rpm"
           },
@@ -9682,9 +9516,6 @@
           },
           "sha256:0c8f8e301f75c77a24821cc9170596a799edb33c1bf58b6490aa97c8ed7d5996": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/gmp-6.2.0-10.el9.x86_64.rpm"
-          },
-          "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/ipset-7.11-6.el9.x86_64.rpm"
           },
           "sha256:0d450719ca6a0d6e56df2cd462a233ad537d238a5af7d6b6551d733320204968": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/lm_sensors-libs-3.6.0-10.el9.x86_64.rpm"
@@ -9715,9 +9546,6 @@
           },
           "sha256:0fd96e53e678f92418c859d8fb95087dd989c7eacb399157768be0daef08cf8f": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-gpg-1.15.1-6.el9.x86_64.rpm"
-          },
-          "sha256:104cfea85cd346eec207c99f537e927de8c22816ef7d5196c4ede389ec045607": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/libcap-ng-python3-0.8.2-7.el9.x86_64.rpm"
           },
           "sha256:10b7e7b592a318fa73f37306b469c140175a1177b987f0041ec2c5b2e110953b": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/lorax-templates-rhel-9.0-35.el9.noarch.rpm"
@@ -9794,9 +9622,6 @@
           "sha256:178d47b34add4ba91b9ae416d2e368b21445975a4d23b197247877f09d38cd7d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-requests-2.25.1-6.el9.noarch.rpm"
           },
-          "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/firewalld-1.1.1-3.el9.noarch.rpm"
-          },
           "sha256:17d14b94f4236d52cf37d75bcef928c82845ddbf573780914da30ff607474ef8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/sssd-ldap-2.7.3-4.el9.x86_64.rpm"
           },
@@ -9833,9 +9658,6 @@
           "sha256:1bc121f166b99cc69d69ad7c7373bd9cd113ce2fe06b1c4ac501e51ac5f045f1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/libvorbis-1.3.7-5.el9.x86_64.rpm"
           },
-          "sha256:1bec0165c2c6351f2db73b3cda9ecfdae77dd61a79a37b499511941b19f04f7d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl5000-firmware-8.83.5.1_1-127.el9.noarch.rpm"
-          },
           "sha256:1c1dc9948dd4203ff4804d94c9cd30b9cc0faab5e5641b2b04b795c408fb4b1d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/tpm2-tools-5.2-1.el9.x86_64.rpm"
           },
@@ -9844,9 +9666,6 @@
           },
           "sha256:1d139cf3a413d30a18c354a1e89597c44bbfad7c46236f2f246cfddbc8d77ffa": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/kexec-tools-2.0.25-1.el9.x86_64.rpm"
-          },
-          "sha256:1d3084f2b9aa415d219f2812da0de1e5800415927dffbb7785bd4f1a2ccc30a4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl6000g2a-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:1d9cba6232250a092056a16aaa5512410611500080c2ababd8648bf38ce1b524": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/cloud-init-22.1-6.el9.noarch.rpm"
@@ -9889,9 +9708,6 @@
           },
           "sha256:219825121d761bf163e746f0ca424e4dfe071aece87c22ccd632abcf78ab4920": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-inotify-0.9.6-25.el9.noarch.rpm"
-          },
-          "sha256:21ceaf55f5726f7edfecc4e1dd8672ba2609c1107e735e20a10a7aa74059c2e4": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl135-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:21d6b644bb88b1ae63341701ab4782b4df3b36a0e1a44ca4e05499a1b5ce2f22": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/initscripts-10.11.5-1.el9.x86_64.rpm"
@@ -9967,9 +9783,6 @@
           },
           "sha256:28447275de51de98d76c70944b577d6aa72ab9fbdc3c23fc2925d41859535a9a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/elfutils-debuginfod-client-0.187-6.el9.x86_64.rpm"
-          },
-          "sha256:284f8e549fd6ad678f0a12def81fd5f6b177e6583d843e7069b2b780130e3fe0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-firewall-1.1.1-3.el9.noarch.rpm"
           },
           "sha256:289d4e53a6d59ba84dffc9ad5f8312bf9c14dc7528556e1a0e94c71428ead7e1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/libthai-0.1.28-8.el9.x86_64.rpm"
@@ -10142,9 +9955,6 @@
           "sha256:39ada507d193a14f8ee3d5226966dca1b5a6e9b591a1a4b11a059445596db7e0": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/linux-firmware-whence-20220708-127.el9.noarch.rpm"
           },
-          "sha256:39cdbcc70f716592fd398f1885e05aaa7ae9ebc9d46d1774bfd090ae4f756096": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl5150-firmware-8.24.2.2-127.el9.noarch.rpm"
-          },
           "sha256:39d6fe73373ae5692e510b7c6219ad1ffadad0f1bc59cb7095faf6e095811768": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-libcomps-0.1.18-1.el9.x86_64.rpm"
           },
@@ -10295,9 +10105,6 @@
           "sha256:46837f640f3bef9667f09fa46b85e0eb6b93c5acc92fb38371edabfcadad02db": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/urw-base35-bookman-fonts-20200910-6.el9.noarch.rpm"
           },
-          "sha256:469bef28b5aa084cfc430c135b215af5bf6e2632e4e4f33819d789665ab540a0": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/firewalld-filesystem-1.1.1-3.el9.noarch.rpm"
-          },
           "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm"
           },
@@ -10375,9 +10182,6 @@
           },
           "sha256:4c30037d7b80ee8355345bb8aab4af619e97cbb2a4cd5936dedf03fd7be72517": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/realmd-0.17.0-9.el9.x86_64.rpm"
-          },
-          "sha256:4c62995f724d8d4d269e0585dfb6fff0b881fc7f8765ff63d52bc315dff83a4d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl1000-firmware-39.31.5.1-127.el9.noarch.rpm"
           },
           "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/perl-File-stat-1.09-479.el9.noarch.rpm"
@@ -10514,9 +10318,6 @@
           "sha256:5a43c616c3f06fbba7d45ea4cdd87ca58cc46102908e089a14604de5d55a0393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/redhat-logos-90.4-1.el9.x86_64.rpm"
           },
-          "sha256:5a93097e08e847b113105a170132f74d91cf7143d2772fc73f78526ee32f32d7": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl6050-firmware-41.28.5.1-127.el9.noarch.rpm"
-          },
           "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm"
           },
@@ -10582,9 +10383,6 @@
           },
           "sha256:61998ac3bf97ca81d88e4e75bcf9ccfe82212802f66979dca2599e1569ce43d3": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/mtr-0.94-4.el9.x86_64.rpm"
-          },
-          "sha256:61a22f5396dc6efc0ba2c8110338b2b3212fb2cbdb6f9e4bb817e7b5b0fddcde": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl2000-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:6269b37dc0ec07fcc0690e9b48ec1f780c3247e65b96dc928e1d362843f07725": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/urw-base35-nimbus-sans-fonts-20200910-6.el9.noarch.rpm"
@@ -11050,9 +10848,6 @@
           },
           "sha256:89079e6774cfbeb847beca5612cf532c0b07df87a5243739ad06be22a6687cf8": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/libksba-1.5.1-5.el9_0.x86_64.rpm"
-          },
-          "sha256:899ffa89ed6e72b237ef9f2f9fffce283e878dff4d12b12afd0f942e1a2b2101": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl100-firmware-39.31.5.1-127.el9.noarch.rpm"
           },
           "sha256:89bd456fd7968d9f60291b9543c80ae190338162da328b11f07b5dec2f3d8edf": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/libnl3-cli-3.7.0-1.el9.x86_64.rpm"
@@ -11669,9 +11464,6 @@
           "sha256:c03849c4132fa3836d4e6957c2dfa48e0e0226097698fb7dbb29759926c7820c": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/webkit2gtk3-jsc-2.36.7-1.el9.x86_64.rpm"
           },
-          "sha256:c05af0e379ec32aafb12872ca346bb83c1608130f7abdf9ef3ecac6811425369": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl3160-firmware-25.30.13.0-127.el9.noarch.rpm"
-          },
           "sha256:c0bc12c29b9da0f5208816f6a88723524ecf8d49e06d4f5e1569d23970cc7955": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/mesa-libGL-22.1.5-2.el9.x86_64.rpm"
           },
@@ -11737,9 +11529,6 @@
           },
           "sha256:c5c3a4558e0eb53a4fd0bc0760e1988779d06c26deb52e135bda1597d86a02f4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/adobe-mappings-cmap-deprecated-20171205-12.el9.noarch.rpm"
-          },
-          "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/ipset-libs-7.11-6.el9.x86_64.rpm"
           },
           "sha256:c77d4fd29bf6af2cb9c67f6a7df7af85807c7722f6154178f0af6c5b9ff9af00": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/curl-7.76.1-20.el9.x86_64.rpm"
@@ -11831,9 +11620,6 @@
           "sha256:cfb5e8fddaed92b1b22c957183d0ea626a4468f42a46dae4e68a795cb8c20393": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/adobe-source-code-pro-fonts-2.030.1.050-12.el9.1.noarch.rpm"
           },
-          "sha256:d00b18500ba10c9545b52ffe443a68abcb30b44a583dabf26a72e70357b75a2d": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-nftables-1.0.4-2.el9.x86_64.rpm"
-          },
           "sha256:d02fbf0c285ba741968358ca1b8a2af93973fc03b1e0235ae967928b0e525a04": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/iso-codes-4.6.0-3.el9.noarch.rpm"
           },
@@ -11917,9 +11703,6 @@
           },
           "sha256:d763e4d9e98fd3aac3db1828ed0de1f4b5ff46c939a207597db05fe60af52832": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/cloud-utils-growpart-0.31-10.el9.x86_64.rpm"
-          },
-          "sha256:d7691f79363d560c06bb4f70466487e83b4b7a8ef1a5d298c38683c65ea23cc8": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl6000g2b-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:d7700be670043322bd376781019b348011642bcf776b453ee35dc860bbe888e4": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/criu-libs-3.17-4.el9.x86_64.rpm"
@@ -12151,9 +11934,6 @@
           },
           "sha256:ef3e27dd3d036a3d3aa7a259ebded846a47e814cc6a6545ebb6d95fb5399737e": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/ostree-libs-2022.6-1.el9.x86_64.rpm"
-          },
-          "sha256:ef40799584612faace9085293822e7c37ca3640b18057992f7a8aa75ac08bc4c": {
-            "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl2030-firmware-18.168.6.1-127.el9.noarch.rpm"
           },
           "sha256:ef6eb3e28612b850c9ae97b260d6a38a7fa77e8b9170516079baaa0f1154c09a": {
             "url": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/ca-certificates-2022.2.54-90.2.el9_0.noarch.rpm"
@@ -15521,26 +15301,6 @@
         "check_gpg": true
       },
       {
-        "name": "firewalld",
-        "epoch": 0,
-        "version": "1.1.1",
-        "release": "3.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/firewalld-1.1.1-3.el9.noarch.rpm",
-        "checksum": "sha256:17925d794b69973c7fa32dad63fe45bd3d2f778152f7188346d12cce8d980885",
-        "check_gpg": true
-      },
-      {
-        "name": "firewalld-filesystem",
-        "epoch": 0,
-        "version": "1.1.1",
-        "release": "3.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/firewalld-filesystem-1.1.1-3.el9.noarch.rpm",
-        "checksum": "sha256:469bef28b5aa084cfc430c135b215af5bf6e2632e4e4f33819d789665ab540a0",
-        "check_gpg": true
-      },
-      {
         "name": "fonts-filesystem",
         "epoch": 1,
         "version": "2.0.5",
@@ -15991,26 +15751,6 @@
         "check_gpg": true
       },
       {
-        "name": "ipset",
-        "epoch": 0,
-        "version": "7.11",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/ipset-7.11-6.el9.x86_64.rpm",
-        "checksum": "sha256:0cc6f5489219f848fa74d3aa01cd8edf29bdae260c81c65e3e57591cc932e70c",
-        "check_gpg": true
-      },
-      {
-        "name": "ipset-libs",
-        "epoch": 0,
-        "version": "7.11",
-        "release": "6.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/ipset-libs-7.11-6.el9.x86_64.rpm",
-        "checksum": "sha256:c713d625acdeeba438c739bc1f9ed6e63e2ee3fb8334d4328fe2c8822e1c9b5d",
-        "check_gpg": true
-      },
-      {
         "name": "iptables-libs",
         "epoch": 0,
         "version": "1.8.8",
@@ -16088,136 +15828,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/isns-utils-libs-0.101-4.el9.x86_64.rpm",
         "checksum": "sha256:b97fdc6512ba9406c92d9eda661f06c30b9d929ec78e437d32490ee4f06738b5",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl100-firmware",
-        "epoch": 0,
-        "version": "39.31.5.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl100-firmware-39.31.5.1-127.el9.noarch.rpm",
-        "checksum": "sha256:899ffa89ed6e72b237ef9f2f9fffce283e878dff4d12b12afd0f942e1a2b2101",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl1000-firmware",
-        "epoch": 1,
-        "version": "39.31.5.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl1000-firmware-39.31.5.1-127.el9.noarch.rpm",
-        "checksum": "sha256:4c62995f724d8d4d269e0585dfb6fff0b881fc7f8765ff63d52bc315dff83a4d",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl105-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl105-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:0ae6761e91cd860b4c6fae7421a6631e074f181de3d5e629f381f4e83a4f3523",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl135-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl135-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:21ceaf55f5726f7edfecc4e1dd8672ba2609c1107e735e20a10a7aa74059c2e4",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl2000-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl2000-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:61a22f5396dc6efc0ba2c8110338b2b3212fb2cbdb6f9e4bb817e7b5b0fddcde",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl2030-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl2030-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:ef40799584612faace9085293822e7c37ca3640b18057992f7a8aa75ac08bc4c",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl3160-firmware",
-        "epoch": 1,
-        "version": "25.30.13.0",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl3160-firmware-25.30.13.0-127.el9.noarch.rpm",
-        "checksum": "sha256:c05af0e379ec32aafb12872ca346bb83c1608130f7abdf9ef3ecac6811425369",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl5000-firmware",
-        "epoch": 0,
-        "version": "8.83.5.1_1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl5000-firmware-8.83.5.1_1-127.el9.noarch.rpm",
-        "checksum": "sha256:1bec0165c2c6351f2db73b3cda9ecfdae77dd61a79a37b499511941b19f04f7d",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl5150-firmware",
-        "epoch": 0,
-        "version": "8.24.2.2",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl5150-firmware-8.24.2.2-127.el9.noarch.rpm",
-        "checksum": "sha256:39cdbcc70f716592fd398f1885e05aaa7ae9ebc9d46d1774bfd090ae4f756096",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl6000g2a-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl6000g2a-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:1d3084f2b9aa415d219f2812da0de1e5800415927dffbb7785bd4f1a2ccc30a4",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl6000g2b-firmware",
-        "epoch": 0,
-        "version": "18.168.6.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl6000g2b-firmware-18.168.6.1-127.el9.noarch.rpm",
-        "checksum": "sha256:d7691f79363d560c06bb4f70466487e83b4b7a8ef1a5d298c38683c65ea23cc8",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl6050-firmware",
-        "epoch": 0,
-        "version": "41.28.5.1",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl6050-firmware-41.28.5.1-127.el9.noarch.rpm",
-        "checksum": "sha256:5a93097e08e847b113105a170132f74d91cf7143d2772fc73f78526ee32f32d7",
-        "check_gpg": true
-      },
-      {
-        "name": "iwl7260-firmware",
-        "epoch": 1,
-        "version": "25.30.13.0",
-        "release": "127.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/iwl7260-firmware-25.30.13.0-127.el9.noarch.rpm",
-        "checksum": "sha256:047751bcc89389360d7375733b64d27bd251da11a257d82f98eaeb204a943d15",
         "check_gpg": true
       },
       {
@@ -18321,16 +17931,6 @@
         "check_gpg": true
       },
       {
-        "name": "python3-firewall",
-        "epoch": 0,
-        "version": "1.1.1",
-        "release": "3.el9",
-        "arch": "noarch",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-firewall-1.1.1-3.el9.noarch.rpm",
-        "checksum": "sha256:284f8e549fd6ad678f0a12def81fd5f6b177e6583d843e7069b2b780130e3fe0",
-        "check_gpg": true
-      },
-      {
         "name": "python3-gobject-base",
         "epoch": 0,
         "version": "3.40.1",
@@ -18458,16 +18058,6 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-linux-procfs-0.7.0-1.el9.noarch.rpm",
         "checksum": "sha256:9e41bd1f52490f21696a4a11a5e0c28fbc74d21930e94cf02c34a8f7430420ac",
-        "check_gpg": true
-      },
-      {
-        "name": "python3-nftables",
-        "epoch": 1,
-        "version": "1.0.4",
-        "release": "2.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-baseos-n9.2-20221025/Packages/python3-nftables-1.0.4-2.el9.x86_64.rpm",
-        "checksum": "sha256:d00b18500ba10c9545b52ffe443a68abcb30b44a583dabf26a72e70357b75a2d",
         "check_gpg": true
       },
       {
@@ -20858,16 +20448,6 @@
         "arch": "x86_64",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/libcanberra-gtk3-0.30-26.el9.x86_64.rpm",
         "checksum": "sha256:b26d88e03ef525396261ff5453178d9a27cdb8d9c39bbcef585d771a2fd19716",
-        "check_gpg": true
-      },
-      {
-        "name": "libcap-ng-python3",
-        "epoch": 0,
-        "version": "0.8.2",
-        "release": "7.el9",
-        "arch": "x86_64",
-        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-x86_64-appstream-n9.2-20221025/Packages/libcap-ng-python3-0.8.2-7.el9.x86_64.rpm",
-        "checksum": "sha256:104cfea85cd346eec207c99f537e927de8c22816ef7d5196c4ede389ec045607",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
@@ -9136,6 +9136,18 @@
             }
           },
           {
+            "type": "org.osbuild.modprobe",
+            "options": {
+              "filename": "blacklist-amdgpu.conf",
+              "commands": [
+                {
+                  "command": "blacklist",
+                  "modulename": "amdgpu"
+                }
+              ]
+            }
+          },
+          {
             "type": "org.osbuild.dracut.conf",
             "options": {
               "filename": "sgdisk.conf",


### PR DESCRIPTION
- disable the `amdgpu` module by default on all RHEL AWS images
- exclude unwanted packages from RHEL-9 EC2 SAP package set

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
