### PR TITLE
disk: align LVM2 volumes to the extent size 

### DIFF
--- a/internal/disk/btrfs.go
+++ b/internal/disk/btrfs.go
@@ -67,6 +67,10 @@ func (b *Btrfs) CreateMountpoint(mountpoint string, size uint64) (Entity, error)
 	return &b.Subvolumes[len(b.Subvolumes)-1], nil
 }
 
+func (b *Btrfs) AlignUp(size uint64) uint64 {
+	return size // No extra alignment necessary for subvolumes
+}
+
 func (b *Btrfs) GenUUID(rng *rand.Rand) {
 	if b.UUID == "" {
 		b.UUID = uuid.Must(newRandomUUIDFromReader(rng)).String()

--- a/internal/disk/disk.go
+++ b/internal/disk/disk.go
@@ -120,6 +120,10 @@ type Mountable interface {
 // returns the entity that represents the new mountpoint.
 type MountpointCreator interface {
 	CreateMountpoint(mountpoint string, size uint64) (Entity, error)
+
+	// AlignUp will align the given bytes according to the
+	// requirements of the container type.
+	AlignUp(size uint64) uint64
 }
 
 // A UniqueEntity is an entity that can be uniquely identified via a UUID.

--- a/internal/disk/lvm.go
+++ b/internal/disk/lvm.go
@@ -61,9 +61,7 @@ func (vg *LVMVolumeGroup) GetChild(n uint) Entity {
 }
 
 func (vg *LVMVolumeGroup) CreateMountpoint(mountpoint string, size uint64) (Entity, error) {
-	if vg == nil {
-		panic("LVMVolumeGroup.CreateMountpoint: nil entity")
-	}
+
 	filesystem := Filesystem{
 		Type:         "xfs",
 		Mountpoint:   mountpoint,
@@ -72,12 +70,20 @@ func (vg *LVMVolumeGroup) CreateMountpoint(mountpoint string, size uint64) (Enti
 		FSTabPassNo:  0,
 	}
 
+	return vg.CreateLogicalVolume(mountpoint, size, &filesystem)
+}
+
+func (vg *LVMVolumeGroup) CreateLogicalVolume(lvName string, size uint64, payload Entity) (Entity, error) {
+	if vg == nil {
+		panic("LVMVolumeGroup.CreateLogicalVolume: nil entity")
+	}
+
 	names := make(map[string]bool, len(vg.LogicalVolumes))
 	for _, lv := range vg.LogicalVolumes {
 		names[lv.Name] = true
 	}
 
-	base := lvname(mountpoint)
+	base := lvname(lvName)
 	var exists bool
 	name := base
 
@@ -100,7 +106,7 @@ func (vg *LVMVolumeGroup) CreateMountpoint(mountpoint string, size uint64) (Enti
 	lv := LVMLogicalVolume{
 		Name:    name,
 		Size:    size,
-		Payload: &filesystem,
+		Payload: payload,
 	}
 
 	vg.LogicalVolumes = append(vg.LogicalVolumes, lv)


### PR DESCRIPTION
When the size of a logical volume is not aligned to the extent size of the volume group, LVM2 will automatically align it by rounding up (see [metadata.c](https://github.com/lvmteam/lvm2/blob/868665766491d9d42b8acedaf07cafc7118d165c/lib/metadata/metadata.c#L1072)):

	Rounding up size to full physical extent 29.80 GiB
	Rounding up size to full physical extent <3.82 GiB

Since we don't take that into account when we create a new volume or set the size of an existing one, the size for the whole volume group will be short by that amount and thus the creation of the last volume
will fail:

  	Volume group <uuid> has insufficient free space (975 extents): 977 required.

To fix this a new `AlignUp` method is added to the `MountpointCreator` creator interface. It will align a given size to the requirements of the implementing container, like e.g. `LVMVolumeGroup`. It is then used by a new `alignEntityBranch` which takes a size and walks the entity path, calling `AlignUp` for all entities that implement said `MountpointCreator` interface; thus the resulting size should fullfil the alignment requirement for all elements in the path. NB: `PartitionTable` already had an `AlignUp` method.

Add a corresponding test.
