### PR TITLE
ci: fix the packer job

### DIFF
--- a/tools/appsre-build-worker-packer.sh
+++ b/tools/appsre-build-worker-packer.sh
@@ -22,6 +22,12 @@ elif [ -n "$GIT_BRANCH" ]; then
 fi
 
 if [ "$ON_JENKINS" = false ]; then
+    # work around not working podman from 9.1 on a 9.0 image
+    # see https://bugzilla.redhat.com/show_bug.cgi?id=2143282
+    # TODO: Remove me when the bug is fixed or we switch to 9.1
+    sudo dnf remove -y python-unversioned-command
+    sudo dnf upgrade -y
+
     sudo dnf install -y podman jq
 fi
 


### PR DESCRIPTION
Podman doesn't work when installed from 9.1 repositories on 9.0 image.

I found that upgrading the whole system helps. Sadly, that requires removing
python-unversioned-command for some reason.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
