### PR TITLE
rhsm: remove CA from consumer secrets

### DIFF
--- a/internal/ostree/ostree_test.go
+++ b/internal/ostree/ostree_test.go
@@ -44,7 +44,6 @@ func TestOstreeResolveRef(t *testing.T) {
 	defer srv2.Close()
 	subs := &rhsm.Subscriptions{
 		Consumer: &rhsm.ConsumerSecrets{
-			CACert:       mTLSSrv.CAPath,
 			ConsumerKey:  mTLSSrv.ClientKeyPath,
 			ConsumerCert: mTLSSrv.ClientCrtPath,
 		},
@@ -79,7 +78,7 @@ func TestOstreeResolveRef(t *testing.T) {
 			{srvConf.Srv.URL, "valid/ostree/ref"}: goodRef,
 		}
 		for in, expOut := range validCases {
-			out, err := ResolveRef(in.location, in.ref, srvConf.RHSM, srvConf.Subs)
+			out, err := ResolveRef(in.location, in.ref, srvConf.RHSM, srvConf.Subs, &mTLSSrv.CAPath)
 			assert.NoError(t, err)
 			assert.Equal(t, expOut, out)
 		}
@@ -92,7 +91,7 @@ func TestOstreeResolveRef(t *testing.T) {
 			{srvConf.Srv.URL, "get_bad_ref"}:        fmt.Sprintf("ostree repository \"%s/refs/heads/get_bad_ref\" returned invalid reference", srvConf.Srv.URL),
 		}
 		for in, expMsg := range errCases {
-			_, err := ResolveRef(in.location, in.ref, srvConf.RHSM, srvConf.Subs)
+			_, err := ResolveRef(in.location, in.ref, srvConf.RHSM, srvConf.Subs, &mTLSSrv.CAPath)
 			assert.EqualError(t, err, expMsg)
 		}
 	}

--- a/internal/rhsm/secrets.go
+++ b/internal/rhsm/secrets.go
@@ -38,7 +38,6 @@ type RHSMSecrets struct {
 
 // These secrets are present on any subscribed system and uniquely identify the host
 type ConsumerSecrets struct {
-	CACert       string
 	ConsumerKey  string
 	ConsumerCert string
 }
@@ -86,7 +85,6 @@ func getListOfSubscriptions() ([]subscription, error) {
 
 func getConsumerSecrets() (*ConsumerSecrets, error) {
 	res := ConsumerSecrets{
-		CACert:       "/etc/rhsm/ca/redhat-uep.pem",
 		ConsumerKey:  "/etc/pki/consumer/key.pem",
 		ConsumerCert: "/etc/pki/consumer/cert.pem",
 	}


### PR DESCRIPTION
This CA is only valid for the entitlement certificates, not the consumer certificates.

As a result resolving the ostree ref should use the system's CA cert pool.

