### PR TITLE
osbuild-worker: handle interruptions gracefully

### DIFF
--- a/cmd/osbuild-composer/composer.go
+++ b/cmd/osbuild-composer/composer.go
@@ -115,7 +115,7 @@ func NewComposer(config *ComposerConfigFile, stateDir, cacheDir string) (*Compos
 	return &c, nil
 }
 
-func (c *Composer) InitWeldr(repoPaths []string, weldrListener net.Listener,
+func (c *Composer) InitWeldr(ctx context.Context, repoPaths []string, weldrListener net.Listener,
 	distrosImageTypeDenylist map[string][]string) (err error) {
 	c.weldr, err = weldr.New(repoPaths, c.stateDir, c.solver, c.distros, c.logger, c.workers, distrosImageTypeDenylist)
 	if err != nil {
@@ -124,7 +124,7 @@ func (c *Composer) InitWeldr(repoPaths []string, weldrListener net.Listener,
 	c.weldrListener = weldrListener
 
 	// Preload the Metadata for all the supported distros
-	c.weldr.PreloadMetadata()
+	c.weldr.PreloadMetadata(ctx)
 	return nil
 }
 

--- a/cmd/osbuild-composer/main.go
+++ b/cmd/osbuild-composer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -94,7 +95,7 @@ func main() {
 			logrus.Fatal("The osbuild-composer.socket unit is misconfigured. It should contain only one socket.")
 		}
 
-		err = composer.InitWeldr(repositoryConfigs, l[0], config.weldrDistrosImageTypeDenyList())
+		err = composer.InitWeldr(context.Background(), repositoryConfigs, l[0], config.weldrDistrosImageTypeDenyList())
 		if err != nil {
 			logrus.Fatalf("Error initializing weldr API: %v", err)
 		}

--- a/cmd/osbuild-dnf-json-tests/main_test.go
+++ b/cmd/osbuild-dnf-json-tests/main_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,7 +62,7 @@ func TestCrossArchDepsolve(t *testing.T) {
 								repos[archStr])
 
 							for _, set := range packages {
-								_, err = solver.Depsolve(set)
+								_, err = solver.Depsolve(context.Background(), set)
 								assert.NoError(t, err)
 							}
 						})
@@ -126,7 +127,7 @@ func TestDepsolvePackageSets(t *testing.T) {
 			gotPackageSpecsSets := make(map[string][]rpmmd.PackageSpec, len(imagePkgSets))
 
 			for name, pkgSet := range imagePkgSets {
-				res, err := solver.Depsolve(pkgSet)
+				res, err := solver.Depsolve(context.Background(), pkgSet)
 				if err != nil {
 					require.Nil(t, err)
 				}

--- a/cmd/osbuild-image-tests/main_test.go
+++ b/cmd/osbuild-image-tests/main_test.go
@@ -335,7 +335,7 @@ func testBootUsingAWS(t *testing.T, imagePath string) {
 	require.NoError(t, err)
 
 	// the following line should be done by osbuild-composer at some point
-	err = boot.UploadImageToAWS(creds, imagePath, imageName)
+	err = boot.UploadImageToAWS(context.Background(), creds, imagePath, imageName)
 	require.NoErrorf(t, err, "upload to amazon failed, resources could have been leaked")
 
 	imageDesc, err := boot.DescribeEC2Image(e, imageName)

--- a/cmd/osbuild-pipeline/main.go
+++ b/cmd/osbuild-pipeline/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -182,7 +183,7 @@ func main() {
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 
 	for name, pkgSet := range packageSets {
-		res, err := solver.Depsolve(pkgSet)
+		res, err := solver.Depsolve(context.Background(), pkgSet)
 		if err != nil {
 			panic("Could not depsolve: " + err.Error())
 		}

--- a/cmd/osbuild-playground/main.go
+++ b/cmd/osbuild-playground/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -104,5 +105,5 @@ func main() {
 
 	state_dir := path.Join(home, ".local/share/osbuild-playground/")
 
-	RunPlayground(img, d, arch, repos, state_dir)
+	RunPlayground(context.Background(), img, d, arch, repos, state_dir)
 }

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -37,7 +37,7 @@ func RunPlayground(ctx context.Context, img image.ImageKind, d distro.Distro, ar
 
 	packageSpecs := make(map[string][]rpmmd.PackageSpec)
 	for name, chain := range manifest.GetPackageSetChains() {
-		packages, err := solver.Depsolve(chain)
+		packages, err := solver.Depsolve(ctx, chain)
 		if err != nil {
 			panic(fmt.Sprintf("failed to depsolve for pipeline %s: %s\n", name, err.Error()))
 		}

--- a/cmd/osbuild-playground/playground.go
+++ b/cmd/osbuild-playground/playground.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
@@ -15,7 +16,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/runner"
 )
 
-func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos map[string][]rpmmd.RepoConfig, state_dir string) {
+func RunPlayground(ctx context.Context, img image.ImageKind, d distro.Distro, arch distro.Arch, repos map[string][]rpmmd.RepoConfig, state_dir string) {
 
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), arch.Name(), path.Join(state_dir, "rpmmd"))
 	solver.SetDNFJSONPath(findDnfJsonBin())
@@ -55,7 +56,7 @@ func RunPlayground(img image.ImageKind, d distro.Distro, arch distro.Arch, repos
 
 	store := path.Join(state_dir, "osbuild-store")
 
-	_, err = osbuild.RunOSBuild(bytes, store, "./", manifest.GetExports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
+	_, err = osbuild.RunOSBuild(ctx, bytes, store, "./", manifest.GetExports(), manifest.GetCheckpoints(), nil, false, os.Stdout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not run osbuild: %s", err.Error())
 	}

--- a/cmd/osbuild-service-maintenance/gcp.go
+++ b/cmd/osbuild-service-maintenance/gcp.go
@@ -15,7 +15,7 @@ import (
 )
 
 func GCPCleanup(creds []byte, maxConcurrentRequests int, dryRun bool, cutoff time.Time) error {
-	g, err := gcp.New(creds)
+	g, err := gcp.New(context.Background(), creds)
 	if err != nil {
 		return err
 	}

--- a/cmd/osbuild-store-dump/main.go
+++ b/cmd/osbuild-store-dump/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path"
 	"time"
@@ -24,7 +25,7 @@ func getManifest(bp blueprint.Blueprint, t distro.ImageType, a distro.Arch, d di
 	pkgSpecSets := make(map[string][]rpmmd.PackageSpec)
 	solver := dnfjson.NewSolver(d.ModulePlatformID(), d.Releasever(), a.Name(), cacheDir)
 	for name, packages := range packageSets {
-		res, err := solver.Depsolve(packages)
+		res, err := solver.Depsolve(context.Background(), packages)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/osbuild-upload-aws/main.go
+++ b/cmd/osbuild-upload-aws/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -50,7 +51,7 @@ func main() {
 	if shareWith != "" {
 		share = append(share, shareWith)
 	}
-	ami, err := a.Register(imageName, bucketName, keyName, share, arch)
+	ami, err := a.Register(context.Background(), imageName, bucketName, keyName, share, arch)
 	if err != nil {
 		println(err.Error())
 		return

--- a/cmd/osbuild-upload-gcp/main.go
+++ b/cmd/osbuild-upload-gcp/main.go
@@ -68,12 +68,12 @@ func main() {
 		}
 	}
 
-	g, err := gcp.New(credentials)
+	ctx := context.Background()
+
+	g, err := gcp.New(ctx, credentials)
 	if err != nil {
 		logrus.Fatalf("[GCP] Failed to create new GCP object: %v", err)
 	}
-
-	ctx := context.Background()
 
 	// Upload image to the Storage
 	if !skipUpload {

--- a/cmd/osbuild-worker/jobimpl-awsec2.go
+++ b/cmd/osbuild-worker/jobimpl-awsec2.go
@@ -41,7 +41,7 @@ func (impl *AWSEC2CopyJobImpl) Run(ctx context.Context, job worker.Job) (interfa
 		return &result, err
 	}
 
-	ami, err := aws.CopyImage(args.TargetName, args.Ami, args.SourceRegion)
+	ami, err := aws.CopyImage(ctx, args.TargetName, args.Ami, args.SourceRegion)
 	if err != nil {
 		logWithId.Errorf("Error copying ami: %v", err)
 		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorSharingTarget, fmt.Sprintf("Error copying ami %s", args.Ami), nil)

--- a/cmd/osbuild-worker/jobimpl-awsec2.go
+++ b/cmd/osbuild-worker/jobimpl-awsec2.go
@@ -23,7 +23,7 @@ type AWSEC2CopyJobImpl struct {
 	AWSCreds string
 }
 
-func (impl *AWSEC2CopyJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *AWSEC2CopyJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	result := worker.AWSEC2CopyJobResult{}
 
@@ -69,7 +69,7 @@ type AWSEC2ShareJobImpl struct {
 	AWSCreds string
 }
 
-func (impl *AWSEC2ShareJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *AWSEC2ShareJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	result := worker.AWSEC2ShareJobResult{}
 

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/sirupsen/logrus"
 
@@ -14,12 +14,12 @@ type ContainerResolveJobImpl struct {
 	AuthFilePath string
 }
 
-func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
+func (impl *ContainerResolveJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	var args worker.ContainerResolveJob
 	err := job.Args(&args)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	result := worker.ContainerResolveJobResult{
@@ -51,10 +51,5 @@ func (impl *ContainerResolveJobImpl) Run(job worker.Job) error {
 		}
 	}
 
-	err = job.Update(&result)
-	if err != nil {
-		return fmt.Errorf("Error reporting job result: %v", err)
-	}
-
-	return nil
+	return &result, nil
 }

--- a/cmd/osbuild-worker/jobimpl-container-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-container-resolve.go
@@ -14,7 +14,7 @@ type ContainerResolveJobImpl struct {
 	AuthFilePath string
 }
 
-func (impl *ContainerResolveJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *ContainerResolveJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	var args worker.ContainerResolveJob
 	err := job.Args(&args)

--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -19,12 +19,12 @@ type DepsolveJobImpl struct {
 // in repos are used for all package sets, whereas the repositories in
 // packageSetsRepos are only used for the package set with the same name
 // (matching map keys).
-func (impl *DepsolveJobImpl) depsolve(packageSets map[string][]rpmmd.PackageSet, modulePlatformID, arch, releasever string) (map[string][]rpmmd.PackageSpec, error) {
+func (impl *DepsolveJobImpl) depsolve(ctx context.Context, packageSets map[string][]rpmmd.PackageSet, modulePlatformID, arch, releasever string) (map[string][]rpmmd.PackageSpec, error) {
 	solver := impl.Solver.NewWithConfig(modulePlatformID, releasever, arch)
 
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	for name, pkgSet := range packageSets {
-		res, err := solver.Depsolve(pkgSet)
+		res, err := solver.Depsolve(ctx, pkgSet)
 		if err != nil {
 			return nil, err
 		}
@@ -43,7 +43,7 @@ func (impl *DepsolveJobImpl) Run(ctx context.Context, job worker.Job) (interface
 	}
 
 	var result worker.DepsolveJobResult
-	result.PackageSpecs, err = impl.depsolve(args.PackageSets, args.ModulePlatformID, args.Arch, args.Releasever)
+	result.PackageSpecs, err = impl.depsolve(ctx, args.PackageSets, args.ModulePlatformID, args.Arch, args.Releasever)
 	if err != nil {
 		switch e := err.(type) {
 		case dnfjson.Error:

--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -34,7 +34,7 @@ func (impl *DepsolveJobImpl) depsolve(ctx context.Context, packageSets map[strin
 	return depsolvedSets, nil
 }
 
-func (impl *DepsolveJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *DepsolveJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	var args worker.DepsolveJob
 	err := job.Args(&args)

--- a/cmd/osbuild-worker/jobimpl-depsolve.go
+++ b/cmd/osbuild-worker/jobimpl-depsolve.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/sirupsen/logrus"
 
@@ -34,12 +34,12 @@ func (impl *DepsolveJobImpl) depsolve(packageSets map[string][]rpmmd.PackageSet,
 	return depsolvedSets, nil
 }
 
-func (impl *DepsolveJobImpl) Run(job worker.Job) error {
+func (impl *DepsolveJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	var args worker.DepsolveJob
 	err := job.Args(&args)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var result worker.DepsolveJobResult
@@ -72,10 +72,5 @@ func (impl *DepsolveJobImpl) Run(job worker.Job) error {
 		logWithId.Errorf("Error during rpm repo cache cleanup: %s", err.Error())
 	}
 
-	err = job.Update(&result)
-	if err != nil {
-		return fmt.Errorf("Error reporting job result: %v", err)
-	}
-
-	return nil
+	return &result, err
 }

--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -84,7 +84,7 @@ func (impl *KojiFinalizeJobImpl) kojiFail(server string, buildID int, token stri
 	return k.CGFailBuild(buildID, token)
 }
 
-func (impl *KojiFinalizeJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *KojiFinalizeJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id().String())
 
 	// initialize the result variable to be used to report status back to composer
@@ -216,7 +216,7 @@ func (impl *KojiFinalizeJobImpl) Run(ctx context.Context, job worker.Job) (inter
 
 // Extracts dynamic args of the koji-finalize job. Returns an error if they
 // cannot be unmarshalled.
-func extractDynamicArgs(job worker.Job) (*worker.KojiInitJobResult, []worker.OSBuildJobResult, error) {
+func extractDynamicArgs(job *worker.Job) (*worker.KojiInitJobResult, []worker.OSBuildJobResult, error) {
 	var kojiInitResult worker.KojiInitJobResult
 	err := job.DynamicArgs(0, &kojiInitResult)
 	if err != nil {

--- a/cmd/osbuild-worker/jobimpl-koji-init.go
+++ b/cmd/osbuild-worker/jobimpl-koji-init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 
@@ -47,11 +48,11 @@ func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (st
 	return buildInfo.Token, uint64(buildInfo.BuildID), nil
 }
 
-func (impl *KojiInitJobImpl) Run(job worker.Job) error {
+func (impl *KojiInitJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
 	var args worker.KojiInitJob
 	err := job.Args(&args)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var result worker.KojiInitJobResult
@@ -60,10 +61,5 @@ func (impl *KojiInitJobImpl) Run(job worker.Job) error {
 		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorKojiInit, err.Error(), nil)
 	}
 
-	err = job.Update(&result)
-	if err != nil {
-		return fmt.Errorf("Error reporting job result: %v", err)
-	}
-
-	return nil
+	return &result, nil
 }

--- a/cmd/osbuild-worker/jobimpl-koji-init.go
+++ b/cmd/osbuild-worker/jobimpl-koji-init.go
@@ -48,7 +48,7 @@ func (impl *KojiInitJobImpl) kojiInit(server, name, version, release string) (st
 	return buildInfo.Token, uint64(buildInfo.BuildID), nil
 }
 
-func (impl *KojiInitJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *KojiInitJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	var args worker.KojiInitJob
 	err := job.Args(&args)
 	if err != nil {

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -254,7 +254,7 @@ func (impl *OSBuildJobImpl) getContainerClient(destination string, targetOptions
 	return client, nil
 }
 
-func (impl *OSBuildJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *OSBuildJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id().String())
 	// Initialize variable needed for reporting back to osbuild-composer.
 	var osbuildJobResult *worker.OSBuildJobResult = &worker.OSBuildJobResult{
@@ -413,7 +413,7 @@ func (impl *OSBuildJobImpl) Run(ctx context.Context, job worker.Job) (interface{
 				break
 			}
 			defer f.Close()
-			err = job.UploadArtifact(jobTarget.ImageName, f)
+			err = job.UploadArtifact(ctx, jobTarget.ImageName, f)
 			if err != nil {
 				targetResult.TargetError = clienterrors.WorkerClientError(clienterrors.ErrorUploadingImage, err.Error(), nil)
 				break

--- a/cmd/osbuild-worker/jobimpl-osbuild.go
+++ b/cmd/osbuild-worker/jobimpl-osbuild.go
@@ -365,7 +365,7 @@ func (impl *OSBuildJobImpl) Run(ctx context.Context, job worker.Job) (interface{
 	}
 
 	// Run osbuild and handle two kinds of errors
-	osbuildJobResult.OSBuildOutput, err = osbuild.RunOSBuild(jobArgs.Manifest, impl.Store, outputDirectory, exports, nil, extraEnv, true, os.Stderr)
+	osbuildJobResult.OSBuildOutput, err = osbuild.RunOSBuild(ctx, jobArgs.Manifest, impl.Store, outputDirectory, exports, nil, extraEnv, true, os.Stderr)
 	// First handle the case when "running" osbuild failed
 	if err != nil {
 		osbuildJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorBuildJob, "osbuild build failed", nil)

--- a/cmd/osbuild-worker/jobimpl-ostree-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-ostree-resolve.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"context"
 
 	"github.com/sirupsen/logrus"
 
@@ -36,12 +36,12 @@ func setError(err error, result *worker.OSTreeResolveJobResult) {
 	}
 }
 
-func (impl *OSTreeResolveJobImpl) Run(job worker.Job) error {
+func (impl *OSTreeResolveJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	var args worker.OSTreeResolveJob
 	err := job.Args(&args)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	result := worker.OSTreeResolveJobResult{
@@ -73,10 +73,5 @@ func (impl *OSTreeResolveJobImpl) Run(job worker.Job) error {
 		}
 	}
 
-	err = job.Update(&result)
-	if err != nil {
-		return fmt.Errorf("Error reporting job result: %v", err)
-	}
-
-	return nil
+	return &result, nil
 }

--- a/cmd/osbuild-worker/jobimpl-ostree-resolve.go
+++ b/cmd/osbuild-worker/jobimpl-ostree-resolve.go
@@ -36,7 +36,7 @@ func setError(err error, result *worker.OSTreeResolveJobResult) {
 	}
 }
 
-func (impl *OSTreeResolveJobImpl) Run(ctx context.Context, job worker.Job) (interface{}, error) {
+func (impl *OSTreeResolveJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
 	logWithId := logrus.WithField("jobId", job.Id())
 	var args worker.OSTreeResolveJob
 	err := job.Args(&args)

--- a/cmd/osbuild-worker/main.go
+++ b/cmd/osbuild-worker/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -9,23 +8,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
-	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/sirupsen/logrus"
 
-	"github.com/osbuild/osbuild-composer/internal/common"
-	"github.com/osbuild/osbuild-composer/internal/dnfjson"
-	"github.com/osbuild/osbuild-composer/internal/upload/azure"
 	"github.com/osbuild/osbuild-composer/internal/upload/koji"
-	"github.com/osbuild/osbuild-composer/internal/worker"
 )
 
 const configFile = "/etc/osbuild-worker/osbuild-worker.toml"
@@ -40,11 +28,6 @@ type connectionConfig struct {
 type kojiServer struct {
 	creds              koji.GSSAPICredentials
 	relaxTimeoutFactor uint
-}
-
-// Represents the implementation of a job type as defined by the worker API.
-type JobImplementation interface {
-	Run(job worker.Job) error
 }
 
 func createTLSConfig(config *connectionConfig) (*tls.Config, error) {
@@ -73,132 +56,6 @@ func createTLSConfig(config *connectionConfig) (*tls.Config, error) {
 		Certificates: certs,
 		MinVersion:   tls.VersionTLS12,
 	}, nil
-}
-
-// Regularly ask osbuild-composer if the compose we're currently working on was
-// canceled and exit the process if it was.
-// It would be cleaner to kill the osbuild process using (`exec.CommandContext`
-// or similar), but osbuild does not currently support this. Exiting here will
-// make systemd clean up the whole cgroup and restart this service.
-func WatchJob(ctx context.Context, job worker.Job) {
-	for {
-		select {
-		case <-time.After(15 * time.Second):
-			canceled, err := job.Canceled()
-			if err == nil && canceled {
-				logrus.Info("Job was canceled. Exiting.")
-				os.Exit(0)
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-// protect an AWS instance from scaling and/or terminating.
-func setProtection(protected bool) {
-	// create a new session
-	awsSession, err := session.NewSession()
-	if err != nil {
-		logrus.Debugf("Error getting an AWS session, %s", err)
-		return
-	}
-
-	// get the identity for the instanceID
-	identity, err := ec2metadata.New(awsSession).GetInstanceIdentityDocument()
-	if err != nil {
-		logrus.Debugf("Error getting the identity document, %s", err)
-		return
-	}
-
-	svc := autoscaling.New(awsSession, aws.NewConfig().WithRegion(identity.Region))
-
-	// get the autoscaling group info for the auto scaling group name
-	asInstanceInput := &autoscaling.DescribeAutoScalingInstancesInput{
-		InstanceIds: []*string{
-			aws.String(identity.InstanceID),
-		},
-	}
-	asInstanceOutput, err := svc.DescribeAutoScalingInstances(asInstanceInput)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			logrus.Warningf("Error getting the Autoscaling instances: %s %s", aerr.Code(), aerr.Error())
-		} else {
-			logrus.Errorf("Error getting the Autoscaling instances: unknown, %s", err)
-		}
-		return
-	}
-	if len(asInstanceOutput.AutoScalingInstances) == 0 {
-		logrus.Info("No Autoscaling instace is defined")
-		return
-	}
-
-	// make the request to protect (or unprotect) the instance
-	input := &autoscaling.SetInstanceProtectionInput{
-		AutoScalingGroupName: asInstanceOutput.AutoScalingInstances[0].AutoScalingGroupName,
-		InstanceIds: []*string{
-			aws.String(identity.InstanceID),
-		},
-		ProtectedFromScaleIn: aws.Bool(protected),
-	}
-	_, err = svc.SetInstanceProtection(input)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			logrus.Warningf("Error protecting instance: %s %s", aerr.Code(), aerr.Error())
-		} else {
-			logrus.Errorf("Error protecting instance: unknown, %s", err)
-		}
-		return
-	}
-	if protected {
-		logrus.Info("Instance protected")
-	} else {
-		logrus.Info("Instance protection removed")
-	}
-}
-
-// Requests and runs 1 job of specified type(s)
-// Returning an error here will result in the worker backing off for a while and retrying
-func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls map[string]JobImplementation) error {
-	logrus.Debug("Waiting for a new job...")
-	job, err := client.RequestJob(acceptedJobTypes, common.CurrentArch())
-	if err == worker.ErrClientRequestJobTimeout {
-		logrus.Debugf("Requesting job timed out: %v", err)
-		return nil
-	}
-	if err != nil {
-		logrus.Errorf("Requesting job failed: %v", err)
-		return err
-	}
-
-	impl, exists := jobImpls[job.Type()]
-	if !exists {
-		logrus.Errorf("Ignoring job with unknown type %s", job.Type())
-		return err
-	}
-
-	// Depsolve requests needs reactivity, since setting the protection can take up to 6s to timeout if the worker isn't
-	// in an AWS env, disable this setting for them.
-	if job.Type() != worker.JobTypeDepsolve {
-		setProtection(true)
-		defer setProtection(false)
-	}
-
-	logrus.Infof("Running job '%s' (%s)\n", job.Id(), job.Type())
-
-	ctx, cancelWatcher := context.WithCancel(context.Background())
-	go WatchJob(ctx, job)
-
-	err = impl.Run(job)
-	cancelWatcher()
-	if err != nil {
-		logrus.Warnf("Job '%s' (%s) failed: %v", job.Id(), job.Type(), err)
-		// Don't return this error so the worker picks up the next job immediately
-		return nil
-	}
-
-	logrus.Infof("Job '%s' (%s) finished", job.Id(), job.Type())
-	return nil
 }
 
 func main() {
@@ -234,256 +91,14 @@ func main() {
 	if !ok {
 		logrus.Fatal("CACHE_DIRECTORY is not set. Is the service file missing CacheDirectory=?")
 	}
-	store := path.Join(cacheDirectory, "osbuild-store")
-	rpmmd_cache := path.Join(cacheDirectory, "rpmmd")
-	output := path.Join(cacheDirectory, "output")
-	_ = os.Mkdir(output, os.ModeDir)
 
-	kojiServers := make(map[string]kojiServer)
-	for server, kojiConfig := range config.Koji {
-		if kojiConfig.Kerberos == nil {
-			// For now we only support Kerberos authentication.
-			continue
-		}
-		kojiServers[server] = kojiServer{
-			creds: koji.GSSAPICredentials{
-				Principal: kojiConfig.Kerberos.Principal,
-				KeyTab:    kojiConfig.Kerberos.KeyTab,
-			},
-			relaxTimeoutFactor: kojiConfig.RelaxTimeoutFactor,
-		}
+	worker, err := NewWorker(config, unix, address, cacheDirectory)
+	if err != nil {
+		logrus.Fatalf("%v", err)
 	}
 
-	var client *worker.Client
-	if unix {
-		client = worker.NewClientUnix(worker.ClientConfig{
-			BaseURL:  address,
-			BasePath: config.BasePath,
-		})
-	} else if config.Authentication != nil {
-		var conf *tls.Config
-		conConf := &connectionConfig{
-			CACertFile: "/etc/osbuild-composer/ca-crt.pem",
-		}
-		if _, err = os.Stat(conConf.CACertFile); err == nil {
-			conf, err = createTLSConfig(conConf)
-			if err != nil {
-				logrus.Fatalf("Error creating TLS config: %v", err)
-			}
-		}
-
-		token := ""
-		if config.Authentication.OfflineTokenPath != "" {
-			t, err := ioutil.ReadFile(config.Authentication.OfflineTokenPath)
-			if err != nil {
-				logrus.Fatalf("Could not read offline token: %v", err)
-			}
-			token = strings.TrimSpace(string(t))
-		}
-
-		clientSecret := ""
-		if config.Authentication.ClientSecretPath != "" {
-			cs, err := ioutil.ReadFile(config.Authentication.ClientSecretPath)
-			if err != nil {
-				logrus.Fatalf("Could not read client secret: %v", err)
-			}
-			clientSecret = strings.TrimSpace(string(cs))
-		}
-
-		proxy := ""
-		if config.Composer != nil && config.Composer.Proxy != "" {
-			proxy = config.Composer.Proxy
-		}
-
-		client, err = worker.NewClient(worker.ClientConfig{
-			BaseURL:      fmt.Sprintf("https://%s", address),
-			TlsConfig:    conf,
-			OfflineToken: token,
-			OAuthURL:     config.Authentication.OAuthURL,
-			ClientId:     config.Authentication.ClientId,
-			ClientSecret: clientSecret,
-			BasePath:     config.BasePath,
-			ProxyURL:     proxy,
-		})
-		if err != nil {
-			logrus.Fatalf("Error creating worker client: %v", err)
-		}
-	} else {
-		var conf *tls.Config
-		conConf := &connectionConfig{
-			CACertFile:     "/etc/osbuild-composer/ca-crt.pem",
-			ClientKeyFile:  "/etc/osbuild-composer/worker-key.pem",
-			ClientCertFile: "/etc/osbuild-composer/worker-crt.pem",
-		}
-		if _, err = os.Stat(conConf.CACertFile); err == nil {
-			conf, err = createTLSConfig(conConf)
-			if err != nil {
-				logrus.Fatalf("Error creating TLS config: %v", err)
-			}
-		}
-
-		proxy := ""
-		if config.Composer != nil && config.Composer.Proxy != "" {
-			proxy = config.Composer.Proxy
-		}
-
-		client, err = worker.NewClient(worker.ClientConfig{
-			BaseURL:   fmt.Sprintf("https://%s", address),
-			TlsConfig: conf,
-			BasePath:  config.BasePath,
-			ProxyURL:  proxy,
-		})
-		if err != nil {
-			logrus.Fatalf("Error creating worker client: %v", err)
-		}
-	}
-
-	// Load Azure credentials early. If the credentials file is malformed,
-	// we can report the issue early instead of waiting for the first osbuild
-	// job with the org.osbuild.azure.image target.
-	var azureCredentials *azure.Credentials
-	if config.Azure != nil {
-		azureCredentials, err = azure.ParseAzureCredentialsFile(config.Azure.Credentials)
-		if err != nil {
-			logrus.Fatalf("cannot load azure credentials: %v", err)
-		}
-	}
-
-	// If the credentials are not provided in the configuration, then the
-	// worker will rely on the GCP library to authenticate using default means.
-	var gcpConfig GCPConfiguration
-	if config.GCP != nil {
-		gcpConfig.Creds = config.GCP.Credentials
-		gcpConfig.Bucket = config.GCP.Bucket
-	}
-
-	// If the credentials are not provided in the configuration, then the
-	// worker will look in $HOME/.aws/credentials or at the file pointed by
-	// the "AWS_SHARED_CREDENTIALS_FILE" variable.
-	var awsCredentials = ""
-	var awsBucket = ""
-	if config.AWS != nil {
-		awsCredentials = config.AWS.Credentials
-		awsBucket = config.AWS.Bucket
-	}
-
-	var genericS3Credentials = ""
-	var genericS3Endpoint = ""
-	var genericS3Region = ""
-	var genericS3Bucket = ""
-	var genericS3CABundle = ""
-	var genericS3SkipSSLVerification = false
-	if config.GenericS3 != nil {
-		genericS3Credentials = config.GenericS3.Credentials
-		genericS3Endpoint = config.GenericS3.Endpoint
-		genericS3Region = config.GenericS3.Region
-		genericS3Bucket = config.GenericS3.Bucket
-		genericS3CABundle = config.GenericS3.CABundle
-		genericS3SkipSSLVerification = config.GenericS3.SkipSSLVerification
-	}
-
-	var containersAuthFilePath string
-	var containersDomain = ""
-	var containersPathPrefix = ""
-	var containersCertPath = ""
-	var containersTLSVerify = true
-	if config.Containers != nil {
-		containersAuthFilePath = config.Containers.AuthFilePath
-		containersDomain = config.Containers.Domain
-		containersPathPrefix = config.Containers.PathPrefix
-		containersCertPath = config.Containers.CertPath
-		containersTLSVerify = config.Containers.TLSVerify
-	}
-
-	// depsolve jobs can be done during other jobs
-	depsolveCtx, depsolveCtxCancel := context.WithCancel(context.Background())
-	solver := dnfjson.NewBaseSolver(rpmmd_cache)
-	if config.DNFJson != "" {
-		solver.SetDNFJSONPath(config.DNFJson)
-	}
-	defer depsolveCtxCancel()
-	go func() {
-		jobImpls := map[string]JobImplementation{
-			worker.JobTypeDepsolve: &DepsolveJobImpl{
-				Solver: solver,
-			},
-		}
-		acceptedJobTypes := []string{}
-		for jt := range jobImpls {
-			acceptedJobTypes = append(acceptedJobTypes, jt)
-		}
-
-		for {
-			err := RequestAndRunJob(client, acceptedJobTypes, jobImpls)
-			if err != nil {
-				logrus.Warn("Received error from RequestAndRunJob, backing off")
-				time.Sleep(backoffDuration)
-			}
-
-			select {
-			case <-depsolveCtx.Done():
-				return
-			default:
-				continue
-			}
-
-		}
-	}()
-
-	// non-depsolve job
-	jobImpls := map[string]JobImplementation{
-		worker.JobTypeOSBuild: &OSBuildJobImpl{
-			Store:       store,
-			Output:      output,
-			KojiServers: kojiServers,
-			GCPConfig:   gcpConfig,
-			AzureCreds:  azureCredentials,
-			AWSCreds:    awsCredentials,
-			AWSBucket:   awsBucket,
-			S3Config: S3Configuration{
-				Creds:               genericS3Credentials,
-				Endpoint:            genericS3Endpoint,
-				Region:              genericS3Region,
-				Bucket:              genericS3Bucket,
-				CABundle:            genericS3CABundle,
-				SkipSSLVerification: genericS3SkipSSLVerification,
-			},
-			ContainersConfig: ContainersConfiguration{
-				AuthFilePath: containersAuthFilePath,
-				Domain:       containersDomain,
-				PathPrefix:   containersPathPrefix,
-				CertPath:     containersCertPath,
-				TLSVerify:    &containersTLSVerify,
-			},
-		},
-		worker.JobTypeKojiInit: &KojiInitJobImpl{
-			KojiServers: kojiServers,
-		},
-		worker.JobTypeKojiFinalize: &KojiFinalizeJobImpl{
-			KojiServers: kojiServers,
-		},
-		worker.JobTypeContainerResolve: &ContainerResolveJobImpl{
-			AuthFilePath: containersAuthFilePath,
-		},
-		worker.JobTypeOSTreeResolve: &OSTreeResolveJobImpl{},
-		worker.JobTypeAWSEC2Copy: &AWSEC2CopyJobImpl{
-			AWSCreds: awsCredentials,
-		},
-		worker.JobTypeAWSEC2Share: &AWSEC2ShareJobImpl{
-			AWSCreds: awsCredentials,
-		},
-	}
-
-	acceptedJobTypes := []string{}
-	for jt := range jobImpls {
-		acceptedJobTypes = append(acceptedJobTypes, jt)
-	}
-
-	for {
-		err = RequestAndRunJob(client, acceptedJobTypes, jobImpls)
-		if err != nil {
-			logrus.Warn("Received error from RequestAndRunJob, backing off")
-			time.Sleep(backoffDuration)
-		}
+	err = worker.Start()
+	if err != nil {
+		logrus.Fatalf("%v", err)
 	}
 }

--- a/cmd/osbuild-worker/worker.go
+++ b/cmd/osbuild-worker/worker.go
@@ -1,0 +1,428 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/sirupsen/logrus"
+
+	"github.com/osbuild/osbuild-composer/internal/common"
+	"github.com/osbuild/osbuild-composer/internal/dnfjson"
+	"github.com/osbuild/osbuild-composer/internal/upload/azure"
+	"github.com/osbuild/osbuild-composer/internal/upload/koji"
+	"github.com/osbuild/osbuild-composer/internal/worker"
+)
+
+// Represents the implementation of a job type as defined by the worker API.
+type JobImplementation interface {
+	Run(job worker.Job) error
+}
+
+type Worker struct {
+	config *workerConfig
+
+	depsolveJobImpls map[string]JobImplementation
+	otherJobImpls    map[string]JobImplementation
+
+	client *worker.Client
+}
+
+func NewWorker(config *workerConfig, unix bool, address, cacheDir string) (*Worker, error) {
+	w := Worker{
+		config: config,
+	}
+
+	solver := dnfjson.NewBaseSolver(path.Join(cacheDir, "rpmmd"))
+	solver.SetDNFJSONPath(w.config.DNFJson)
+	w.depsolveJobImpls = map[string]JobImplementation{
+		worker.JobTypeDepsolve: &DepsolveJobImpl{
+			Solver: solver,
+		},
+	}
+
+	store := path.Join(cacheDir, "osbuild-store")
+	output := path.Join(cacheDir, "output")
+	_ = os.Mkdir(output, os.ModeDir)
+
+	kojiServers := make(map[string]kojiServer)
+	for server, kojiConfig := range config.Koji {
+		if kojiConfig.Kerberos == nil {
+			// For now we only support Kerberos authentication.
+			continue
+		}
+		kojiServers[server] = kojiServer{
+			creds: koji.GSSAPICredentials{
+				Principal: kojiConfig.Kerberos.Principal,
+				KeyTab:    kojiConfig.Kerberos.KeyTab,
+			},
+			relaxTimeoutFactor: kojiConfig.RelaxTimeoutFactor,
+		}
+	}
+
+	if unix {
+		w.client = worker.NewClientUnix(worker.ClientConfig{
+			BaseURL:  address,
+			BasePath: config.BasePath,
+		})
+	} else if config.Authentication != nil {
+		var conf *tls.Config
+		conConf := &connectionConfig{
+			CACertFile: "/etc/osbuild-composer/ca-crt.pem",
+		}
+		if _, err := os.Stat(conConf.CACertFile); err == nil {
+			conf, err = createTLSConfig(conConf)
+			if err != nil {
+				logrus.Fatalf("Error creating TLS config: %v", err)
+			}
+		}
+
+		token := ""
+		if config.Authentication.OfflineTokenPath != "" {
+			t, err := ioutil.ReadFile(config.Authentication.OfflineTokenPath)
+			if err != nil {
+				logrus.Fatalf("Could not read offline token: %v", err)
+			}
+			token = strings.TrimSpace(string(t))
+		}
+
+		clientSecret := ""
+		if config.Authentication.ClientSecretPath != "" {
+			cs, err := ioutil.ReadFile(config.Authentication.ClientSecretPath)
+			if err != nil {
+				logrus.Fatalf("Could not read client secret: %v", err)
+			}
+			clientSecret = strings.TrimSpace(string(cs))
+		}
+
+		proxy := ""
+		if config.Composer != nil && config.Composer.Proxy != "" {
+			proxy = config.Composer.Proxy
+		}
+
+		client, err := worker.NewClient(worker.ClientConfig{
+			BaseURL:      fmt.Sprintf("https://%s", address),
+			TlsConfig:    conf,
+			OfflineToken: token,
+			OAuthURL:     config.Authentication.OAuthURL,
+			ClientId:     config.Authentication.ClientId,
+			ClientSecret: clientSecret,
+			BasePath:     config.BasePath,
+			ProxyURL:     proxy,
+		})
+		if err != nil {
+			logrus.Fatalf("Error creating worker client: %v", err)
+		}
+		w.client = client
+	} else {
+		var conf *tls.Config
+		conConf := &connectionConfig{
+			CACertFile:     "/etc/osbuild-composer/ca-crt.pem",
+			ClientKeyFile:  "/etc/osbuild-composer/worker-key.pem",
+			ClientCertFile: "/etc/osbuild-composer/worker-crt.pem",
+		}
+		if _, err := os.Stat(conConf.CACertFile); err == nil {
+			conf, err = createTLSConfig(conConf)
+			if err != nil {
+				logrus.Fatalf("Error creating TLS config: %v", err)
+			}
+		}
+
+		proxy := ""
+		if config.Composer != nil && config.Composer.Proxy != "" {
+			proxy = config.Composer.Proxy
+		}
+
+		client, err := worker.NewClient(worker.ClientConfig{
+			BaseURL:   fmt.Sprintf("https://%s", address),
+			TlsConfig: conf,
+			BasePath:  config.BasePath,
+			ProxyURL:  proxy,
+		})
+		if err != nil {
+			logrus.Fatalf("Error creating worker client: %v", err)
+		}
+		w.client = client
+	}
+
+	// Load Azure credentials early. If the credentials file is malformed,
+	// we can report the issue early instead of waiting for the first osbuild
+	// job with the org.osbuild.azure.image target.
+	var azureCredentials *azure.Credentials
+	if config.Azure != nil {
+		var err error
+		azureCredentials, err = azure.ParseAzureCredentialsFile(config.Azure.Credentials)
+		if err != nil {
+			logrus.Fatalf("cannot load azure credentials: %v", err)
+		}
+	}
+
+	// If the credentials are not provided in the configuration, then the
+	// worker will rely on the GCP library to authenticate using default means.
+	var gcpConfig GCPConfiguration
+	if config.GCP != nil {
+		gcpConfig.Creds = config.GCP.Credentials
+		gcpConfig.Bucket = config.GCP.Bucket
+	}
+
+	// If the credentials are not provided in the configuration, then the
+	// worker will look in $HOME/.aws/credentials or at the file pointed by
+	// the "AWS_SHARED_CREDENTIALS_FILE" variable.
+	var awsCredentials = ""
+	var awsBucket = ""
+	if config.AWS != nil {
+		awsCredentials = config.AWS.Credentials
+		awsBucket = config.AWS.Bucket
+	}
+
+	var genericS3Credentials = ""
+	var genericS3Endpoint = ""
+	var genericS3Region = ""
+	var genericS3Bucket = ""
+	var genericS3CABundle = ""
+	var genericS3SkipSSLVerification = false
+	if config.GenericS3 != nil {
+		genericS3Credentials = config.GenericS3.Credentials
+		genericS3Endpoint = config.GenericS3.Endpoint
+		genericS3Region = config.GenericS3.Region
+		genericS3Bucket = config.GenericS3.Bucket
+		genericS3CABundle = config.GenericS3.CABundle
+		genericS3SkipSSLVerification = config.GenericS3.SkipSSLVerification
+	}
+
+	var containersAuthFilePath string
+	var containersDomain = ""
+	var containersPathPrefix = ""
+	var containersCertPath = ""
+	var containersTLSVerify = true
+	if config.Containers != nil {
+		containersAuthFilePath = config.Containers.AuthFilePath
+		containersDomain = config.Containers.Domain
+		containersPathPrefix = config.Containers.PathPrefix
+		containersCertPath = config.Containers.CertPath
+		containersTLSVerify = config.Containers.TLSVerify
+	}
+
+	// non-depsolve job
+	w.otherJobImpls = map[string]JobImplementation{
+		worker.JobTypeOSBuild: &OSBuildJobImpl{
+			Store:       store,
+			Output:      output,
+			KojiServers: kojiServers,
+			GCPConfig:   gcpConfig,
+			AzureCreds:  azureCredentials,
+			AWSCreds:    awsCredentials,
+			AWSBucket:   awsBucket,
+			S3Config: S3Configuration{
+				Creds:               genericS3Credentials,
+				Endpoint:            genericS3Endpoint,
+				Region:              genericS3Region,
+				Bucket:              genericS3Bucket,
+				CABundle:            genericS3CABundle,
+				SkipSSLVerification: genericS3SkipSSLVerification,
+			},
+			ContainersConfig: ContainersConfiguration{
+				AuthFilePath: containersAuthFilePath,
+				Domain:       containersDomain,
+				PathPrefix:   containersPathPrefix,
+				CertPath:     containersCertPath,
+				TLSVerify:    &containersTLSVerify,
+			},
+		},
+		worker.JobTypeKojiInit: &KojiInitJobImpl{
+			KojiServers: kojiServers,
+		},
+		worker.JobTypeKojiFinalize: &KojiFinalizeJobImpl{
+			KojiServers: kojiServers,
+		},
+		worker.JobTypeContainerResolve: &ContainerResolveJobImpl{
+			AuthFilePath: containersAuthFilePath,
+		},
+		worker.JobTypeOSTreeResolve: &OSTreeResolveJobImpl{},
+		worker.JobTypeAWSEC2Copy: &AWSEC2CopyJobImpl{
+			AWSCreds: awsCredentials,
+		},
+		worker.JobTypeAWSEC2Share: &AWSEC2ShareJobImpl{
+			AWSCreds: awsCredentials,
+		},
+	}
+
+	return &w, nil
+}
+
+// Regularly ask osbuild-composer if the compose we're currently working on was
+// canceled and exit the process if it was.
+// It would be cleaner to kill the osbuild process using (`exec.CommandContext`
+// or similar), but osbuild does not currently support this. Exiting here will
+// make systemd clean up the whole cgroup and restart this service.
+func WatchJob(ctx context.Context, job worker.Job) {
+	for {
+		select {
+		case <-time.After(15 * time.Second):
+			canceled, err := job.Canceled()
+			if err == nil && canceled {
+				logrus.Info("Job was canceled. Exiting.")
+				os.Exit(0)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// protect an AWS instance from scaling and/or terminating.
+func setProtection(protected bool) {
+	// create a new session
+	awsSession, err := session.NewSession()
+	if err != nil {
+		logrus.Debugf("Error getting an AWS session, %s", err)
+		return
+	}
+
+	// get the identity for the instanceID
+	identity, err := ec2metadata.New(awsSession).GetInstanceIdentityDocument()
+	if err != nil {
+		logrus.Debugf("Error getting the identity document, %s", err)
+		return
+	}
+
+	svc := autoscaling.New(awsSession, aws.NewConfig().WithRegion(identity.Region))
+
+	// get the autoscaling group info for the auto scaling group name
+	asInstanceInput := &autoscaling.DescribeAutoScalingInstancesInput{
+		InstanceIds: []*string{
+			aws.String(identity.InstanceID),
+		},
+	}
+	asInstanceOutput, err := svc.DescribeAutoScalingInstances(asInstanceInput)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			logrus.Warningf("Error getting the Autoscaling instances: %s %s", aerr.Code(), aerr.Error())
+		} else {
+			logrus.Errorf("Error getting the Autoscaling instances: unknown, %s", err)
+		}
+		return
+	}
+	if len(asInstanceOutput.AutoScalingInstances) == 0 {
+		logrus.Info("No Autoscaling instace is defined")
+		return
+	}
+
+	// make the request to protect (or unprotect) the instance
+	input := &autoscaling.SetInstanceProtectionInput{
+		AutoScalingGroupName: asInstanceOutput.AutoScalingInstances[0].AutoScalingGroupName,
+		InstanceIds: []*string{
+			aws.String(identity.InstanceID),
+		},
+		ProtectedFromScaleIn: aws.Bool(protected),
+	}
+	_, err = svc.SetInstanceProtection(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			logrus.Warningf("Error protecting instance: %s %s", aerr.Code(), aerr.Error())
+		} else {
+			logrus.Errorf("Error protecting instance: unknown, %s", err)
+		}
+		return
+	}
+	if protected {
+		logrus.Info("Instance protected")
+	} else {
+		logrus.Info("Instance protection removed")
+	}
+}
+
+// Requests and runs 1 job of specified type(s)
+// Returning an error here will result in the worker backing off for a while and retrying
+func RequestAndRunJob(client *worker.Client, acceptedJobTypes []string, jobImpls map[string]JobImplementation) error {
+	logrus.Debug("Waiting for a new job...")
+	job, err := client.RequestJob(acceptedJobTypes, common.CurrentArch())
+	if err == worker.ErrClientRequestJobTimeout {
+		logrus.Debugf("Requesting job timed out: %v", err)
+		return nil
+	}
+	if err != nil {
+		logrus.Errorf("Requesting job failed: %v", err)
+		return err
+	}
+
+	impl, exists := jobImpls[job.Type()]
+	if !exists {
+		logrus.Errorf("Ignoring job with unknown type %s", job.Type())
+		return err
+	}
+
+	// Depsolve requests needs reactivity, since setting the protection can take up to 6s to timeout if the worker isn't
+	// in an AWS env, disable this setting for them.
+	if job.Type() != worker.JobTypeDepsolve {
+		setProtection(true)
+		defer setProtection(false)
+	}
+
+	logrus.Infof("Running job '%s' (%s)\n", job.Id(), job.Type())
+
+	ctx, cancelWatcher := context.WithCancel(context.Background())
+	go WatchJob(ctx, job)
+
+	err = impl.Run(job)
+	cancelWatcher()
+	if err != nil {
+		logrus.Warnf("Job '%s' (%s) failed: %v", job.Id(), job.Type(), err)
+		// Don't return this error so the worker picks up the next job immediately
+		return nil
+	}
+
+	logrus.Infof("Job '%s' (%s) finished", job.Id(), job.Type())
+	return nil
+}
+
+func (worker *Worker) Start() error {
+	// depsolve jobs can be done during other jobs
+	depsolveCtx, depsolveCtxCancel := context.WithCancel(context.Background())
+	defer depsolveCtxCancel()
+	go func() {
+		acceptedJobTypes := []string{}
+		for jt := range worker.depsolveJobImpls {
+			acceptedJobTypes = append(acceptedJobTypes, jt)
+		}
+
+		for {
+			err := RequestAndRunJob(worker.client, acceptedJobTypes, worker.depsolveJobImpls)
+			if err != nil {
+				logrus.Warn("Received error from RequestAndRunJob, backing off")
+				time.Sleep(backoffDuration)
+			}
+
+			select {
+			case <-depsolveCtx.Done():
+				return
+			default:
+				continue
+			}
+
+		}
+	}()
+
+	acceptedJobTypes := []string{}
+	for jt := range worker.otherJobImpls {
+		acceptedJobTypes = append(acceptedJobTypes, jt)
+	}
+
+	for {
+		err := RequestAndRunJob(worker.client, acceptedJobTypes, worker.otherJobImpls)
+		if err != nil {
+			logrus.Warn("Received error from RequestAndRunJob, backing off")
+			time.Sleep(backoffDuration)
+		}
+	}
+}

--- a/internal/boot/aws.go
+++ b/internal/boot/aws.go
@@ -1,8 +1,10 @@
+//go:build integration
 // +build integration
 
 package boot
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -90,7 +92,7 @@ func wrapErrorf(innerError error, format string, a ...interface{}) error {
 // It takes an image and an image name and creates an ec2 instance from them.
 // The s3 key is never returned - the same thing is done in osbuild-composer,
 // the user has no way of getting the s3 key.
-func UploadImageToAWS(c *awsCredentials, imagePath string, imageName string) error {
+func UploadImageToAWS(ctx context.Context, c *awsCredentials, imagePath string, imageName string) error {
 	uploader, err := awscloud.New(c.Region, c.AccessKeyId, c.SecretAccessKey, c.sessionToken)
 	if err != nil {
 		return fmt.Errorf("cannot create aws uploader: %v", err)
@@ -100,7 +102,7 @@ func UploadImageToAWS(c *awsCredentials, imagePath string, imageName string) err
 	if err != nil {
 		return fmt.Errorf("cannot upload the image: %v", err)
 	}
-	_, err = uploader.Register(imageName, c.Bucket, imageName, nil, common.CurrentArch())
+	_, err = uploader.Register(ctx, imageName, c.Bucket, imageName, nil, common.CurrentArch())
 	if err != nil {
 		return fmt.Errorf("cannot register the image: %v", err)
 	}

--- a/internal/cloud/gcp/gcp.go
+++ b/internal/cloud/gcp/gcp.go
@@ -24,7 +24,7 @@ type GCP struct {
 }
 
 // New returns an authenticated GCP instance, allowing to interact with GCP API.
-func New(credentials []byte) (*GCP, error) {
+func New(ctx context.Context, credentials []byte) (*GCP, error) {
 	scopes := []string{storage.ScopeReadWrite}                 // file upload
 	scopes = append(scopes, compute.DefaultAuthScopes()...)    // permissions to image
 	scopes = append(scopes, cloudbuild.DefaultAuthScopes()...) // image import
@@ -33,7 +33,7 @@ func New(credentials []byte) (*GCP, error) {
 	if credentials != nil {
 		getCredsFunc = func() (*google.Credentials, error) {
 			return google.CredentialsFromJSON(
-				context.Background(),
+				ctx,
 				credentials,
 				scopes...,
 			)
@@ -41,7 +41,7 @@ func New(credentials []byte) (*GCP, error) {
 	} else {
 		getCredsFunc = func() (*google.Credentials, error) {
 			return google.FindDefaultCredentials(
-				context.Background(),
+				ctx,
 				scopes...,
 			)
 		}
@@ -57,12 +57,12 @@ func New(credentials []byte) (*GCP, error) {
 
 // NewFromFile loads the credentials from a file and returns an authenticated
 // *GCP object instance.
-func NewFromFile(path string) (*GCP, error) {
+func NewFromFile(ctx context.Context, path string) (*GCP, error) {
 	gcpCredentials, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot load GCP credentials from file %q: %v", path, err)
 	}
-	return New(gcpCredentials)
+	return New(ctx, gcpCredentials)
 }
 
 // GetProjectID returns a string with the Project ID of the project, used for

--- a/internal/cloud/instanceprotector/instance-protector.go
+++ b/internal/cloud/instanceprotector/instance-protector.go
@@ -1,0 +1,156 @@
+package instanceprotector
+
+import (
+	"context"
+	"time"
+)
+
+type InstanceProtectorImpl interface {
+	SetProtection(bool)
+}
+
+type InstanceProtector struct {
+	protImpl         InstanceProtectorImpl
+	protectTimeout   time.Duration
+	unprotectTimeout time.Duration
+	protect          chan struct{}
+	unprotect        chan struct{}
+}
+
+// NewInstanceProtector returns an instance protector that can
+// protect up to @size jobs in parallel. Beyond that limit
+// calls to Protect() starts to block.
+func NewInstanceProtector(protectTimeout, unprotectTimeout time.Duration, size uint64, protImpl InstanceProtectorImpl) *InstanceProtector {
+	ip := &InstanceProtector{
+		protImpl:         protImpl,
+		protectTimeout:   protectTimeout,
+		unprotectTimeout: unprotectTimeout,
+		protect:          make(chan struct{}, size),
+		unprotect:        make(chan struct{}, size),
+	}
+	return ip
+}
+
+// Protect requests the instance to be protected from shutdown.
+//
+// The request is serviced asynchronously and is best effort only.
+func (ip *InstanceProtector) Protect() {
+	if ip != nil {
+		ip.protect <- struct{}{}
+	}
+}
+
+// Unprotect indicates that the instance no longer needs to be protected.
+//
+// The request is serviced asynchronosuly, so the instance may still
+// remain protected even though all Protect requests have been undone.
+func (ip *InstanceProtector) Unprotect() {
+	if ip != nil {
+		ip.unprotect <- struct{}{}
+	}
+}
+
+// protectOnce asynchronously performs one protect followed by one
+// unprotect call. Return early in case the context is cancelled.
+//
+// If the context is cancelled, we may not actually call
+// protect/unprotect at all. But if protect is called, then
+// unprotect is always called too.
+//
+// Collate matching protect/unprotect tokens when possible
+// to avoid uneccesary calls (which can be slow), this should
+// minimize the risk of queues of tokens building up which in
+// the worst case could block new work being scheduled, or at
+// least cause us to unprotect when we should still be protected
+// and vice versa.
+//
+// The main reason for doing this async, is that the calls can
+// be very slow and cause unneccesary blocking. There is already
+// a race between a job being dequeued and the instance being
+// protected, and moreover the protection is not always respected
+// by the cloud provider, so we do not lose much by being async.
+func (ip *InstanceProtector) protectOnce(ctx context.Context) {
+protect:
+	for {
+		// Pop off alternating protect / unprotect tokens until we receive
+		// a protect token without a matching unprotect one for ten seconds.
+		// At that point, protect the instance and break from this loop.
+		//
+		// We wait for ten seconds to avoid a busy loop, and allow more
+		// collation. At worst this means we have to redo ten seconds of
+		// work in case the instance is killed early (but that can anyway
+		// happen for other reasons).
+
+		var timeout <-chan time.Time
+		select {
+		case <-ip.protect:
+			// received the initial protect request, do not act on it
+			// for at least ten seconds
+			timeout = time.After(ip.protectTimeout)
+		case <-ctx.Done():
+			return
+		}
+		for {
+			// Drain the channels of already scheduled protect / unprotect pairs
+			select {
+			case <-ip.unprotect:
+			case <-timeout:
+				// There has been more protect than unprotect requests for
+				// the duration of the timeout. Ready to set protection,
+				// break out of the loop.
+				break protect
+			case <-ctx.Done():
+				return
+			}
+			select {
+			case <-ip.protect:
+			default:
+				// All protect and unprotect calls have been matched up before
+				// the timeout expired and no protect requests are pending. Discard
+				// the request to protect the instance and start over.
+				continue protect
+			}
+		}
+	}
+	ip.protImpl.SetProtection(true)
+	defer ip.protImpl.SetProtection(false)
+unprotect:
+	for {
+		// Pop off alternating unprotect / protect tokens until we receive
+		// an unprotect token without a matching protect one for one minute.
+		// At that point, unprotect the instance and break from this loop and
+		// start waiting for a protect token again.
+		//
+		// We wait for one minute to avoid a busy loop, and allow more
+		// collation. At worst this means we keep an instance running for
+		// one more minute than we need to.
+		select {
+		case <-ip.unprotect:
+		case <-ctx.Done():
+			return
+		}
+		select {
+		case <-ip.protect:
+		case <-time.After(ip.unprotectTimeout):
+			break unprotect
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Start performs alternating calls to protect / unprotect in
+// response to asynchronous Protect()/Unprotect() calls on
+// ip.
+//
+// The function returns when ctx is cancelled.
+func (ip *InstanceProtector) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		ip.protectOnce(ctx)
+	}
+}

--- a/internal/cloud/instanceprotector/instance-protector_test.go
+++ b/internal/cloud/instanceprotector/instance-protector_test.go
@@ -1,0 +1,99 @@
+package instanceprotector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type DummyInstanceProtector struct {
+	protected int
+	barrier   chan bool
+}
+
+func NewDummyInstanceProtector() *DummyInstanceProtector {
+	return &DummyInstanceProtector{
+		barrier: make(chan bool),
+	}
+}
+
+func (p *DummyInstanceProtector) SetProtection(protected bool) {
+	if protected {
+		p.protected += 1
+	} else {
+		p.protected -= 1
+	}
+	p.barrier <- protected
+}
+
+func TestInstanceProtector_Start(t *testing.T) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	defer ctxCancel()
+
+	p := NewDummyInstanceProtector()
+	ip := NewInstanceProtector(10*time.Millisecond, 10*time.Millisecond, 10, p)
+	require.Equal(t, 0, p.protected)
+
+	go ip.Start(ctx)
+
+	// double protect + double unprotect, no collation
+	ip.Protect()
+	require.True(t, <-p.barrier) // wait for the protection to kick in
+	require.Equal(t, 1, p.protected)
+	ip.Protect()   // already protected - no effect
+	ip.Unprotect() // undoes one protection - no effect
+	ip.Unprotect()
+	require.False(t, <-p.barrier) // wait for the protection te be lifted
+	require.Equal(t, 0, p.protected)
+
+	// double protect + double unprotect, partial collation
+	ip.Protect()
+	ip.Protect()
+	ip.Unprotect()
+	require.True(t, <-p.barrier) // wait for the protection to kick in
+	require.Equal(t, 1, p.protected)
+	ip.Unprotect()
+	require.False(t, <-p.barrier) // wait for the protection to be lifted
+	require.Equal(t, 0, p.protected)
+}
+
+func TestInstanceProtector_Cancel1(t *testing.T) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	p := NewDummyInstanceProtector()
+	ip := NewInstanceProtector(10*time.Millisecond, 10*time.Millisecond, 10, p)
+	require.Equal(t, 0, p.protected)
+
+	go ip.Start(ctx)
+
+	// protect, no unprotect
+	ip.Protect()
+	require.True(t, <-p.barrier) // wait for the protection to kick in
+	require.Equal(t, 1, p.protected)
+
+	// cancel the context
+	ctxCancel()
+	require.False(t, <-p.barrier) // wait for the protection to be lifted
+	require.Equal(t, 0, p.protected)
+}
+
+func TestInstanceProtector_Cancel2(t *testing.T) {
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	p := NewDummyInstanceProtector()
+	ip := NewInstanceProtector(10*time.Millisecond, 20*time.Millisecond, 10, p)
+	require.Equal(t, 0, p.protected)
+
+	go ip.Start(ctx)
+
+	// protect, unprotect pending
+	ip.Protect()
+	require.True(t, <-p.barrier) // wait for the protection to kick in
+	require.Equal(t, 1, p.protected)
+	ip.Unprotect()
+
+	// cancel the context
+	ctxCancel()
+	require.False(t, <-p.barrier) // wait for the protection to be lifted
+	require.Equal(t, 0, p.protected)
+}

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -1,6 +1,7 @@
 package distro_test_common
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -156,7 +157,7 @@ func getImageTypePkgSpecSets(imageType distro.ImageType, bp blueprint.Blueprint,
 	solver := dnfjson.NewSolver(imageType.Arch().Distro().ModulePlatformID(), imageType.Arch().Distro().Releasever(), imageType.Arch().Name(), cacheDir)
 	depsolvedSets := make(map[string][]rpmmd.PackageSpec)
 	for name, packages := range imgPackageSets {
-		res, err := solver.Depsolve(packages)
+		res, err := solver.Depsolve(context.Background(), packages)
 		if err != nil {
 			panic("Could not depsolve: " + err.Error())
 		}

--- a/internal/dnfjson/dnfjson.go
+++ b/internal/dnfjson/dnfjson.go
@@ -597,7 +597,7 @@ func run(ctx context.Context, dnfJsonCmd []string, req *Request) ([]byte, error)
 
 	err = cmd.Start()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %s", cmd.String(), err.Error())
 	}
 
 	err = json.NewEncoder(stdin).Encode(req)

--- a/internal/dnfjson/dnfjson_test.go
+++ b/internal/dnfjson/dnfjson_test.go
@@ -1,6 +1,7 @@
 package dnfjson
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -44,7 +45,7 @@ func TestDepsolver(t *testing.T) {
 	{ // single depsolve
 		pkgsets := []rpmmd.PackageSet{{Include: []string{"kernel", "vim-minimal", "tmux", "zsh"}, Repositories: []rpmmd.RepoConfig{s.RepoConfig}}} // everything you'll ever need
 
-		deps, err := solver.Depsolve(pkgsets)
+		deps, err := solver.Depsolve(context.Background(), pkgsets)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -57,7 +58,7 @@ func TestDepsolver(t *testing.T) {
 			{Include: []string{"kernel"}, Repositories: []rpmmd.RepoConfig{s.RepoConfig}},
 			{Include: []string{"vim-minimal", "tmux", "zsh"}, Repositories: []rpmmd.RepoConfig{s.RepoConfig}},
 		}
-		deps, err := solver.Depsolve(pkgsets)
+		deps, err := solver.Depsolve(context.Background(), pkgsets)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -536,13 +537,14 @@ func TestErrorRepoInfo(t *testing.T) {
 	solver.SetDNFJSONPath("../../dnf-json")
 	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
-			_, err := solver.Depsolve([]rpmmd.PackageSet{
-				{
-					Include:      []string{"osbuild"},
-					Exclude:      nil,
-					Repositories: []rpmmd.RepoConfig{tc.repo},
-				},
-			})
+			_, err := solver.Depsolve(context.Background(),
+				[]rpmmd.PackageSet{
+					{
+						Include:      []string{"osbuild"},
+						Exclude:      nil,
+						Repositories: []rpmmd.RepoConfig{tc.repo},
+					},
+				})
 			assert.Error(err)
 			assert.Contains(err.Error(), tc.expMsg)
 		})

--- a/internal/osbuild/osbuild-exec.go
+++ b/internal/osbuild/osbuild-exec.go
@@ -2,6 +2,7 @@ package osbuild
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,11 +15,12 @@ import (
 // Note that osbuild returns non-zero when the pipeline fails. This function
 // does not return an error in this case. Instead, the failure is communicated
 // with its corresponding logs through osbuild.Result.
-func RunOSBuild(manifest []byte, store, outputDirectory string, exports, checkpoints, extraEnv []string, result bool, errorWriter io.Writer) (*Result, error) {
+func RunOSBuild(ctx context.Context, manifest []byte, store, outputDirectory string, exports, checkpoints, extraEnv []string, result bool, errorWriter io.Writer) (*Result, error) {
 	var stdoutBuffer bytes.Buffer
 	var res Result
 
-	cmd := exec.Command(
+	cmd := exec.CommandContext(
+		ctx,
 		"osbuild",
 		"--store", store,
 		"--output-directory", outputDirectory,

--- a/internal/worker/api/api.gen.go
+++ b/internal/worker/api/api.gen.go
@@ -44,6 +44,9 @@ type GetJobResponse struct {
 	Canceled bool `json:"canceled"`
 }
 
+// InterruptJobResponse defines model for InterruptJobResponse.
+type InterruptJobResponse ObjectReference
+
 // ObjectReference defines model for ObjectReference.
 type ObjectReference struct {
 	Href string `json:"href"`
@@ -105,6 +108,9 @@ type ServerInterface interface {
 	// Request a job
 	// (POST /jobs)
 	RequestJob(ctx echo.Context) error
+	// Interrupt a running job
+	// (DELETE /jobs/{token})
+	InterruptJob(ctx echo.Context, token string) error
 	// Get running job
 	// (GET /jobs/{token})
 	GetJob(ctx echo.Context, token string) error
@@ -151,6 +157,22 @@ func (w *ServerInterfaceWrapper) RequestJob(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshalled arguments
 	err = w.Handler.RequestJob(ctx)
+	return err
+}
+
+// InterruptJob converts echo context to params.
+func (w *ServerInterfaceWrapper) InterruptJob(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "token" -------------
+	var token string
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "token", runtime.ParamLocationPath, ctx.Param("token"), &token)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter token: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.InterruptJob(ctx, token)
 	return err
 }
 
@@ -258,6 +280,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 
 	router.GET(baseURL+"/errors/:id", wrapper.GetError)
 	router.POST(baseURL+"/jobs", wrapper.RequestJob)
+	router.DELETE(baseURL+"/jobs/:token", wrapper.InterruptJob)
 	router.GET(baseURL+"/jobs/:token", wrapper.GetJob)
 	router.PATCH(baseURL+"/jobs/:token", wrapper.UpdateJob)
 	router.PUT(baseURL+"/jobs/:token/artifacts/:name", wrapper.UploadJobArtifact)
@@ -269,26 +292,27 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/9xYX2/bNhD/KgS3hw2QLadpXwTsoemGIh26DMmKFciC4EydLSYSqZAnO4ah7z6QlP9J",
-	"ip0A8UPzJFk83p/f/Xh39JILXZRaoSLLkyW3IsMC/OsfxmjjXiDPLyY8uV7ynw1OeMJ/ijeb4mZHfDG+",
-	"Q0GXOEGDSiCvoyUvjS7RkESvUOgU3ZMWJfKEWzJSTXkd8QKthalfS9EKI0uSWvGEn4G4n4NJmbMHJMcy",
-	"l7Rgc0kZm2tzj8ay/6rR6FT8xmanpxHDhwpyywyC1YpHXVPOH3Dab2Xa60uztbvk1x4qaTDlyXUIZi3e",
-	"UrwJ6Wbtg/b48PqmjvhnpC96fIm21Mriq2IMSmCO27GNtc4RVDeClWi/j21bSdtU5h3tgfAJZO+lSg/j",
-	"6tHzolGw0PUu4pf4UKENGPq3rndgRNbrhvvgJSRhYZ8U4QkHY2DRcTDsj4KBQ869foLBTP3zcTDVg8b2",
-	"ndVqeAnzrw3paucdyQkIus21gHCaegJNFwoKKW5XSteQHNC+C1DE9xoJHw7l3a9uaeoLoZ+oVwRU2WNg",
-	"bb3mw743cv3ufStTINxHVYO2yukg7C2jza4+Bm6Z3IDyIiicMakmuluS/8mkZdIyUOzj3+dsos26EpNm",
-	"JsTIQKUsA5XmyO702A5dKZaUOzcvrs4qmafsk3PDomED9q9XwCM+Q2ODmZOmWCsoJU/46XA0HPGIl0CZ",
-	"xyxG151svJRp7X5Pkbq+fkbnCZPKkqt1TE8YZcj8VmZLFHIiMWXjBfNVZ13Cz9OwOXRAZ9VAgYTGelLt",
-	"Gjn/fUcvd8DxxHvKI66gcEF7/ZvskakwanqtcxsfoSg9Oien3a5V37i9IZM++HejUeinilD5uKEscxlO",
-	"SXzX9K+N+n2pDzHWPuPvv38/it4PR9FbR9yiqIykhU/LGYJBw5PrGweYrYoCzKJhQUj5duLc9thx059H",
-	"bXvo0xxYy8CReMg89dckYeNci3vLKkUyDyL+XMxA5jDOcdhh1KYxNGRAS2c6XbwaNt22GGBqkefkKAab",
-	"SuMN7uL4ySAQpu5Evxu9fzXjvUVr1/Jf2qdlDlt5iRiZBYMpSMV/NM634/Ms3jD9clV9XdQbhsdL0veo",
-	"tutkp9StSHmkKtMaeHtCufiT/5AVaKfMmEopqaYB/k7f6OkLPjF7W0NPLyiBwmy7m8V11z9SdekMMr3F",
-	"ZXQMe2+YNiFKBrvcaR/deDUM23jpqOPPcllRHwtyDekXPf7Y7ODP4aF/vISG0evR+Xlc1YKQBpYMQrEL",
-	"elvlU6R8c8RxiXbz7YobgTbrofnpYn/RiDwHp0adH5eZVMz57qb+AvxV48MxRtH2If+m8LFEQZg2g5wW",
-	"ojKOX90S7AbxvT47jDYXu957w5V00zgLUs09xrB5JkXGDFJllGUWzUyKlVDf7eFqtXK0Ctm6+b7F8tjA",
-	"20z7ZtZ/B/sKUrFfSqPTSrhPv7IgyyNemZwnPCMqbRLHUMqhY4fN5ISGQhfuSywLmOJg7K6laAbhOhvP",
-	"Tvw/Ai1mEExdkd6j3hJM8YVGgpaXiG0t3NT/BwAA//+IToO0xRUAAA==",
+	"H4sIAAAAAAAC/9xY32/jtg//VwR9vw8b4MTp9e7FwB6ut+HQG24d2h12QFcUjMzEam3JleikQeD/fZDk",
+	"/LLdpB2ah+tTHIsiPyQ/IkUvudBFqRUqsjxZcisyLMA//maMNu4B8vxiwpPrJf+/wQlP+P/izaa42RFf",
+	"jO9Q0CVO0KASyOtoyUujSzQk0SsUOkX3S4sSecItGammvI54gdbC1K+laIWRJUmteMLPQNzPwaTM2QOS",
+	"Y5lLWrC5pIzNtblHY9k/1Wh0Kn5hs9PTiOFDBbllBsFqxaOuKYcHnPZbmfZiabZ2l/zaQyUNpjy5Ds6s",
+	"xVuKNy7drDFoHx9e39QR/4z0RY8v0ZZaWXzVGIMSmOO2b2OtcwTV9WAl2o/xXBEaU5VtpC/Dx9uvkjbi",
+	"zOvrycQTCbqXKj2cHp8ELxoFC10nI36JDxXa4KB/6qIDI7JeGO6Fl5CEhX1ShCccjIFFB2DYHwUDh8C9",
+	"Pk/ATP3v42CqB43tO6vV8BLmXxvu1g4dyQkIus21gHAoexxNFwoKKW5XStchOaB9N0AR32skvDiUd7+6",
+	"panPhX6+XxFQZY8Ra+s1H8beyPXD+1amQLiPqgZtldPBsLeMNrv6GLhl8j8ef2dMqonuVva/MmmZtAwU",
+	"+/jnOZtosy7opJkJPjJQKctApTmyOz22Q1fRJeUO5sXVWSXzlH1yMCwaNmB/ewU84jM0Npg5aWq+glLy",
+	"hJ8OR8MRj3gJlPmYxeianI2XMq3d/ylSF+tndEiYVJZcyWR6wihD5rcyW6KQE4kpGy+YrzrrTnCehs2h",
+	"kTqrBgokNNaTatfI+a87erkLHE88Uh5xBYVz2uvfZI9MhVHTsh1sfISi9NE5Oe02v/rG7Q2Z9M6/G41C",
+	"W1aEyvsNZZnLcEriu6YNbtTvS33wsfYZf//9+1H0fjiK3jriFkVlJC18Ws4QDBqeXN+4gNmqKMAsGhaE",
+	"lG8nzm2PHTf9edS2hz7NgbUMHImHzFN/TRI2zrW4t6xSJPMg4s/FDGQO4xyHHUZtGkNDBrR0ptPFq8Wm",
+	"2xZDmFrkOTmKwabSeIO7cfxkEAhTd6Lfjd6/mvHeorVr+Q/t0zKHrbxEjMyCwRSk4j8a59v+eRZvmH65",
+	"qr7O6w3D4yXpe1R1YHiO5PvBLje3L438iOWm93La49nF7/yHLEjrXKwdZcBMpZRU05CVaNWrOu3myKFv",
+	"zS5vMeiu1LeC3erdPb3ZH4697bmnH5dAYb7YzeL65nWkCt+5TPYW+NEx7L1h2gQv2we1XT7j1UBi46Wj",
+	"jq+nZUV9LMg1pF/0+GOzgz+Hh/7nJTSMXo/Oz+OqFoQ0sGQQit2gt1U+Rco3RxyXaDdjrLgRaLMeXJZP",
+	"FvuLRuQ5cWrU+ZGFScUcdjd5FeDHvQ/HGAfah/ybwscSBWHaXKa1EJVx/OqWYDcM7cXsYrQZrntntyvp",
+	"JiIWpJpZ0rB5JkXGDFJllGUWzUyKlVDfBHe1WjlahWx9fXiL5bEJbzNxmVn/HPwVpGI/lUanlXCvfmZB",
+	"lke8MjlPeEZU2iSOoZRDxw6byQkNhS7cm1gWMMXBuJJ5imYQPinEsxP/VabFDIKpK9J71FuCKb7QSNDy",
+	"ErGthZv63wAAAP//2xy7+JAXAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/worker/api/openapi.yml
+++ b/internal/worker/api/openapi.yml
@@ -136,6 +136,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    delete:
+      operationId: InterruptJob
+      summary: Interrupt a running job
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InterruptJobResponse'
+        '4XX':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '5XX':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /jobs/{token}/artifacts/{name}:
     put:
@@ -300,4 +320,6 @@ components:
         result:
           x-go-type: json.RawMessage
     UpdateJobResponse:
+      $ref: '#/components/schemas/ObjectReference'
+    InterruptJobResponse:
       $ref: '#/components/schemas/ObjectReference'

--- a/internal/worker/client_test.go
+++ b/internal/worker/client_test.go
@@ -1,11 +1,14 @@
 package worker_test
 
 import (
+	"context"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -13,13 +16,19 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/worker"
 )
 
-// newTestWorkerServer returns 3 strings:
-// - base URL of the worker server
-// - base URL of the OAuth server
-// - offline token for OAuth
-//
-// The worker server has one pending osbuild job of arch "arch" ready to be dequeued.
-func newTestWorkerServer(t *testing.T) (string, string, string) {
+type RunFunc func(context.Context, *worker.Job) (interface{}, error)
+type TestJobImpl struct {
+	testRun RunFunc
+}
+
+func (impl *TestJobImpl) Run(ctx context.Context, job *worker.Job) (interface{}, error) {
+	if impl.testRun == nil {
+		panic("no testRun() function defined")
+	}
+	return impl.testRun(ctx, job)
+}
+
+func newTestWorkerServerClientPair(t *testing.T, heartbeat time.Duration, proxy *proxy) (*worker.Server, *worker.Client) {
 	tempdir := t.TempDir()
 
 	q, err := fsjobqueue.New(tempdir)
@@ -29,8 +38,6 @@ func newTestWorkerServer(t *testing.T) (string, string, string) {
 		BasePath:     "/api/image-builder-worker/v1",
 	}
 	workerServer := worker.NewServer(nil, q, config)
-	_, err = workerServer.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
-	require.NoError(t, err)
 
 	handler := workerServer.Handler()
 
@@ -42,7 +49,7 @@ func newTestWorkerServer(t *testing.T) (string, string, string) {
 
 	/* Check that the worker supplies the access token  */
 	calls := 0
-	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	gatewaySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if calls == 0 {
 			require.Equal(t, "Bearer", r.Header.Get("Authorization"))
 			w.WriteHeader(http.StatusUnauthorized)
@@ -51,7 +58,7 @@ func newTestWorkerServer(t *testing.T) (string, string, string) {
 		require.Equal(t, "Bearer "+accessToken, r.Header.Get("Authorization"))
 		handler.ServeHTTP(w, r)
 	}))
-	t.Cleanup(proxySrv.Close)
+	t.Cleanup(gatewaySrv.Close)
 
 	/* Start oauth srv supplying the bearer token */
 	oauthSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -77,62 +84,214 @@ func newTestWorkerServer(t *testing.T) (string, string, string) {
 	}))
 	t.Cleanup(oauthSrv.Close)
 
-	return proxySrv.URL, oauthSrv.URL, offlineToken
-}
+	var proxyURL string
+	if proxy != nil {
+		// initialize a test proxy server
+		proxySrv := httptest.NewServer(proxy)
+		t.Cleanup(proxySrv.Close)
+		proxyURL = proxySrv.URL
+	}
 
-func TestOAuth(t *testing.T) {
-	workerURL, oauthURL, offlineToken := newTestWorkerServer(t)
-
-	client, err := worker.NewClient(worker.ClientConfig{
-		BaseURL:      workerURL,
-		TlsConfig:    nil,
+	workerClient, err := worker.NewClient(worker.ClientConfig{
+		BaseURL:      gatewaySrv.URL,
+		Heartbeat:    heartbeat,
 		ClientId:     "rhsm-api",
 		OfflineToken: offlineToken,
-		OAuthURL:     oauthURL,
+		OAuthURL:     oauthSrv.URL,
 		BasePath:     "/api/image-builder-worker/v1",
+		ProxyURL:     proxyURL,
 	})
 	require.NoError(t, err)
-	job, err := client.RequestJob([]string{worker.JobTypeOSBuild}, "arch")
-	require.NoError(t, err)
-	r := strings.NewReader("artifact contents")
-	require.NoError(t, job.UploadArtifact("some-artifact", r))
-	c, err := job.Canceled()
-	require.False(t, c)
-	require.NoError(t, err)
+
+	return workerServer, workerClient
 }
 
-func TestProxy(t *testing.T) {
-	workerURL, oauthURL, offlineToken := newTestWorkerServer(t)
+func TestClient(t *testing.T) {
+	server, client := newTestWorkerServerClientPair(t, 0, nil)
 
-	// initialize a test proxy server
-	proxy := &proxy{}
-	proxySrv := httptest.NewServer(proxy)
-	t.Cleanup(proxySrv.Close)
+	barrier := make(chan bool)
+	testRun := func(ctx context.Context, job *worker.Job) (interface{}, error) {
+		if <-barrier {
+			return struct{}{}, nil
+		} else {
+			return nil, nil
+		}
+	}
+	jobImpls := map[string]worker.JobImplementation{
+		worker.JobTypeOSBuild: &TestJobImpl{testRun},
+	}
+	requestCtx, requestCtxCancel := context.WithCancel(context.Background())
+	go client.Start(requestCtx, time.Duration(10*time.Microsecond), nil, "arch", jobImpls)
+	t.Cleanup(requestCtxCancel)
 
-	client, err := worker.NewClient(worker.ClientConfig{
-		BaseURL:      workerURL,
-		TlsConfig:    nil,
-		ClientId:     "rhsm-api",
-		OfflineToken: offlineToken,
-		OAuthURL:     oauthURL,
-		BasePath:     "/api/image-builder-worker/v1",
-		ProxyURL:     proxySrv.URL,
-	})
+	// schedule two jobs
+	// we only really care about the first one, and use the second one
+	// only as a barrier: once it is being processed we know the first one
+	// has been finished.
+	jobID, err := server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
+	require.NoError(t, err)
+	_, err = server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
+	require.NoError(t, err)
 
+	barrier <- true  // processing first job - run the test
+	barrier <- false // processing second job - only a barrier, don't run the test
+
+	var result worker.OSBuildJobResult
+	info, err := server.OSBuildJobInfo(jobID, &result)
 	require.NoError(t, err)
-	job, err := client.RequestJob([]string{worker.JobTypeOSBuild}, "arch")
+	require.NotZero(t, info.JobStatus.Finished)
+}
+
+func TestClientCancel(t *testing.T) {
+	barrier := make(chan bool)
+	testRun := func(ctx context.Context, job *worker.Job) (interface{}, error) {
+		if <-barrier {
+			<-ctx.Done() // wait to be cancelled
+			return struct{}{}, nil
+		} else {
+			return nil, nil
+		}
+	}
+	jobImpls := map[string]worker.JobImplementation{
+		worker.JobTypeOSBuild: &TestJobImpl{testRun},
+	}
+
+	server, client := newTestWorkerServerClientPair(t, 2*time.Millisecond, nil)
+
+	requestCtx, requestCtxCancel := context.WithCancel(context.Background())
+	go client.Start(requestCtx, time.Duration(10*time.Microsecond), nil, "arch", jobImpls)
+	t.Cleanup(requestCtxCancel)
+
+	// schedule two jobs
+	// we only really care about the first one, and use the second one
+	// only as a barrier: once it is being processed we know the first one
+	// has been finished.
+	jobID, err := server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
 	require.NoError(t, err)
-	r := strings.NewReader("artifact contents")
-	require.NoError(t, job.UploadArtifact("some-artifact", r))
-	c, err := job.Canceled()
-	require.False(t, c)
+	_, err = server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
 	require.NoError(t, err)
+
+	barrier <- true // processing first job - run the test
+	err = server.Cancel(jobID)
+	require.NoError(t, err)
+	barrier <- false // processing second job - only a barrier, don't run the test
+}
+
+func TestClientUpload(t *testing.T) {
+	server, client := newTestWorkerServerClientPair(t, 0, nil)
+
+	barrier := make(chan bool)
+	artifactName := "some-artifact"
+	artifactContents := "artifact contents"
+	testRun := func(ctx context.Context, job *worker.Job) (interface{}, error) {
+		if <-barrier {
+			r := strings.NewReader(artifactContents)
+			require.NoError(t, job.UploadArtifact(ctx, artifactName, r))
+			return struct{}{}, nil
+		} else {
+			return nil, nil
+		}
+	}
+	jobImpls := map[string]worker.JobImplementation{
+		worker.JobTypeOSBuild: &TestJobImpl{testRun},
+	}
+	requestCtx, requestCtxCancel := context.WithCancel(context.Background())
+	go client.Start(requestCtx, time.Duration(10*time.Microsecond), nil, "arch", jobImpls)
+	t.Cleanup(requestCtxCancel)
+
+	// schedule two jobs
+	jobID, err := server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
+	require.NoError(t, err)
+	_, err = server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
+	require.NoError(t, err)
+
+	barrier <- true  // processing first job - run the test
+	barrier <- false // processing second job - only a barrier, don't run the test
+
+	var result worker.OSBuildJobResult
+	info, err := server.OSBuildJobInfo(jobID, &result)
+	require.NoError(t, err)
+	require.NotZero(t, info.JobStatus.Finished)
+	reader, size, err := server.JobArtifact(jobID, artifactName)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(artifactContents)), size)
+	artifact, err := ioutil.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, artifactContents, string(artifact))
+}
+
+func TestClientProxy(t *testing.T) {
+	proxy := proxy{}
+	server, client := newTestWorkerServerClientPair(t, 0, &proxy)
+
+	barrier := make(chan bool)
+	testRun := func(ctx context.Context, job *worker.Job) (interface{}, error) {
+		if <-barrier {
+			return struct{}{}, nil
+		} else {
+			return nil, nil
+		}
+	}
+	jobImpls := map[string]worker.JobImplementation{
+		worker.JobTypeOSBuild: &TestJobImpl{testRun},
+	}
+	requestCtx, requestCtxCancel := context.WithCancel(context.Background())
+	go client.Start(requestCtx, time.Duration(10*time.Microsecond), nil, "arch", jobImpls)
+	t.Cleanup(requestCtxCancel)
+
+	// schedule two jobs
+	_, err := server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
+	require.NoError(t, err)
+	_, err = server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
+	require.NoError(t, err)
+
+	barrier <- true  // processing first job - run the test
+	barrier <- false // processing second job - only a barrier, don't run the test
 
 	// we expect 5 calls to go through the proxy:
 	// - request job (fails, no oauth token)
 	// - oauth call
 	// - request job (succeeds)
-	// - upload artifact
-	// - cancel
+	// - finish
+	// - request next job (hangs)
 	require.Equal(t, 5, proxy.calls)
+}
+
+func TestClientInterrupt(t *testing.T) {
+	server, client := newTestWorkerServerClientPair(t, 0, nil)
+
+	_, err := server.EnqueueOSBuild("arch", &worker.OSBuildJob{}, "")
+	require.NoError(t, err)
+
+	barrier1 := make(chan struct{})
+	testRun1 := func(ctx context.Context, job *worker.Job) (interface{}, error) {
+		barrier1 <- struct{}{}
+		<-ctx.Done()
+		return struct{}{}, nil
+	}
+	jobImpls1 := map[string]worker.JobImplementation{
+		worker.JobTypeOSBuild: &TestJobImpl{testRun1},
+	}
+
+	clientCtx1, clientCtxCancel1 := context.WithCancel(context.Background())
+	go client.Start(clientCtx1, time.Duration(10*time.Microsecond), nil, "arch", jobImpls1)
+
+	<-barrier1         // processing first job - will hang to wait for cancellation
+	clientCtxCancel1() // cancel the client - this will cause the job to get rescheduled
+
+	// start a second client to pick up the job
+	barrier2 := make(chan struct{})
+	testRun2 := func(ctx context.Context, job *worker.Job) (interface{}, error) {
+		barrier2 <- struct{}{}
+		return struct{}{}, nil
+	}
+	jobImpls2 := map[string]worker.JobImplementation{
+		worker.JobTypeOSBuild: &TestJobImpl{testRun2},
+	}
+
+	clientCtx2, clientCtxCancel2 := context.WithCancel(context.Background())
+	go client.Start(clientCtx2, time.Duration(10*time.Microsecond), nil, "arch", jobImpls2)
+	t.Cleanup(clientCtxCancel2)
+
+	<-barrier2 // the job got picked up again - interruption worked as expected
 }

--- a/internal/worker/clienterrors/errors.go
+++ b/internal/worker/clienterrors/errors.go
@@ -36,6 +36,7 @@ const (
 	ErrorOSTreeRefResolution  ClientErrorCode = 33
 	ErrorOSTreeParamsInvalid  ClientErrorCode = 34
 	ErrorOSTreeDependency     ClientErrorCode = 35
+	ErrorJobInterrupted       ClientErrorCode = 36
 )
 
 type ClientErrorCode int


### PR DESCRIPTION
When a machine is being shut down systemd will send each service a SIGTERM signal, essentially
asking them to please shut down. If they do not do so within a certain timeout, systemd sends
SIGKILL instead, which forcibly shuts down the service immediately. This is what currently happens
if a worker machine is being shut down, for instance because AWS decides they want their VMs
back.

When a worker is shut down mid-job we currently lose track of the job, and wait for the
heartbeat to expire, before rescheduling the job. This is both slow and means we can't
distinguish between jobs that failed because of a bug (i.e., unexpectedly) and jobs that
failed because they were interrupted for external reasons (to be expected).

This PR improves the situation by listening for SIGTERM, and when we receive it immediately
cancelling all in-flight work. Moreover, if a job is cancelled in this way, composer is notified
that the job was interrupted, and as a result composer immediately reschedules the job.