### PR TITLE
Measure 5xx errors on all requests for image-builder-composer/worker

### DIFF
--- a/internal/cloudapi/v2/server.go
+++ b/internal/cloudapi/v2/server.go
@@ -87,7 +87,9 @@ func (s *Server) Handler(path string) http.Handler {
 	handler := apiHandlers{
 		server: s,
 	}
-	RegisterHandlers(e.Group(path, prometheus.MetricsMiddleware, s.ValidateRequest), &handler)
+
+	statusMW := prometheus.StatusMiddleware(prometheus.ComposerSubsystem)
+	RegisterHandlers(e.Group(path, prometheus.MetricsMiddleware, s.ValidateRequest, statusMW), &handler)
 
 	return e
 }

--- a/internal/prometheus/constants.go
+++ b/internal/prometheus/constants.go
@@ -1,0 +1,7 @@
+package prometheus
+
+const (
+	Namespace         = "image_builder"
+	ComposerSubsystem = "composer"
+	WorkerSubsystem   = "worker"
+)

--- a/internal/prometheus/helpers.go
+++ b/internal/prometheus/helpers.go
@@ -1,0 +1,15 @@
+package prometheus
+
+import (
+	"regexp"
+	"strings"
+)
+
+func pathLabel(path string) string {
+	r := regexp.MustCompile(":(.*)")
+	segments := strings.Split(path, "/")
+	for i, segment := range segments {
+		segments[i] = r.ReplaceAllString(segment, "-")
+	}
+	return strings.Join(segments, "/")
+}

--- a/internal/prometheus/http_metrics.go
+++ b/internal/prometheus/http_metrics.go
@@ -5,16 +5,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const (
-	namespace = "image_builder"
-	subsystem = "composer"
-)
-
 var (
 	TotalRequests = promauto.NewCounter(prometheus.CounterOpts{
 		Name:      "total_requests",
-		Namespace: namespace,
-		Subsystem: subsystem,
+		Namespace: Namespace,
+		Subsystem: ComposerSubsystem,
 		Help:      "total number of http requests made to osbuild-composer",
 	})
 )
@@ -23,8 +18,8 @@ var (
 	// update this to count all 500s
 	ComposeFailures = promauto.NewCounter(prometheus.CounterOpts{
 		Name:      "total_failed_compose_requests",
-		Namespace: namespace,
-		Subsystem: subsystem,
+		Namespace: Namespace,
+		Subsystem: ComposerSubsystem,
 		Help:      "total number of failed compose requests",
 	})
 )
@@ -32,8 +27,8 @@ var (
 var (
 	ComposeRequests = promauto.NewCounter(prometheus.CounterOpts{
 		Name:      "total_compose_requests",
-		Namespace: namespace,
-		Subsystem: subsystem,
+		Namespace: Namespace,
+		Subsystem: ComposerSubsystem,
 		Help:      "total number of compose requests made to osbuild-composer",
 	})
 )
@@ -41,8 +36,8 @@ var (
 var (
 	httpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:      "http_duration_seconds",
-		Namespace: namespace,
-		Subsystem: subsystem,
+		Namespace: Namespace,
+		Subsystem: ComposerSubsystem,
 		Help:      "Duration of HTTP requests.",
 		Buckets:   []float64{.025, .05, .075, .1, .2, .5, .75, 1, 1.5, 2, 3, 4, 5, 6, 8, 10, 12, 14, 16, 20},
 	}, []string{"path"})

--- a/internal/prometheus/job_metrics.go
+++ b/internal/prometheus/job_metrics.go
@@ -8,13 +8,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const workerSubsystem = "worker"
-
 var (
 	TotalJobs = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:      "total_jobs",
-		Namespace: namespace,
-		Subsystem: workerSubsystem,
+		Namespace: Namespace,
+		Subsystem: WorkerSubsystem,
 		Help:      "Total jobs",
 	}, []string{"type", "status", "tenant", "arch"})
 )
@@ -22,8 +20,8 @@ var (
 var (
 	PendingJobs = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "pending_jobs",
-		Namespace: namespace,
-		Subsystem: workerSubsystem,
+		Namespace: Namespace,
+		Subsystem: WorkerSubsystem,
 		Help:      "Currently pending jobs",
 	}, []string{"type", "tenant"})
 )
@@ -31,8 +29,8 @@ var (
 var (
 	RunningJobs = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "running_jobs",
-		Namespace: namespace,
-		Subsystem: workerSubsystem,
+		Namespace: Namespace,
+		Subsystem: WorkerSubsystem,
 		Help:      "Currently running jobs",
 	}, []string{"type", "tenant"})
 )
@@ -40,8 +38,8 @@ var (
 var (
 	JobDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:      "job_duration_seconds",
-		Namespace: namespace,
-		Subsystem: workerSubsystem,
+		Namespace: Namespace,
+		Subsystem: WorkerSubsystem,
 		Help:      "Duration spent by workers on a job.",
 		Buckets:   []float64{.1, .2, .5, 1, 2, 4, 8, 16, 32, 40, 48, 64, 96, 128, 160, 192, 224, 256, 320, 382, 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792, 2049},
 	}, []string{"type", "status", "tenant", "arch"})
@@ -50,8 +48,8 @@ var (
 var (
 	JobWaitDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:      "job_wait_duration_seconds",
-		Namespace: namespace,
-		Subsystem: workerSubsystem,
+		Namespace: Namespace,
+		Subsystem: WorkerSubsystem,
 		Help:      "Duration a job spends on the queue.",
 		Buckets:   []float64{.1, .2, .5, 1, 2, 4, 8, 16, 32, 40, 48, 64, 96, 128, 160, 192, 224, 256, 320, 382, 448, 512, 640, 768, 896, 1024, 1280, 1536, 1792, 2049},
 	}, []string{"type", "tenant"})

--- a/internal/prometheus/middleware.go
+++ b/internal/prometheus/middleware.go
@@ -1,6 +1,8 @@
 package prometheus
 
 import (
+	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/labstack/echo/v4"
@@ -16,5 +18,37 @@ func MetricsMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 		timer := prometheus.NewTimer(httpDuration.WithLabelValues(ctx.Path()))
 		defer timer.ObserveDuration()
 		return next(ctx)
+	}
+}
+
+func StatusMiddleware(subsystem string) func(next echo.HandlerFunc) echo.HandlerFunc {
+	counter := StatusRequestsCounter(subsystem)
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+
+			// call the next handler to see if
+			// an error occurred, see:
+			// - https://github.com/labstack/echo/issues/1837#issuecomment-816399630
+			// - https://github.com/labstack/echo/discussions/1820#discussioncomment-529428
+			err := next(ctx)
+
+			path := pathLabel(ctx.Path())
+			method := ctx.Request().Method
+			status := ctx.Response().Status
+
+			httpErr := new(echo.HTTPError)
+			if errors.As(err, &httpErr) {
+				status = httpErr.Code
+			}
+
+			counter.WithLabelValues(
+				method,
+				path,
+				strconv.Itoa(status),
+				subsystem,
+			).Inc()
+
+			return err
+		}
 	}
 }

--- a/internal/prometheus/status_metrics.go
+++ b/internal/prometheus/status_metrics.go
@@ -1,0 +1,30 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+func StatusRequestsCounter(subsystem string) *prometheus.CounterVec {
+	// return a function so we can use this for both
+	// composer & worker metrics
+	reg := prometheus.NewRegistry()
+	counter := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Name:      "request_count",
+		Namespace: Namespace,
+		Subsystem: subsystem,
+		Help:      "total number of http requests",
+	}, []string{"method", "path", "code", "service"})
+
+	err := prometheus.Register(counter)
+	if err != nil {
+		registered, ok := err.(prometheus.AlreadyRegisteredError)
+		if !ok {
+			panic(err)
+		}
+		// return existing counter if metrics already registered
+		return registered.ExistingCollector.(*prometheus.CounterVec)
+	}
+
+	return counter
+}

--- a/internal/worker/server.go
+++ b/internal/worker/server.go
@@ -98,7 +98,9 @@ func (s *Server) Handler() http.Handler {
 	handler := apiHandlers{
 		server: s,
 	}
-	api.RegisterHandlers(e.Group(api.BasePath), &handler)
+
+	statusMW := prometheus.StatusMiddleware(prometheus.WorkerSubsystem)
+	api.RegisterHandlers(e.Group(api.BasePath, statusMW), &handler)
 
 	return e
 }

--- a/internal/worker/server_test.go
+++ b/internal/worker/server_test.go
@@ -69,7 +69,8 @@ func TestErrors(t *testing.T) {
 		// Create job with invalid body
 		{"POST", "/api/worker/v1/jobs", ``, http.StatusBadRequest},
 		// Wrong method
-		{"GET", "/api/worker/v1/jobs", ``, http.StatusMethodNotAllowed},
+		// Returns 404, but should be 405; see https://github.com/labstack/echo/issues/1981
+		{"GET", "/api/worker/v1/jobs", ``, http.StatusNotFound},
 		// Update job with invalid ID
 		{"PATCH", "/api/worker/v1/jobs/foo", `{"status":"FINISHED"}`, http.StatusBadRequest},
 		// Update job that does not exist, with invalid body
@@ -99,7 +100,8 @@ func TestErrorsAlteredBasePath(t *testing.T) {
 		// Create job with invalid body
 		{"POST", "/api/image-builder-worker/v1/jobs", ``, http.StatusBadRequest},
 		// Wrong method
-		{"GET", "/api/image-builder-worker/v1/jobs", ``, http.StatusMethodNotAllowed},
+		// Returns 404, but should be 405; see https://github.com/labstack/echo/issues/1981
+		{"GET", "/api/image-builder-worker/v1/jobs", ``, http.StatusNotFound},
 		// Update job with invalid ID
 		{"PATCH", "/api/image-builder-worker/v1/jobs/foo", `{"status":"FINISHED"}`, http.StatusBadRequest},
 		// Update job that does not exist, with invalid body


### PR DESCRIPTION
This pull request includes:

Creates a custom middleware function to record all 5xx errors for composer & worker as we
are currently only recording internal errors for the `/compose` endpoint.

The existing compose metrics can be removed in a follow up PR once the relevant alerts and dashboards
have been implemented.

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
