### PR TITLE
SPEC: run the %preun commands in worker package only on removal

### DIFF
--- a/osbuild-composer.spec
+++ b/osbuild-composer.spec
@@ -326,8 +326,9 @@ The worker for osbuild-composer
 %preun worker
 # systemd_preun uses systemctl disable --now which doesn't work well with template services.
 # See https://github.com/systemd/systemd/issues/15620
-# The following lines mimicks its behaviour by running two commands:
-if [ -d /run/systemd/system ]; then
+# The following lines mimicks its behaviour by running two commands.
+# The scriptlet is supposed to run only when the package is being removed.
+if [ $1 -eq 0 ] && [ -d /run/systemd/system ]; then
     # disable and stop all the worker services
     systemctl --no-reload disable osbuild-worker@.service osbuild-remote-worker@.service
     systemctl stop "osbuild-worker@*.service" "osbuild-remote-worker@*.service"


### PR DESCRIPTION
PR#553 [1] introduced a change to the worker subpackage and replaced the systemd %preun RPM macro with a literal calls to `systemctl` due to missing functionality in systemd. However, the change omitted the fact, that the RPM macro executes commands only on package removal, not upgrade.

As a result a local or remote worker which is running on the system while the osbuild-composer-worker package is updated, gets stopped.

Fix the scriptlet and run the commands only on package removal.

[1] https://github.com/osbuild/osbuild-composer/pull/553

Signed-off-by: Tomáš Hozza <thozza@redhat.com>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
