### PR TITLE
tools: silence version comparison in get_build_info()

### DIFF
--- a/test/cases/shared_lib.sh
+++ b/test/cases/shared_lib.sh
@@ -26,7 +26,7 @@ function get_build_info() {
     local fname="$2"
     if rpm -q --quiet weldr-client; then
         key=".body${key}"
-        if nvrGreaterOrEqual "weldr-client" "35.6"; then
+        if nvrGreaterOrEqual "weldr-client" "35.6" 2> /dev/null; then
             key=".[0]${key}"
         fi
     fi


### PR DESCRIPTION
The get_build_info() function uses nvrGreaterOrEqual() to determine how to parse the output from composer-cli.  The function prints the result of the comparison but is often used in a loop when waiting for a compose to finish, which makes CI logs very annoying.

Silence the version comparison output when called form get_build_info().