### PR TITLE
image: image_installer, use gzip compression

### DIFF
--- a/internal/image/image_installer.go
+++ b/internal/image/image_installer.go
@@ -62,7 +62,7 @@ func (img *ImageInstaller) InstantiateManifest(m *manifest.Manifest,
 		img.OSVersion)
 
 	interactiveDefaults := manifest.NewAnacondaInteractiveDefaults(
-		"file:///run/install/repo/liveimg.tar",
+		"file:///run/install/repo/liveimg.tar.gz",
 	)
 
 	anacondaPipeline.ExtraPackages = img.ExtraBasePackages.Include

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -209,7 +209,8 @@ func (p *ISOTree) serialize() osbuild.Pipeline {
 	}
 
 	if p.OSPipeline != nil {
-		pipeline.AddStage(osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: "/liveimg.tar"}, p.OSPipeline.name))
+		// The TarStage has --autocompress
+		pipeline.AddStage(osbuild.NewTarStage(&osbuild.TarStageOptions{Filename: "/liveimg.tar.gz"}, p.OSPipeline.name))
 
 		// In the case of OSPipeline then the ImageInstaller has already set InteractiveDefaults on the anaconda-tree,
 		// eliminating the need to set a separate kickstart here.

--- a/test/data/manifests/fedora_35-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-image_installer-boot.json
@@ -9931,7 +9931,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -12929,7 +12929,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_35-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-image_installer_with_users-boot.json
@@ -9961,7 +9961,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -12959,7 +12959,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_35-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-image_installer-boot.json
@@ -10124,7 +10124,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13162,7 +13162,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_35-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-image_installer_with_users-boot.json
@@ -10154,7 +10154,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13192,7 +13192,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
@@ -10219,7 +10219,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13585,7 +13585,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
@@ -10249,7 +10249,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13615,7 +13615,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_36-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-image_installer-boot.json
@@ -10412,7 +10412,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13866,7 +13866,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_36-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-image_installer_with_users-boot.json
@@ -10442,7 +10442,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13896,7 +13896,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
@@ -10345,7 +10345,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13757,7 +13757,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
@@ -10375,7 +10375,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13787,7 +13787,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_37-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-image_installer-boot.json
@@ -10546,7 +10546,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -14046,7 +14046,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_37-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-image_installer_with_users-boot.json
@@ -10576,7 +10576,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -14076,7 +14076,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
@@ -10213,7 +10213,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13637,7 +13637,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
@@ -10243,7 +10243,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13667,7 +13667,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_38-x86_64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-image_installer-boot.json
@@ -10398,7 +10398,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13902,7 +13902,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {

--- a/test/data/manifests/fedora_38-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-image_installer_with_users-boot.json
@@ -10428,7 +10428,7 @@
             "options": {
               "path": "/usr/share/anaconda/interactive-defaults.ks",
               "liveimg": {
-                "url": "file:///run/install/repo/liveimg.tar"
+                "url": "file:///run/install/repo/liveimg.tar.gz"
               }
             }
           }
@@ -13932,7 +13932,7 @@
               }
             },
             "options": {
-              "filename": "/liveimg.tar"
+              "filename": "/liveimg.tar.gz"
             }
           },
           {


### PR DESCRIPTION
Anaconda has support for compression on the liveimg. There is little reason not to compress the tarball using gzip.

I also want to replace the liveimg.tar in our CI for the preview images with the compressed version, it's much easier to do so when the initial liveimg is already .gz (less mksisofs)