### PR TITLE
`internal/rpmmd` cleanup 🧹

### DIFF
--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -178,34 +178,6 @@ type PackageInfo struct {
 	Dependencies []PackageSpec  `json:"dependencies,omitempty"`
 }
 
-type RPMMD interface {
-	// FetchMetadata returns all metadata about the repositories we use in the code. Specifically it is a
-	// list of packages and dictionary of checksums of the repositories.
-	FetchMetadata(repos []RepoConfig, modulePlatformID, arch, releasever string) (PackageList, map[string]string, error)
-
-	// Depsolve takes a list of required content (specs), explicitly unwanted content (excludeSpecs), list
-	// or repositories, and platform ID for modularity. It returns a list of all packages (with solved
-	// dependencies) that will be installed into the system.
-	//
-	// NOTE: Kept for legacy purposes (Weldr). New code should default to using DepsolvePackageSets().
-	Depsolve(packageSet PackageSet, repos []RepoConfig, modulePlatformID, arch, releasever string) ([]PackageSpec, map[string]string, error)
-
-	// DepsolvePackageSets takes a map of package sets chains, which should be depsolved as separate transactions,
-	// a map of package sets (included and excluded), a list of common and package-set-specific repositories,
-	// platform ID for modularity, architecture and release version. It returns a map of Package Specs, depsolved
-	// in a chain or alone, as defined based on the provided arguments.
-	DepsolvePackageSets(packageSetsChains map[string][]string, packageSets map[string]PackageSet, repos []RepoConfig, packageSetsRepos map[string][]RepoConfig, modulePlatformID, arch, releasever string) (map[string][]PackageSpec, error)
-}
-
-type DNFError struct {
-	Kind   string `json:"kind"`
-	Reason string `json:"reason"`
-}
-
-func (err *DNFError) Error() string {
-	return fmt.Sprintf("DNF error occured: %s: %s", err.Kind, err.Reason)
-}
-
 type RepositoryError struct {
 	msg string
 }

--- a/internal/rpmmd/repository.go
+++ b/internal/rpmmd/repository.go
@@ -178,14 +178,6 @@ type PackageInfo struct {
 	Dependencies []PackageSpec  `json:"dependencies,omitempty"`
 }
 
-type RepositoryError struct {
-	msg string
-}
-
-func (re *RepositoryError) Error() string {
-	return re.msg
-}
-
 func GetVerStrFromPackageSpecList(pkgs []PackageSpec, packageName string) (string, error) {
 	for _, pkg := range pkgs {
 		if pkg.Name == packageName {
@@ -310,7 +302,7 @@ func LoadRepositories(confPaths []string, distro string) (map[string][]RepoConfi
 	}
 
 	if repoConfigs == nil {
-		return nil, &RepositoryError{"LoadRepositories failed: none of the provided paths contain distro configuration"}
+		return nil, fmt.Errorf("LoadRepositories failed: none of the provided paths contain distro configuration")
 	}
 
 	return repoConfigs, nil


### PR DESCRIPTION
Get rid of unused interfaces, data structures and some weirdness...

This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
