### PR TITLE
Bugfix: Add RHSM Fact (APIType) to RHEL 9 image definitions

### DIFF
--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -46,6 +46,7 @@ type repository struct {
 	RHSM           bool     `json:"rhsm,omitempty"`
 	MetadataExpire string   `json:"metadata_expire,omitempty"`
 	ImageTypeTags  []string `json:"image_type_tags,omitempty"`
+	PackageSets    []string `json:"package-sets,omitempty"`
 }
 
 type ostreeOptions struct {

--- a/cmd/gen-manifests/main.go
+++ b/cmd/gen-manifests/main.go
@@ -121,6 +121,12 @@ func makeManifestJob(name string, imgType distro.ImageType, cr composeRequest, d
 			FetchChecksum: cr.OSTree.Parent,
 		}
 	}
+
+	// add RHSM fact to detect changes
+	options.Facts = &distro.FactsImageOptions{
+		ApiType: "test-manifest",
+	}
+
 	job := func(msgq chan string) (err error) {
 		defer func() {
 			msg := fmt.Sprintf("Finished job %s", filename)

--- a/internal/distro/distro_test_common/distro_test_common.go
+++ b/internal/distro/distro_test_common/distro_test_common.go
@@ -105,6 +105,9 @@ func TestDistro_Manifest(t *testing.T, pipelinePath string, prefix string, regis
 			options := distro.ImageOptions{
 				Size:   imageType.Size(0),
 				OSTree: ostreeOptions,
+				Facts: &distro.FactsImageOptions{
+					ApiType: "test-manifest",
+				},
 			}
 
 			var imgPackageSpecSets map[string][]rpmmd.PackageSpec

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -129,6 +129,10 @@ func osCustomizations(
 		)
 	}
 
+	if t.arch.distro.isRHEL() && options.Facts != nil {
+		osc.FactAPIType = options.Facts.ApiType
+	}
+
 	osc.Grub2Config = imageConfig.Grub2Config
 	osc.Sysconfig = imageConfig.Sysconfig
 	osc.SystemdLogind = imageConfig.SystemdLogind

--- a/internal/manifest/os.go
+++ b/internal/manifest/os.go
@@ -95,6 +95,7 @@ type OSCustomizations struct {
 	WAAgentConfig       *osbuild.WAAgentConfStageOptions
 	UdevRules           *osbuild.UdevRulesStageOptions
 	LeapSecTZ           *string
+	FactAPIType         string
 
 	Subscription *distro.SubscriptionImageOptions
 	RHSMConfig   map[distro.RHSMSubscriptionStatus]*osbuild.RHSMStageOptions
@@ -519,6 +520,14 @@ func (p *OS) serialize() osbuild.Pipeline {
 
 	if p.OpenSCAPConfig != nil {
 		pipeline.AddStage(osbuild.NewOscapRemediationStage(p.OpenSCAPConfig))
+	}
+
+	if p.FactAPIType != "" {
+		pipeline.AddStage(osbuild.NewRHSMFactsStage(&osbuild.RHSMFactsStageOptions{
+			Facts: osbuild.RHSMFacts{
+				ApiType: p.FactAPIType,
+			},
+		}))
 	}
 
 	if p.SElinux != "" {

--- a/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-azure_rhui-boot.json
@@ -11441,5 +11441,6 @@
         "checksum": "sha256:000bd49aea30ee3534e6cde11188afa4b567711b13acbcf531e5542fc7b2aefe"
       }
     ]
-  }
+  },
+  "no-image-info": true
 }

--- a/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2-boot.json
@@ -22,7 +22,10 @@
       },
       {
         "name": "rhel-eng",
-        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530"
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530",
+        "package-sets": [
+          "build"
+        ]
       },
       {
         "name": "azure-rhui-7",

--- a/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_7-x86_64-qcow2_customize-boot.json
@@ -22,7 +22,10 @@
       },
       {
         "name": "rhel-eng",
-        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530"
+        "baseurl": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el7/el7-x86_64-eng-rel-20220530",
+        "package-sets": [
+          "build"
+        ]
       },
       {
         "name": "azure-rhui-7",

--- a/test/data/manifests/rhel_8-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ami-boot.json
@@ -2288,6 +2288,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-ec2-boot.json
@@ -2304,6 +2304,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit-boot.json
@@ -1958,6 +1958,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_commit_with_container-boot.json
@@ -2080,6 +2080,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-edge_container-boot.json
@@ -1958,6 +1958,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-image_installer-boot.json
@@ -2448,6 +2448,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-image_installer_with_users-boot.json
@@ -2531,6 +2531,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-openstack-boot.json
@@ -2248,6 +2248,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2-boot.json
@@ -2246,6 +2246,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-qcow2_customize-boot.json
@@ -2458,6 +2458,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_8-aarch64-tar-boot.json
@@ -1368,6 +1368,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2-boot.json
@@ -2390,6 +2390,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-qcow2_customize-boot.json
@@ -2602,6 +2602,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_8-ppc64le-tar-boot.json
@@ -1389,6 +1389,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2-boot.json
@@ -2479,6 +2479,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-s390x-qcow2_customize-boot.json
@@ -2691,6 +2691,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_8-s390x-tar-boot.json
@@ -1665,6 +1665,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ami-boot.json
@@ -2219,6 +2219,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-azure_rhui-boot.json
@@ -3046,6 +3046,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-azure_sap_rhui-boot.json
@@ -3710,6 +3710,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2-boot.json
@@ -2237,6 +2237,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_ha-boot.json
@@ -2770,6 +2770,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-ec2_sap-boot.json
@@ -3626,6 +3626,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit-boot.json
@@ -2037,6 +2037,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_rt-boot.json
@@ -2113,6 +2113,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_commit_with_container-boot.json
@@ -2159,6 +2159,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-edge_container-boot.json
@@ -2027,6 +2027,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-gce-boot.json
@@ -2381,6 +2381,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-gce_rhui-boot.json
@@ -2392,6 +2392,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-image_installer-boot.json
@@ -2490,6 +2490,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-image_installer_with_users-boot.json
@@ -2573,6 +2573,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-oci-boot.json
@@ -2262,6 +2262,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-openstack-boot.json
@@ -2294,6 +2294,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2-boot.json
@@ -2283,6 +2283,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-qcow2_customize-boot.json
@@ -2498,6 +2498,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-tar-boot.json
@@ -1392,6 +1392,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vhd-boot.json
@@ -3012,6 +3012,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_8-x86_64-vmdk-boot.json
@@ -2294,6 +2294,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ami-boot.json
@@ -2321,6 +2321,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-ec2-boot.json
@@ -2337,6 +2337,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit-boot.json
@@ -2022,6 +2022,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_commit_with_container-boot.json
@@ -2087,6 +2087,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-edge_container-boot.json
@@ -2022,6 +2022,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-image_installer-boot.json
@@ -2481,6 +2481,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-image_installer_with_users-boot.json
@@ -2564,6 +2564,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-openstack-boot.json
@@ -2248,6 +2248,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2-boot.json
@@ -2270,6 +2270,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-qcow2_customize-boot.json
@@ -2473,6 +2473,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_84-aarch64-tar-boot.json
@@ -1416,6 +1416,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2-boot.json
@@ -2414,6 +2414,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-qcow2_customize-boot.json
@@ -2617,6 +2617,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_84-ppc64le-tar-boot.json
@@ -1437,6 +1437,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2-boot.json
@@ -2512,6 +2512,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-s390x-qcow2_customize-boot.json
@@ -2715,6 +2715,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_84-s390x-tar-boot.json
@@ -1716,6 +1716,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ami-boot.json
@@ -2249,6 +2249,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-azure_rhui-boot.json
@@ -3076,6 +3076,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-azure_sap_rhui-boot.json
@@ -3673,6 +3673,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2-boot.json
@@ -2267,6 +2267,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_ha-boot.json
@@ -2803,6 +2803,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-ec2_sap-boot.json
@@ -3573,6 +3573,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit-boot.json
@@ -2101,6 +2101,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_rt-boot.json
@@ -2177,6 +2177,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_commit_with_container-boot.json
@@ -2166,6 +2166,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-edge_container-boot.json
@@ -2091,6 +2091,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-gce-boot.json
@@ -2413,6 +2413,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-gce_rhui-boot.json
@@ -2424,6 +2424,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-image_installer-boot.json
@@ -2526,6 +2526,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-image_installer_with_users-boot.json
@@ -2609,6 +2609,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-oci-boot.json
@@ -2289,6 +2289,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-openstack-boot.json
@@ -2297,6 +2297,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2-boot.json
@@ -2310,6 +2310,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-qcow2_customize-boot.json
@@ -2516,6 +2516,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-tar-boot.json
@@ -1440,6 +1440,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vhd-boot.json
@@ -3042,6 +3042,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_84-x86_64-vmdk-boot.json
@@ -2318,6 +2318,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ami-boot.json
@@ -2285,6 +2285,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-ec2-boot.json
@@ -2301,6 +2301,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit-boot.json
@@ -1963,6 +1963,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_commit_with_container-boot.json
@@ -2097,6 +2097,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-edge_container-boot.json
@@ -1963,6 +1963,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-image_installer-boot.json
@@ -2457,6 +2457,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-image_installer_with_users-boot.json
@@ -2540,6 +2540,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-openstack-boot.json
@@ -2248,6 +2248,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2-boot.json
@@ -2243,6 +2243,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-qcow2_customize-boot.json
@@ -2502,6 +2502,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_85-aarch64-tar-boot.json
@@ -1362,6 +1362,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2-boot.json
@@ -2399,6 +2399,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-qcow2_customize-boot.json
@@ -2655,6 +2655,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_85-ppc64le-tar-boot.json
@@ -1437,6 +1437,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2-boot.json
@@ -2497,6 +2497,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-s390x-qcow2_customize-boot.json
@@ -2752,6 +2752,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_85-s390x-tar-boot.json
@@ -1716,6 +1716,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ami-boot.json
@@ -2210,6 +2210,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-azure_rhui-boot.json
@@ -3049,6 +3049,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-azure_sap_rhui-boot.json
@@ -3649,6 +3649,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2-boot.json
@@ -2227,6 +2227,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-ec2_ha-boot.json
@@ -2759,6 +2759,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit-boot.json
@@ -2042,6 +2042,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_rt-boot.json
@@ -2115,6 +2115,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_commit_with_container-boot.json
@@ -2176,6 +2176,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-edge_container-boot.json
@@ -2032,6 +2032,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-gce-boot.json
@@ -2381,6 +2381,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-gce_rhui-boot.json
@@ -2392,6 +2392,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-image_installer-boot.json
@@ -2499,6 +2499,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-image_installer_with_users-boot.json
@@ -2582,6 +2582,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-oci-boot.json
@@ -2259,6 +2259,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-openstack-boot.json
@@ -2294,6 +2294,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2-boot.json
@@ -2280,6 +2280,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-qcow2_customize-boot.json
@@ -2542,6 +2542,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-tar-boot.json
@@ -1386,6 +1386,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-vhd-boot.json
@@ -3015,6 +3015,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_85-x86_64-vmdk-boot.json
@@ -2291,6 +2291,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ami-boot.json
@@ -2288,6 +2288,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-ec2-boot.json
@@ -2304,6 +2304,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit-boot.json
@@ -1958,6 +1958,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_commit_with_container-boot.json
@@ -2080,6 +2080,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-edge_container-boot.json
@@ -1958,6 +1958,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-image_installer-boot.json
@@ -2448,6 +2448,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-image_installer_with_users-boot.json
@@ -2531,6 +2531,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-openstack-boot.json
@@ -2248,6 +2248,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2-boot.json
@@ -2246,6 +2246,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-qcow2_customize-boot.json
@@ -2497,6 +2497,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_86-aarch64-tar-boot.json
@@ -1368,6 +1368,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2-boot.json
@@ -2390,6 +2390,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-qcow2_customize-boot.json
@@ -2641,6 +2641,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_86-ppc64le-tar-boot.json
@@ -1389,6 +1389,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2-boot.json
@@ -2479,6 +2479,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-s390x-qcow2_customize-boot.json
@@ -2729,6 +2729,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_86-s390x-tar-boot.json
@@ -1665,6 +1665,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ami-boot.json
@@ -2219,6 +2219,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_rhui-boot.json
@@ -3046,6 +3046,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-azure_sap_rhui-boot.json
@@ -3721,6 +3721,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2-boot.json
@@ -2237,6 +2237,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_ha-boot.json
@@ -2770,6 +2770,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-ec2_sap-boot.json
@@ -3627,6 +3627,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit-boot.json
@@ -2037,6 +2037,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_rt-boot.json
@@ -2113,6 +2113,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_commit_with_container-boot.json
@@ -2159,6 +2159,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-edge_container-boot.json
@@ -2027,6 +2027,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-gce-boot.json
@@ -2381,6 +2381,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-gce_rhui-boot.json
@@ -2392,6 +2392,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-image_installer-boot.json
@@ -2490,6 +2490,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-image_installer_with_users-boot.json
@@ -2573,6 +2573,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-oci-boot.json
@@ -2262,6 +2262,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-openstack-boot.json
@@ -2294,6 +2294,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2-boot.json
@@ -2283,6 +2283,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-qcow2_customize-boot.json
@@ -2537,6 +2537,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-tar-boot.json
@@ -1392,6 +1392,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vhd-boot.json
@@ -3012,6 +3012,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_86-x86_64-vmdk-boot.json
@@ -2294,6 +2294,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ami-boot.json
@@ -2285,6 +2285,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-ec2-boot.json
@@ -2291,6 +2291,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit-boot.json
@@ -1961,6 +1961,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_commit_with_container-boot.json
@@ -2083,6 +2083,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-edge_container-boot.json
@@ -1961,6 +1961,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-image_installer-boot.json
@@ -2442,6 +2442,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-image_installer_with_users-boot.json
@@ -2528,6 +2528,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-openstack-boot.json
@@ -2257,6 +2257,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-qcow2-boot.json
@@ -2249,6 +2249,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-qcow2_customize-boot.json
@@ -2500,6 +2500,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_87-aarch64-tar-boot.json
@@ -1368,6 +1368,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_87-ppc64le-qcow2-boot.json
@@ -2393,6 +2393,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-ppc64le-qcow2_customize-boot.json
@@ -2644,6 +2644,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_87-ppc64le-tar-boot.json
@@ -1389,6 +1389,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_87-s390x-qcow2-boot.json
@@ -2497,6 +2497,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-s390x-qcow2_customize-boot.json
@@ -2747,6 +2747,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_87-s390x-tar-boot.json
@@ -1677,6 +1677,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ami-boot.json
@@ -2219,6 +2219,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_rhui-boot.json
@@ -3043,6 +3043,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-azure_sap_rhui-boot.json
@@ -3680,6 +3680,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2-boot.json
@@ -2227,6 +2227,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_ha-boot.json
@@ -2760,6 +2760,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-ec2_sap-boot.json
@@ -3586,6 +3586,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit-boot.json
@@ -2040,6 +2040,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_rt-boot.json
@@ -2113,6 +2113,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_commit_with_container-boot.json
@@ -2162,6 +2162,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-edge_container-boot.json
@@ -2030,6 +2030,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-gce-boot.json
@@ -2375,6 +2375,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-gce_rhui-boot.json
@@ -2386,6 +2386,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-image_installer-boot.json
@@ -2484,6 +2484,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-image_installer_with_users-boot.json
@@ -2570,6 +2570,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-oci-boot.json
@@ -2265,6 +2265,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-openstack-boot.json
@@ -2303,6 +2303,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-qcow2-boot.json
@@ -2286,6 +2286,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-qcow2_customize-boot.json
@@ -2540,6 +2540,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-tar-boot.json
@@ -1392,6 +1392,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-vhd-boot.json
@@ -3009,6 +3009,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_87-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_87-x86_64-vmdk-boot.json
@@ -2297,6 +2297,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-ami-boot.json
@@ -2285,6 +2285,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-ec2-boot.json
@@ -2291,6 +2291,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit-boot.json
@@ -1961,6 +1961,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_commit_with_container-boot.json
@@ -2083,6 +2083,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-edge_container-boot.json
@@ -1961,6 +1961,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-image_installer-boot.json
@@ -2442,6 +2442,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-image_installer_with_users-boot.json
@@ -2528,6 +2528,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-openstack-boot.json
@@ -2257,6 +2257,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-qcow2-boot.json
@@ -2249,6 +2249,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-qcow2_customize-boot.json
@@ -2500,6 +2500,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_88-aarch64-tar-boot.json
@@ -1368,6 +1368,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_88-ppc64le-qcow2-boot.json
@@ -2393,6 +2393,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-ppc64le-qcow2_customize-boot.json
@@ -2644,6 +2644,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_88-ppc64le-tar-boot.json
@@ -1389,6 +1389,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_88-s390x-qcow2-boot.json
@@ -2497,6 +2497,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-s390x-qcow2_customize-boot.json
@@ -2747,6 +2747,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_88-s390x-tar-boot.json
@@ -1677,6 +1677,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ami-boot.json
@@ -2219,6 +2219,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-azure_rhui-boot.json
@@ -3043,6 +3043,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-azure_sap_rhui-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-azure_sap_rhui-boot.json
@@ -3680,6 +3680,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2-boot.json
@@ -2227,6 +2227,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2_ha-boot.json
@@ -2760,6 +2760,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-ec2_sap-boot.json
@@ -3586,6 +3586,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit-boot.json
@@ -2040,6 +2040,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_rt-boot.json
@@ -2110,6 +2110,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_commit_with_container-boot.json
@@ -2162,6 +2162,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-edge_container-boot.json
@@ -2030,6 +2030,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-gce-boot.json
@@ -2375,6 +2375,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-gce_rhui-boot.json
@@ -2386,6 +2386,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-image_installer-boot.json
@@ -2484,6 +2484,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-image_installer_with_users-boot.json
@@ -2570,6 +2570,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-oci-boot.json
@@ -2265,6 +2265,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-openstack-boot.json
@@ -2303,6 +2303,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-qcow2-boot.json
@@ -2286,6 +2286,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-qcow2_customize-boot.json
@@ -2540,6 +2540,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-tar-boot.json
@@ -1392,6 +1392,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-vhd-boot.json
@@ -3009,6 +3009,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_88-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_88-x86_64-vmdk-boot.json
@@ -2297,6 +2297,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ami-boot.json
@@ -1918,6 +1918,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-ec2-boot.json
@@ -1937,6 +1937,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit-boot.json
@@ -1681,6 +1681,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_commit_with_container-boot.json
@@ -1794,6 +1794,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_container-boot.json
@@ -1681,6 +1681,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -5107,6 +5107,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
@@ -5202,6 +5202,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-openstack-boot.json
@@ -1820,6 +1820,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2-boot.json
@@ -1875,6 +1875,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-qcow2_customize-boot.json
@@ -2069,6 +2069,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-tar-boot.json
@@ -861,6 +861,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2-boot.json
@@ -2102,6 +2102,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-qcow2_customize-boot.json
@@ -2290,6 +2290,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_90-ppc64le-tar-boot.json
@@ -1224,6 +1224,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -1958,6 +1958,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -2152,6 +2152,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_90-s390x-tar-boot.json
@@ -1128,6 +1128,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ami-boot.json
@@ -1918,6 +1918,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-azure_rhui-boot.json
@@ -2719,6 +2719,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2-boot.json
@@ -1939,6 +1939,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_ha-boot.json
@@ -2511,6 +2511,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-ec2_sap-boot.json
@@ -3431,6 +3431,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit-boot.json
@@ -1769,6 +1769,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_rt-boot.json
@@ -1938,6 +1938,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_commit_with_container-boot.json
@@ -1882,6 +1882,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_container-boot.json
@@ -1759,6 +1759,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce-boot.json
@@ -2005,6 +2005,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-gce_rhui-boot.json
@@ -2011,6 +2011,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
@@ -5198,6 +5198,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
@@ -5293,6 +5293,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-oci-boot.json
@@ -1957,6 +1957,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-openstack-boot.json
@@ -1965,6 +1965,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2-boot.json
@@ -1978,6 +1978,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-qcow2_customize-boot.json
@@ -2202,6 +2202,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-tar-boot.json
@@ -864,6 +864,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vhd-boot.json
@@ -2679,6 +2679,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-vmdk-boot.json
@@ -1965,6 +1965,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ami-boot.json
@@ -4613,6 +4613,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-ec2-boot.json
@@ -4646,6 +4646,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit-boot.json
@@ -4488,6 +4488,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_commit_with_container-boot.json
@@ -4537,6 +4537,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_container-boot.json
@@ -4488,6 +4488,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
@@ -13303,6 +13303,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
@@ -13490,6 +13490,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-openstack-boot.json
@@ -4570,6 +4570,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2-boot.json
@@ -4717,6 +4717,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-qcow2_customize-boot.json
@@ -5307,6 +5307,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-tar-boot.json
@@ -2046,6 +2046,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2-boot.json
@@ -5331,6 +5331,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-qcow2_customize-boot.json
@@ -5905,6 +5905,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_91-ppc64le-tar-boot.json
@@ -3014,6 +3014,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2-boot.json
@@ -4978,6 +4978,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
@@ -5568,6 +5568,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_91-s390x-tar-boot.json
@@ -2766,6 +2766,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ami-boot.json
@@ -4574,6 +4574,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-azure_rhui-boot.json
@@ -6653,6 +6653,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2-boot.json
@@ -4609,6 +4609,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_ha-boot.json
@@ -6053,6 +6053,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-ec2_sap-boot.json
@@ -8608,6 +8608,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit-boot.json
@@ -4699,6 +4699,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_rt-boot.json
@@ -5130,6 +5130,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_commit_with_container-boot.json
@@ -4748,6 +4748,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_container-boot.json
@@ -4688,6 +4688,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce-boot.json
@@ -4835,6 +4835,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-gce_rhui-boot.json
@@ -4841,6 +4841,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
@@ -13504,6 +13504,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
@@ -13691,6 +13691,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-oci-boot.json
@@ -4953,6 +4953,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-openstack-boot.json
@@ -4931,6 +4931,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2-boot.json
@@ -4974,6 +4974,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-qcow2_customize-boot.json
@@ -5644,6 +5644,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-tar-boot.json
@@ -2054,6 +2054,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-vhd-boot.json
@@ -6588,6 +6588,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_91-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-vmdk-boot.json
@@ -4931,6 +4931,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-ami-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-ami-boot.json
@@ -4613,6 +4613,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-ec2-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-ec2-boot.json
@@ -4646,6 +4646,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit-boot.json
@@ -4488,6 +4488,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_commit_with_container-boot.json
@@ -4537,6 +4537,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_container-boot.json
@@ -4488,6 +4488,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
@@ -13327,6 +13327,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
@@ -13514,6 +13514,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-openstack-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-openstack-boot.json
@@ -4570,6 +4570,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-qcow2-boot.json
@@ -4717,6 +4717,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-qcow2_customize-boot.json
@@ -5042,6 +5042,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-aarch64-tar-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-tar-boot.json
@@ -2046,6 +2046,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-ppc64le-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-ppc64le-qcow2-boot.json
@@ -5331,6 +5331,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-ppc64le-qcow2_customize-boot.json
@@ -5640,6 +5640,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-ppc64le-tar-boot.json
+++ b/test/data/manifests/rhel_92-ppc64le-tar-boot.json
@@ -3014,6 +3014,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-s390x-qcow2-boot.json
@@ -4978,6 +4978,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
@@ -5303,6 +5303,14 @@
             "options": {}
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_92-s390x-tar-boot.json
@@ -2766,6 +2766,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-ami-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ami-boot.json
@@ -4574,6 +4574,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-azure_rhui-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-azure_rhui-boot.json
@@ -6653,6 +6653,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-ec2-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2-boot.json
@@ -4609,6 +4609,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_ha-boot.json
@@ -6053,6 +6053,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-ec2_sap-boot.json
@@ -8608,6 +8608,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit-boot.json
@@ -4699,6 +4699,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_rt-boot.json
@@ -5130,6 +5130,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_commit_with_container-boot.json
@@ -4748,6 +4748,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_container-boot.json
@@ -4688,6 +4688,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-gce-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-gce-boot.json
@@ -4835,6 +4835,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-gce_rhui-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-gce_rhui-boot.json
@@ -4841,6 +4841,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-image_installer-boot.json
@@ -13528,6 +13528,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-image_installer_with_users-boot.json
@@ -13715,6 +13715,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-oci-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-oci-boot.json
@@ -4953,6 +4953,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-openstack-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-openstack-boot.json
@@ -4931,6 +4931,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-qcow2-boot.json
@@ -4974,6 +4974,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-qcow2_customize-boot.json
@@ -5379,6 +5379,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-tar-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-tar-boot.json
@@ -2054,6 +2054,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-vhd-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-vhd-boot.json
@@ -6588,6 +6588,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"

--- a/test/data/manifests/rhel_92-x86_64-vmdk-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-vmdk-boot.json
@@ -4931,6 +4931,14 @@
             }
           },
           {
+            "type": "org.osbuild.rhsm.facts",
+            "options": {
+              "facts": {
+                "image-builder.osbuild-composer.api-type": "test-manifest"
+              }
+            }
+          },
+          {
             "type": "org.osbuild.selinux",
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts"


### PR DESCRIPTION
- Added an API type to the RHSM Fact option when generating manifests with the `gen-manifests` tool.  The value is `test-manifest` which should never appear in our data but can be used to check if the stage is properly applied in the test manifests.
- Fixed bug in RHEL 9 where the RHSM facts were missing.