### PR TITLE
Ignition blueprint config support on rhel9

### DIFF
--- a/internal/blueprint/customizations.go
+++ b/internal/blueprint/customizations.go
@@ -23,6 +23,21 @@ type Customizations struct {
 	InstallationDevice string                    `json:"installation_device,omitempty" toml:"installation_device,omitempty"`
 	FDO                *FDOCustomization         `json:"fdo,omitempty" toml:"fdo,omitempty"`
 	OpenSCAP           *OpenSCAPCustomization    `json:"openscap,omitempty" toml:"openscap,omitempty"`
+	Ignition           *IgnitionCustomization    `json:"ignition,omitempty" toml:"ignition,omitempty"`
+}
+
+type IgnitionCustomization struct {
+	Embedded  *EmbeddedIgnitionCustomization  `json:"embedded,omitempty" toml:"embedded,omitempty"`
+	FirstBoot *FirstBootIgnitionCustomization `json:"firstboot,omitempty" toml:"firstboot,omitempty"`
+}
+
+type EmbeddedIgnitionCustomization struct {
+	ProvisioningURL string `json:"url,omitempty" toml:"url,omitempty"`
+	Data64          string `json:"data,omitempty" toml:"data,omitempty"`
+}
+
+type FirstBootIgnitionCustomization struct {
+	ProvisioningURL string `json:"url,omitempty" toml:"url"`
 }
 
 type FDOCustomization struct {
@@ -389,4 +404,26 @@ func (c *Customizations) GetOpenSCAP() *OpenSCAPCustomization {
 
 func (f *FDOCustomization) HasFDO() bool {
 	return f != nil
+}
+
+func (c *Customizations) GetIgnition() *IgnitionCustomization {
+	if c == nil {
+		return nil
+	}
+	return c.Ignition
+}
+
+func (c *IgnitionCustomization) HasIgnition() bool {
+	return c != nil
+}
+
+func (c *EmbeddedIgnitionCustomization) CheckEmbeddedIgnition() error {
+	if c == nil {
+		return nil
+	}
+	if c.Data64 != "" && c.ProvisioningURL != "" {
+		t := reflect.TypeOf(*c)
+		return &CustomizationError{fmt.Sprintf("'%s' and '%s' are not allowed at the same time", t.Field(0).Name, t.Field(1).Name)}
+	}
+	return nil
 }

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/container"
 	"github.com/osbuild/osbuild-composer/internal/distro"
 	"github.com/osbuild/osbuild-composer/internal/fdo"
+	"github.com/osbuild/osbuild-composer/internal/ignition"
 	"github.com/osbuild/osbuild-composer/internal/image"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/osbuild"
@@ -410,6 +411,9 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	img.Filename = t.Filename()
 	if bpFDO := customizations.GetFDO(); bpFDO != nil {
 		img.FDO = fdo.FromBP(*bpFDO)
+	}
+	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && customizations.Ignition.FirstBoot != nil {
+		img.Ignition = ignition.FromBP(*bpIgnition.FirstBoot)
 	}
 
 	d := t.arch.distro

--- a/internal/distro/rhel9/images.go
+++ b/internal/distro/rhel9/images.go
@@ -412,8 +412,14 @@ func edgeSimplifiedInstallerImage(workload workload.Workload,
 	if bpFDO := customizations.GetFDO(); bpFDO != nil {
 		img.FDO = fdo.FromBP(*bpFDO)
 	}
-	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil && customizations.Ignition.FirstBoot != nil {
-		img.Ignition = ignition.FromBP(*bpIgnition.FirstBoot)
+	// ignition configs from blueprint
+	if bpIgnition := customizations.GetIgnition(); bpIgnition != nil {
+		if bpIgnition.FirstBoot != nil {
+			img.IgnitionFirstBoot = ignition.FirstbootOptionsFromBP(*bpIgnition.FirstBoot)
+		}
+		if bpIgnition.Embedded != nil {
+			img.IgnitionEmbedded = ignition.EmbeddedOptionsFromBP(*bpIgnition.Embedded)
+		}
 	}
 
 	d := t.arch.distro

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -2,11 +2,21 @@ package ignition
 
 import "github.com/osbuild/osbuild-composer/internal/blueprint"
 
-type Options struct {
+type FirstBootOptions struct {
 	ProvisioningURL string
 }
 
-func FromBP(bpIgnitionFirstboot blueprint.FirstBootIgnitionCustomization) *Options {
-	ignition := Options(bpIgnitionFirstboot)
+func FirstbootOptionsFromBP(bpIgnitionFirstboot blueprint.FirstBootIgnitionCustomization) *FirstBootOptions {
+	ignition := FirstBootOptions(bpIgnitionFirstboot)
+	return &ignition
+}
+
+type EmbeddedOptions struct {
+	ProvisioningURL string
+	Data64          string
+}
+
+func EmbeddedOptionsFromBP(bpIgnitionEmbedded blueprint.EmbeddedIgnitionCustomization) *EmbeddedOptions {
+	ignition := EmbeddedOptions(bpIgnitionEmbedded)
 	return &ignition
 }

--- a/internal/ignition/ignition.go
+++ b/internal/ignition/ignition.go
@@ -1,0 +1,12 @@
+package ignition
+
+import "github.com/osbuild/osbuild-composer/internal/blueprint"
+
+type Options struct {
+	ProvisioningURL string
+}
+
+func FromBP(bpIgnitionFirstboot blueprint.FirstBootIgnitionCustomization) *Options {
+	ignition := Options(bpIgnitionFirstboot)
+	return &ignition
+}

--- a/internal/image/ostree_simplified_installer.go
+++ b/internal/image/ostree_simplified_installer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osbuild/osbuild-composer/internal/disk"
 	"github.com/osbuild/osbuild-composer/internal/environment"
 	"github.com/osbuild/osbuild-composer/internal/fdo"
+	"github.com/osbuild/osbuild-composer/internal/ignition"
 	"github.com/osbuild/osbuild-composer/internal/manifest"
 	"github.com/osbuild/osbuild-composer/internal/platform"
 	"github.com/osbuild/osbuild-composer/internal/rpmmd"
@@ -49,6 +50,9 @@ type OSTreeSimplifiedInstaller struct {
 	Filename string
 
 	FDO *fdo.Options
+
+	// ignition firstboot configuration options
+	Ignition *ignition.Options
 
 	AdditionalDracutModules []string
 }
@@ -118,6 +122,12 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 			kernelOpts = append(kernelOpts, "fdo.diun_pub_key_root_certs=/fdo_diun_pub_key_root_certs.pem")
 		}
 	}
+
+	// ignition firstboot options
+	if img.Ignition != nil {
+		kernelOpts = append(kernelOpts, "coreos.inst.append ignition.config.url="+img.Ignition.ProvisioningURL)
+	}
+
 	bootTreePipeline.KernelOpts = kernelOpts
 
 	rootfsPartitionTable := &disk.PartitionTable{

--- a/internal/image/ostree_simplified_installer.go
+++ b/internal/image/ostree_simplified_installer.go
@@ -51,8 +51,11 @@ type OSTreeSimplifiedInstaller struct {
 
 	FDO *fdo.Options
 
-	// ignition firstboot configuration options
-	Ignition *ignition.Options
+	// Ignition firstboot configuration options
+	IgnitionFirstBoot *ignition.FirstBootOptions
+
+	// Ignition embedded configuration options
+	IgnitionEmbedded *ignition.EmbeddedOptions
 
 	AdditionalDracutModules []string
 }
@@ -88,6 +91,7 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	coiPipeline.ExtraPackages = img.ExtraBasePackages.Include
 	coiPipeline.ExtraRepos = img.ExtraBasePackages.Repositories
 	coiPipeline.FDO = img.FDO
+	coiPipeline.Ignition = img.IgnitionEmbedded
 	coiPipeline.Biosdevname = (img.Platform.GetArch() == platform.ARCH_X86_64)
 	coiPipeline.Variant = img.Variant
 	coiPipeline.AdditionalDracutModules = img.AdditionalDracutModules
@@ -124,8 +128,8 @@ func (img *OSTreeSimplifiedInstaller) InstantiateManifest(m *manifest.Manifest,
 	}
 
 	// ignition firstboot options
-	if img.Ignition != nil {
-		kernelOpts = append(kernelOpts, "coreos.inst.append ignition.config.url="+img.Ignition.ProvisioningURL)
+	if img.IgnitionFirstBoot != nil {
+		kernelOpts = append(kernelOpts, "coreos.inst.append ignition.config.url="+img.IgnitionFirstBoot.ProvisioningURL)
 	}
 
 	bootTreePipeline.KernelOpts = kernelOpts

--- a/internal/osbuild/ignition_stage.go
+++ b/internal/osbuild/ignition_stage.go
@@ -1,0 +1,29 @@
+package osbuild
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+type IgnitionStageInputInline struct {
+	InlineFile IgnitionStageInput `json:"inlinefile"`
+}
+
+func (IgnitionStageInputInline) isStageInputs() {}
+
+type IgnitionStageInput struct {
+	inputCommon
+	References IgnitionStageReferences `json:"references"`
+}
+
+type IgnitionStageReferences []string
+
+func (IgnitionStageReferences) isReferences() {}
+
+func NewIgnitionInlineInput(embeddedData string) Inputs {
+	inputs := new(IgnitionStageInputInline)
+	inputs.InlineFile.Type = "org.osbuild.files"
+	inputs.InlineFile.Origin = "org.osbuild.source"
+	inputs.InlineFile.References = IgnitionStageReferences{fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(embeddedData)))}
+	return inputs
+}


### PR DESCRIPTION
This allows a user to configure the system via `edge-simplified-installer`
using an ignition configuration specified in the blueprint.

This ignition config can be embedded in the ISO as a Base64
encoded file (`ignition.embedded.data`) or as a file
containing the URL where the ignition config file is served
(`ignition.embedded.url`).
This embedded config (either data or url) ends up in the root
of the ISO.

The user can also instead specify an URL serving an ignition
config file that will passed as a karg and be fetched at first
boot (`ignition.firstboot.url`).

<hr>
depends on osbuild/osbuild-composer#3130 (that PR sets the things needed to run ignition, this PR allows the user to configure the things to pass to ignition, so this PR doesn't break anything)
<hr>

This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
- [x] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/ --> see osbuild/guides#96
