### PR TITLE
worker: fix reporting the import error to composer

### DIFF
--- a/cmd/osbuild-worker/jobimpl-koji-finalize.go
+++ b/cmd/osbuild-worker/jobimpl-koji-finalize.go
@@ -208,10 +208,9 @@ func (impl *KojiFinalizeJobImpl) Run(job worker.Job) error {
 		})
 	}
 
-	var result worker.KojiFinalizeJobResult
 	err = impl.kojiImport(args.Server, build, buildRoots, images, args.KojiDirectory, initArgs.Token)
 	if err != nil {
-		result.JobError = clienterrors.WorkerClientError(clienterrors.ErrorKojiFinalize, err.Error(), nil)
+		kojiFinalizeJobResult.JobError = clienterrors.WorkerClientError(clienterrors.ErrorKojiFinalize, err.Error(), nil)
 		return err
 	}
 

--- a/tools/run-koji-container.sh
+++ b/tools/run-koji-container.sh
@@ -106,6 +106,17 @@ koji_start() {
   psql_cmd -c "insert into content_generator (name) values ('osbuild')" >/dev/null
   psql_cmd -c "insert into cg_users (cg_id, user_id, creator_id, active) values (1, 2, 1, true), (1, 3, 1, true)" >/dev/null
 
+  # When the test upload a vhd.xz image to koji, it returns `koji.GenericError:
+  # multiple matches for file extension: vhd.xz`. It seems like the default
+  # schema is not valid for vhd.xz images because it contains two archive types
+  # for them which koji cannot handle. I reported this issue as
+  #
+  # https://pagure.io/koji/issue/3605
+  #
+  # This line works around that by removing one of the archive types, so koji
+  # isn't confused by two same records.
+  psql_cmd -c "delete from archivetypes where name='vhdx-compressed'" >/dev/null
+
   echo "Containers are running, to stop them use:"
   echo "$0 stop"
 


### PR DESCRIPTION
The result variable wasn't used at all, kojiFinalizeJobResult is what actually reports the error.

Edit: Also, I had to fix the koji test. It was actually invisibly failing the whole time.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
