### PR TITLE
gcp: Cross-reference to coreos-assembler code

### DIFF
--- a/internal/cloud/gcp/compute.go
+++ b/internal/cloud/gcp/compute.go
@@ -18,7 +18,9 @@ var GuestOsFeaturesRHEL8 []*computepb.GuestOsFeature = []*computepb.GuestOsFeatu
 	{Type: common.StringToPtr(computepb.GuestOsFeature_SEV_CAPABLE.String())},
 }
 
-// Guest OS Features for RHEL9 images
+// Guest OS Features for RHEL9 images.  Note that if you update this, also
+// consider changing the code in https://github.com/coreos/coreos-assembler/blob/0083086c4720b602b8243effb85c0a1f73f013dd/mantle/platform/api/gcloud/image.go#L105
+// for RHEL CoreOS which uses coreos-assembler today.
 var GuestOsFeaturesRHEL9 []*computepb.GuestOsFeature = []*computepb.GuestOsFeature{
 	{Type: common.StringToPtr(computepb.GuestOsFeature_UEFI_COMPATIBLE.String())},
 	{Type: common.StringToPtr(computepb.GuestOsFeature_VIRTIO_SCSI_MULTIQUEUE.String())},


### PR DESCRIPTION
At the moment we have duplicate logic here; ideally of course we consolidate (since both codebases are Go, perhaps we could create a tiny little Go library for "RHEL GCP stuff"?) but for now let's just cross-link for awareness.



This pull request includes:

- [x] adequate testing for the new functionality or fixed issue
- [x] adequate documentation informing people about the change such as
  - [x] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/
