### PR TITLE
Enable isolinux only for x86_64

### DIFF
--- a/internal/image/image_installer.go
+++ b/internal/image/image_installer.go
@@ -146,7 +146,7 @@ func (img *ImageInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline)
 	isoPipeline.Filename = img.Filename
-	isoPipeline.ISOLinux = true
+	isoPipeline.ISOLinux = img.Platform.GetArch() == platform.ARCH_X86_64
 
 	artifact := isoPipeline.Export()
 

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -114,7 +114,7 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 
 	isoPipeline := manifest.NewISO(m, buildPipeline, isoTreePipeline)
 	isoPipeline.Filename = img.Filename
-	isoPipeline.ISOLinux = true
+	isoPipeline.ISOLinux = img.Platform.GetArch() == platform.ARCH_X86_64
 	artifact := isoPipeline.Export()
 
 	return artifact, nil

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -9365,12 +9365,7 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-9-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
@@ -9416,12 +9416,7 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-9-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -13056,12 +13056,7 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-9-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
@@ -13273,12 +13273,7 @@
               "filename": "installer.iso",
               "volid": "CentOS-Stream-9-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-image_installer-boot.json
@@ -12962,12 +12962,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-image_installer_with_users-boot.json
@@ -13115,12 +13115,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
@@ -10316,12 +10316,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
@@ -10367,12 +10367,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-35-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer-boot.json
@@ -13618,12 +13618,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-image_installer_with_users-boot.json
@@ -13779,12 +13779,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
@@ -10837,12 +10837,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
@@ -10888,12 +10888,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-36-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer-boot.json
@@ -13790,12 +13790,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-37-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-image_installer_with_users-boot.json
@@ -13967,12 +13967,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-37-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
@@ -10963,12 +10963,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-37-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
@@ -11014,12 +11014,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-37-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer-boot.json
@@ -13670,12 +13670,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-38-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-image_installer_with_users-boot.json
@@ -13839,12 +13839,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-38-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -10602,12 +10602,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-38-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -10653,12 +10653,7 @@
               "filename": "installer.iso",
               "volid": "Fedora-38-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -3885,12 +3885,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-0-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
@@ -3936,12 +3936,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-0-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -5340,12 +5340,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-0-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
@@ -5457,12 +5457,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-0-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -9862,12 +9862,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-1-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
@@ -9913,12 +9913,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-1-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
@@ -13536,12 +13536,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-1-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
@@ -13745,12 +13745,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-1-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
@@ -9878,12 +9878,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-2-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
@@ -9929,12 +9929,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-2-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
@@ -13560,12 +13560,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-2-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },

--- a/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
@@ -13769,12 +13769,7 @@
               "filename": "installer.iso",
               "volid": "RHEL-9-2-0-BaseOS-aarch64",
               "sysid": "LINUX",
-              "boot": {
-                "image": "isolinux/isolinux.bin",
-                "catalog": "isolinux/boot.cat"
-              },
               "efi": "images/efiboot.img",
-              "isohybridmbr": "/usr/share/syslinux/isohdpfx.bin",
               "isolevel": 3
             }
           },


### PR DESCRIPTION
ISOLinux was unconditionally enabled for all ISOs, which is incorrect and breaks builds on aarch64.
Enable it only for x86_64.

Fixes https://github.com/osbuild/osbuild-composer/issues/3168