### PR TITLE
cloudapi/v2: set ostree rhsm option on image options

### DIFF
--- a/internal/cloudapi/v2/handler.go
+++ b/internal/cloudapi/v2/handler.go
@@ -313,6 +313,10 @@ func (h *apiHandlers) PostCompose(ctx echo.Context) error {
 				}
 				if ir.Ostree.Rhsm != nil {
 					ostreeOptions.RHSM = *ir.Ostree.Rhsm
+
+					// RHSM needs to be set on imageoptions directly in addition
+					// to the resolve job input
+					imageOptions.OSTree.RHSM = *ir.Ostree.Rhsm
 				}
 			}
 			if ostreeOptions.Ref == "" {


### PR DESCRIPTION
The ostree options are used during the ostree resolve job, but when generating the manifest the rhsm value comes from the image options, so it's necessary to set it on both.
