### PR TITLE
distro/rhel9: fix /usr/sbin/zipl unavailable in the buildroot

### DIFF
--- a/internal/platform/s390x.go
+++ b/internal/platform/s390x.go
@@ -16,3 +16,9 @@ func (p *S390X) GetPackages() []string {
 		"s390utils-core",
 	}
 }
+
+func (p *S390X) GetBuildPackages() []string {
+	return []string{
+		"s390utils-base",
+	}
+}

--- a/test/data/manifests/centos_9-s390x-qcow2-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2-boot.json
@@ -54,6 +54,470 @@
                     }
                   },
                   {
+                    "id": "sha256:fe3d9211cf713a58a8b4e10904742ef57b2dcfac97c895e9b784ccd0a30da78d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34e7241407d72c2bad191133752d9e9d8a54299150ef6145e91a0da4fd310c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1ca6aaa47ef96d6b47f20f3a2df2ce530228790f2c0330ece567cc77ddd5063",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cfb719169e88332200502321bb2d6ba6a092e24efebd3ae9fcfa704eebac487",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6f4d668df3cff11aa488fab1eecdc13df798fa3eb577f378e971f014672b94b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de4b71c1cf818d48940ca0f68f5d3c520a321affe9e33b5afd7976c811f1d741",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:032a7f8100c97e7225e5faeba4110bd57fb440aabc8f0c15b7134d63e55e99d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e7e6b0fc298782ee5c538f90343851ac0b3cefc868ed72a063c16f249d37b72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30696fa3556f587c3b5372956fe8bf9e99cb2eea024e40215b38c5052a11da81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:098c570e4b7213ed4df7022a5d36bbe4c6947ac341f8018d739160da0eb24e0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fefc5a7bc8cd31a853c090cdaa0758344cacc56561532dfef20ab70bd30bcab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62e316599585124817c5217e402bbbde48df6b6309d0b59af3ec4d8bc0fcf216",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ec3d80d08e7468dfeeec00d598c3015a3c0af2abc56b05a57557bcc84b01146",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74b7f75cf3c8bf7191a8e6d88689d7aca1b1f60d56c890ead7d558a704a4a4cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1416670c051fdf7ea5e7ffac059d88e17b14a61cf75a95be6e3c6d2e730101b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:362bb253991b67fd82c6063483f2a2cb32b3c0198e9e42f7f8f8597433fe350b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29afb66559fb138d410a2dd1acddd6ee210864bf654b43c8b0bb81c060c2e7a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0053d63a5eb0bc399e2e56a2599a1a09dca20c5bcac36f713a56fec46abac391",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1c61c0ebb588d0314ecba36879b53f2d7f0fc84375724bb282a48697be81bf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368b2e96ca6be6b79d0e3b4f580c1a73edd6ea966af40b7ffdaacb2fdeda3e62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7e4138eafa78600420e0f1a5f5819affd45c59b1747bf6dc231e4f83882315",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95babe1d96f2dfd85f161d3f82bb3ba4ad4a2591d0d90919132f1358377f53bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888fb6d76d4d63b3d210a5da8b046c879fcfdaefb9fd00b2a34e65305596bb58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b33971afed2b744ce6f578d5c8c691099439d708869730f4cab7199ddc905c94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:904abfa862ecd90ef5bf869619efe77555f67077edf2e38d2879182342983cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27dfc72f604506654c671d164852668094da5e817e84b8192f21e29429a59838",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25c28c9e3d5f2ec0ad1c3c7d3c2484284ef6aa31675f0cd2d347c6abadb6f2a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e5f72e9a15488ce18a59626f69400e8faab466812489f2b66a7b2307b3ca18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29a03f6ad794f171ed8aa7a991aede7f006e9667a32ff1cf592aefd99e4b8c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaf7ecd82cec96b7474850ae6de4d883e69fe531a66bdf74d2b93bf8f1c2c573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c32ad4f02ecad264d2337837848706cc44f0502f39d978a6c055166fcf8ce917",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb38583786c1d851fe160de0e436ae2bb332f60e072a6e58db02b2affb9aab6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b70575a9f0ebc0f0026681112532243b0699ca7dc5dcb165cef856adc1ec0d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dded1efa254118c646affd59615237825f00e36b86a96a98fd59c8b6015612a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73db2d64e46f08667c4ad5225da81942072b0411c30b030bf1dcd16f8cd59936",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f15acb9fda15f0bb8cdd37d3763af70510554bf5f1cc99b679af94ee1065a74a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9ae0cdc8113ae9b80204cc26c12dd7a5f83c5d9e68b49a0517e418c007a3bea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfd3a0e15c81442c7b5d8a52bd183374e4d2dcb7dc5f586484877d8331ab5d4f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02186ed7d490b5d403c43282b8f448de509db85188c260378c5fb2cbe67a4353",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e87c795780fa190baba5291c390e9af304e4f134e4aa4f2d03fc9b91ca5d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c38c53e562f24cbdb395b11358efaaf6aee82ccd385055c5ffcf1843593d8da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1264dd35d5deda51b4431955b2838cd18e0012dc27f0e0cb65061324216ff22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11966231d2834b2a9c2c0bf2af231e1257ce030da1cfecdd16d08a6a23222b24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53f9616f9c60c8fb7befeff87f5b76c61ee75686a6c289f394c4793d3692de3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:745f84fc781c84763cad8001841711d6142eb13f50e55de928d3d051a0435ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eeb8d0fd12dc02fa13dac763d7d035e7cb40ab2c3410e70a3c23467fafbc8f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a25cfb9d83c69bd767be0e30de26dbc9ece902c9e848965c3378ef1405ceb6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e961a7b4eeff849489a8e9a26f32906b3aa5dc2273573fe41a01a2f9cc4fd20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ad31b9f568c1ae2508dbd7832047874a8e29d149f52d346509244febdda763f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b882c8742426d278d387432a65220bd63ffd1670737aea43084994d2b638e5d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b78c857f8c1ae8a5b13dd914b08b118f39f0a2f7c0dc8b7df2b29ed353638acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10f8b31849feda8da595ebe9c8e83c6d75745d157b899451507fc730ddc6a677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e2013098c4a46adaa2d3531c23c9328b5b7b960d8d9135c50d6d0fbde4800b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36081cad622d6c897c3b299c903ca652729861019b7241045b5ae2b7b03a8a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:342a7b84a44cd59bea045f679309ef6145a235897dedb8a9afd2d015bc17f72a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aac9b4c1ccd942afaec19299880eb89e1889b4531e7cab751c3be6a66f9c5fa6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7df2f1b732dd9c6ae1edba61e11d3c1da9003af529130ea98c62980147104e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f19f01a6382b276a1930b95080a69a6734b6cf54b4f4b67661852d4aeb25e40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:eaa6b1a04ed162da5e5b1fcfe4e2618d2227fa980075e74ae15f11a38d939570",
                     "options": {
                       "metadata": {
@@ -63,6 +527,14 @@
                   },
                   {
                     "id": "sha256:1e4572080614db5c6940db3bbdbe9241bd179658e9c2cc76b1f304fed3118825",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f34596b206951c3c00c10df343614374ca0cc0955938de6ec68d7884a4caac7",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -286,6 +758,14 @@
                     }
                   },
                   {
+                    "id": "sha256:efe1c638da6ed71b4985ade0dacc7f3ae9ec41a1ee0bbbad75c5ace10d055eee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f801fe42eb6057abacd6d1f67ce9c87cd5df5a6f7e71384579af967cf97f31f5",
                     "options": {
                       "metadata": {
@@ -294,7 +774,31 @@
                     }
                   },
                   {
+                    "id": "sha256:3d3638132b7b9dfc387c71ec199f8bd0ae7e00725a43966068ea4f0e3bfffc1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d73d7bc2e7974b56df5f727ea5915a6d909e24db5a37830f5a3f84c7f50ef68a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:d7964cb337adb860a737828759fbd1c64a2ab2d2eb62411aa66525ece2ed62af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c72647810ee5826d0523f597af1f17b64905918f40b6ec20cabc57eed8ca6dc6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -375,6 +879,14 @@
                   },
                   {
                     "id": "sha256:b6b83738fc6afb9ba28d0c2c57eaf17cdbe5b26ff89a8da17812dd261045df3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21d30be749bc446799494a0671d12e76a2d03d26d0306a219d0dc8c14951402b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -582,6 +1094,14 @@
                     }
                   },
                   {
+                    "id": "sha256:13cd29557725ee71c62724cc90d0347c00ca71117f01f3c2b843f251e7c32a71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:613ac2b76e4c72b94a08e543413bdcf8a519ce337d761b2ef326b0d4f6862b32",
                     "options": {
                       "metadata": {
@@ -686,6 +1206,14 @@
                     }
                   },
                   {
+                    "id": "sha256:790e79118d14dc374eb682e5a54dff4555b669f9c28852c6caafbc9175011ece",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f5e75617bef4f791984c171fe4c0017894585519e4615cd3665a096b07fad09",
                     "options": {
                       "metadata": {
@@ -767,6 +1295,14 @@
                   },
                   {
                     "id": "sha256:7297fc0b6869453925eed12b13c17ed76379352f63e0303644bef64386b034f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:276e1f87c77d8713387434dd1d5d9044743ba2a8574a917971e6923b7dcec4e7",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -966,6 +1502,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bd5c4016683263c546f901f70436720c78b40815fccff6df449f8d21f7cabe11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7185b39912949fe56bc0a9bd6463b1c2dc1206efa00dadecfd6e37c9028e1575",
                     "options": {
                       "metadata": {
@@ -991,6 +1535,22 @@
                   },
                   {
                     "id": "sha256:c0202712e8ec928cf61f3d777f23859ba6de2e85786e928ee5472fdde570aeee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d75a26e481988ac84f26998cb6c2df021ae4c6a1d7bf92e3bb2becbff20b44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11a90d19c3cf1fa06aa66835a845f448ef81f049407e0dd9797a2cdad38b9bed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1039,6 +1599,14 @@
                   },
                   {
                     "id": "sha256:3552f7cc9077d5831f859f6cf721d419eccc83cb381d14a7a1483512272bd586",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1d21070de4d32d4ee8c6594232190ef844340daa2d68146dced5a78a01ca73b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1124,7 +1692,8 @@
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
               "labels": {
-                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
               }
             }
           }
@@ -6330,6 +6899,586 @@
         "check_gpg": true
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:fe3d9211cf713a58a8b4e10904742ef57b2dcfac97c895e9b784ccd0a30da78d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:34e7241407d72c2bad191133752d9e9d8a54299150ef6145e91a0da4fd310c47",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:f1ca6aaa47ef96d6b47f20f3a2df2ce530228790f2c0330ece567cc77ddd5063",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:1cfb719169e88332200502321bb2d6ba6a092e24efebd3ae9fcfa704eebac487",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:a6f4d668df3cff11aa488fab1eecdc13df798fa3eb577f378e971f014672b94b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:de4b71c1cf818d48940ca0f68f5d3c520a321affe9e33b5afd7976c811f1d741",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:032a7f8100c97e7225e5faeba4110bd57fb440aabc8f0c15b7134d63e55e99d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:9e7e6b0fc298782ee5c538f90343851ac0b3cefc868ed72a063c16f249d37b72",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:30696fa3556f587c3b5372956fe8bf9e99cb2eea024e40215b38c5052a11da81",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:098c570e4b7213ed4df7022a5d36bbe4c6947ac341f8018d739160da0eb24e0d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:1fefc5a7bc8cd31a853c090cdaa0758344cacc56561532dfef20ab70bd30bcab",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:62e316599585124817c5217e402bbbde48df6b6309d0b59af3ec4d8bc0fcf216",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:2ec3d80d08e7468dfeeec00d598c3015a3c0af2abc56b05a57557bcc84b01146",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:74b7f75cf3c8bf7191a8e6d88689d7aca1b1f60d56c890ead7d558a704a4a4cc",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:a1416670c051fdf7ea5e7ffac059d88e17b14a61cf75a95be6e3c6d2e730101b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:362bb253991b67fd82c6063483f2a2cb32b3c0198e9e42f7f8f8597433fe350b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:29afb66559fb138d410a2dd1acddd6ee210864bf654b43c8b0bb81c060c2e7a9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:0053d63a5eb0bc399e2e56a2599a1a09dca20c5bcac36f713a56fec46abac391",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:c1c61c0ebb588d0314ecba36879b53f2d7f0fc84375724bb282a48697be81bf5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:368b2e96ca6be6b79d0e3b4f580c1a73edd6ea966af40b7ffdaacb2fdeda3e62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:bf7e4138eafa78600420e0f1a5f5819affd45c59b1747bf6dc231e4f83882315",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:95babe1d96f2dfd85f161d3f82bb3ba4ad4a2591d0d90919132f1358377f53bf",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:888fb6d76d4d63b3d210a5da8b046c879fcfdaefb9fd00b2a34e65305596bb58",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:b33971afed2b744ce6f578d5c8c691099439d708869730f4cab7199ddc905c94",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:904abfa862ecd90ef5bf869619efe77555f67077edf2e38d2879182342983cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:27dfc72f604506654c671d164852668094da5e817e84b8192f21e29429a59838",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:25c28c9e3d5f2ec0ad1c3c7d3c2484284ef6aa31675f0cd2d347c6abadb6f2a8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Net-SSLeay-1.92-1.el9.s390x.rpm",
+        "checksum": "sha256:e8e5f72e9a15488ce18a59626f69400e8faab466812489f2b66a7b2307b3ca18",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:29a03f6ad794f171ed8aa7a991aede7f006e9667a32ff1cf592aefd99e4b8c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:eaf7ecd82cec96b7474850ae6de4d883e69fe531a66bdf74d2b93bf8f1c2c573",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:c32ad4f02ecad264d2337837848706cc44f0502f39d978a6c055166fcf8ce917",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:fb38583786c1d851fe160de0e436ae2bb332f60e072a6e58db02b2affb9aab6c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:4b70575a9f0ebc0f0026681112532243b0699ca7dc5dcb165cef856adc1ec0d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:2dded1efa254118c646affd59615237825f00e36b86a96a98fd59c8b6015612a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:73db2d64e46f08667c4ad5225da81942072b0411c30b030bf1dcd16f8cd59936",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:f15acb9fda15f0bb8cdd37d3763af70510554bf5f1cc99b679af94ee1065a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:b9ae0cdc8113ae9b80204cc26c12dd7a5f83c5d9e68b49a0517e418c007a3bea",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:dfd3a0e15c81442c7b5d8a52bd183374e4d2dcb7dc5f586484877d8331ab5d4f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:02186ed7d490b5d403c43282b8f448de509db85188c260378c5fb2cbe67a4353",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:d4e87c795780fa190baba5291c390e9af304e4f134e4aa4f2d03fc9b91ca5d60",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:5c38c53e562f24cbdb395b11358efaaf6aee82ccd385055c5ffcf1843593d8da",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:1264dd35d5deda51b4431955b2838cd18e0012dc27f0e0cb65061324216ff22c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:11966231d2834b2a9c2c0bf2af231e1257ce030da1cfecdd16d08a6a23222b24",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:53f9616f9c60c8fb7befeff87f5b76c61ee75686a6c289f394c4793d3692de3b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:745f84fc781c84763cad8001841711d6142eb13f50e55de928d3d051a0435ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:eeb8d0fd12dc02fa13dac763d7d035e7cb40ab2c3410e70a3c23467fafbc8f62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:6a25cfb9d83c69bd767be0e30de26dbc9ece902c9e848965c3378ef1405ceb6e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:7e961a7b4eeff849489a8e9a26f32906b3aa5dc2273573fe41a01a2f9cc4fd20",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:1ad31b9f568c1ae2508dbd7832047874a8e29d149f52d346509244febdda763f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:b882c8742426d278d387432a65220bd63ffd1670737aea43084994d2b638e5d4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:b78c857f8c1ae8a5b13dd914b08b118f39f0a2f7c0dc8b7df2b29ed353638acb",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:10f8b31849feda8da595ebe9c8e83c6d75745d157b899451507fc730ddc6a677",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:2e2013098c4a46adaa2d3531c23c9328b5b7b960d8d9135c50d6d0fbde4800b3",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:36081cad622d6c897c3b299c903ca652729861019b7241045b5ae2b7b03a8a57",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:342a7b84a44cd59bea045f679309ef6145a235897dedb8a9afd2d015bc17f72a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:aac9b4c1ccd942afaec19299880eb89e1889b4531e7cab751c3be6a66f9c5fa6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:b7df2f1b732dd9c6ae1edba61e11d3c1da9003af529130ea98c62980147104e8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:2f19f01a6382b276a1930b95080a69a6734b6cf54b4f4b67661852d4aeb25e40",
+        "check_gpg": true
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.10",
@@ -6347,6 +7496,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/qemu-img-6.2.0-5.el9.s390x.rpm",
         "checksum": "sha256:1e4572080614db5c6940db3bbdbe9241bd179658e9c2cc76b1f304fed3118825",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/s390utils-base-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:5f34596b206951c3c00c10df343614374ca0cc0955938de6ec68d7884a4caac7",
         "check_gpg": true
       },
       {
@@ -6620,6 +7779,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.10",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/ethtool-5.10-4.el9.s390x.rpm",
+        "checksum": "sha256:efe1c638da6ed71b4985ade0dacc7f3ae9ec41a1ee0bbbad75c5ace10d055eee",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.2.10",
@@ -6630,6 +7799,26 @@
         "check_gpg": true
       },
       {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/file-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:3d3638132b7b9dfc387c71ec199f8bd0ae7e00725a43966068ea4f0e3bfffc1d",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/file-libs-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:d73d7bc2e7974b56df5f727ea5915a6d909e24db5a37830f5a3f84c7f50ef68a",
+        "check_gpg": true
+      },
+      {
         "name": "filesystem",
         "epoch": 0,
         "version": "3.16",
@@ -6637,6 +7826,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/filesystem-3.16-2.el9.s390x.rpm",
         "checksum": "sha256:d7964cb337adb860a737828759fbd1c64a2ab2d2eb62411aa66525ece2ed62af",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/fuse-libs-2.9.9-15.el9.s390x.rpm",
+        "checksum": "sha256:c72647810ee5826d0523f597af1f17b64905918f40b6ec20cabc57eed8ca6dc6",
         "check_gpg": true
       },
       {
@@ -6737,6 +7936,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:b6b83738fc6afb9ba28d0c2c57eaf17cdbe5b26ff89a8da17812dd261045df3e",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:21d30be749bc446799494a0671d12e76a2d03d26d0306a219d0dc8c14951402b",
         "check_gpg": true
       },
       {
@@ -6990,6 +8199,16 @@
         "check_gpg": true
       },
       {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:13cd29557725ee71c62724cc90d0347c00ca71117f01f3c2b843f251e7c32a71",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.2",
@@ -7120,6 +8339,16 @@
         "check_gpg": true
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "9.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libstdc++-11.2.1-9.1.el9.s390x.rpm",
+        "checksum": "sha256:790e79118d14dc374eb682e5a54dff4555b669f9c28852c6caafbc9175011ece",
+        "check_gpg": true
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -7227,6 +8456,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/mpfr-4.1.0-7.el9.s390x.rpm",
         "checksum": "sha256:7297fc0b6869453925eed12b13c17ed76379352f63e0303644bef64386b034f1",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:276e1f87c77d8713387434dd1d5d9044743ba2a8574a917971e6923b7dcec4e7",
         "check_gpg": true
       },
       {
@@ -7470,6 +8709,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/s390utils-core-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:bd5c4016683263c546f901f70436720c78b40815fccff6df449f8d21f7cabe11",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -7507,6 +8756,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/setup-2.13.7-6.el9.noarch.rpm",
         "checksum": "sha256:c0202712e8ec928cf61f3d777f23859ba6de2e85786e928ee5472fdde570aeee",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/sg3_utils-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:c4d75a26e481988ac84f26998cb6c2df021ae4c6a1d7bf92e3bb2becbff20b44",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/sg3_utils-libs-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:11a90d19c3cf1fa06aa66835a845f448ef81f049407e0dd9797a2cdad38b9bed",
         "check_gpg": true
       },
       {
@@ -7567,6 +8836,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/systemd-rpm-macros-249-9.el9.noarch.rpm",
         "checksum": "sha256:3552f7cc9077d5831f859f6cf721d419eccc83cb381d14a7a1483512272bd586",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/tar-1.34-3.el9.s390x.rpm",
+        "checksum": "sha256:b1d21070de4d32d4ee8c6594232190ef844340daa2d68146dced5a78a01ca73b",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/centos_9-s390x-qcow2_customize-boot.json
@@ -120,6 +120,470 @@
                     }
                   },
                   {
+                    "id": "sha256:fe3d9211cf713a58a8b4e10904742ef57b2dcfac97c895e9b784ccd0a30da78d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34e7241407d72c2bad191133752d9e9d8a54299150ef6145e91a0da4fd310c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1ca6aaa47ef96d6b47f20f3a2df2ce530228790f2c0330ece567cc77ddd5063",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cfb719169e88332200502321bb2d6ba6a092e24efebd3ae9fcfa704eebac487",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6f4d668df3cff11aa488fab1eecdc13df798fa3eb577f378e971f014672b94b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de4b71c1cf818d48940ca0f68f5d3c520a321affe9e33b5afd7976c811f1d741",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:032a7f8100c97e7225e5faeba4110bd57fb440aabc8f0c15b7134d63e55e99d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e7e6b0fc298782ee5c538f90343851ac0b3cefc868ed72a063c16f249d37b72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30696fa3556f587c3b5372956fe8bf9e99cb2eea024e40215b38c5052a11da81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:098c570e4b7213ed4df7022a5d36bbe4c6947ac341f8018d739160da0eb24e0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fefc5a7bc8cd31a853c090cdaa0758344cacc56561532dfef20ab70bd30bcab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62e316599585124817c5217e402bbbde48df6b6309d0b59af3ec4d8bc0fcf216",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ec3d80d08e7468dfeeec00d598c3015a3c0af2abc56b05a57557bcc84b01146",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74b7f75cf3c8bf7191a8e6d88689d7aca1b1f60d56c890ead7d558a704a4a4cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1416670c051fdf7ea5e7ffac059d88e17b14a61cf75a95be6e3c6d2e730101b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:362bb253991b67fd82c6063483f2a2cb32b3c0198e9e42f7f8f8597433fe350b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29afb66559fb138d410a2dd1acddd6ee210864bf654b43c8b0bb81c060c2e7a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0053d63a5eb0bc399e2e56a2599a1a09dca20c5bcac36f713a56fec46abac391",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1c61c0ebb588d0314ecba36879b53f2d7f0fc84375724bb282a48697be81bf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368b2e96ca6be6b79d0e3b4f580c1a73edd6ea966af40b7ffdaacb2fdeda3e62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7e4138eafa78600420e0f1a5f5819affd45c59b1747bf6dc231e4f83882315",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95babe1d96f2dfd85f161d3f82bb3ba4ad4a2591d0d90919132f1358377f53bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888fb6d76d4d63b3d210a5da8b046c879fcfdaefb9fd00b2a34e65305596bb58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b33971afed2b744ce6f578d5c8c691099439d708869730f4cab7199ddc905c94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:904abfa862ecd90ef5bf869619efe77555f67077edf2e38d2879182342983cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27dfc72f604506654c671d164852668094da5e817e84b8192f21e29429a59838",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25c28c9e3d5f2ec0ad1c3c7d3c2484284ef6aa31675f0cd2d347c6abadb6f2a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e5f72e9a15488ce18a59626f69400e8faab466812489f2b66a7b2307b3ca18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29a03f6ad794f171ed8aa7a991aede7f006e9667a32ff1cf592aefd99e4b8c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaf7ecd82cec96b7474850ae6de4d883e69fe531a66bdf74d2b93bf8f1c2c573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c32ad4f02ecad264d2337837848706cc44f0502f39d978a6c055166fcf8ce917",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb38583786c1d851fe160de0e436ae2bb332f60e072a6e58db02b2affb9aab6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b70575a9f0ebc0f0026681112532243b0699ca7dc5dcb165cef856adc1ec0d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dded1efa254118c646affd59615237825f00e36b86a96a98fd59c8b6015612a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73db2d64e46f08667c4ad5225da81942072b0411c30b030bf1dcd16f8cd59936",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f15acb9fda15f0bb8cdd37d3763af70510554bf5f1cc99b679af94ee1065a74a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9ae0cdc8113ae9b80204cc26c12dd7a5f83c5d9e68b49a0517e418c007a3bea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfd3a0e15c81442c7b5d8a52bd183374e4d2dcb7dc5f586484877d8331ab5d4f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02186ed7d490b5d403c43282b8f448de509db85188c260378c5fb2cbe67a4353",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e87c795780fa190baba5291c390e9af304e4f134e4aa4f2d03fc9b91ca5d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c38c53e562f24cbdb395b11358efaaf6aee82ccd385055c5ffcf1843593d8da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1264dd35d5deda51b4431955b2838cd18e0012dc27f0e0cb65061324216ff22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11966231d2834b2a9c2c0bf2af231e1257ce030da1cfecdd16d08a6a23222b24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53f9616f9c60c8fb7befeff87f5b76c61ee75686a6c289f394c4793d3692de3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:745f84fc781c84763cad8001841711d6142eb13f50e55de928d3d051a0435ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eeb8d0fd12dc02fa13dac763d7d035e7cb40ab2c3410e70a3c23467fafbc8f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a25cfb9d83c69bd767be0e30de26dbc9ece902c9e848965c3378ef1405ceb6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e961a7b4eeff849489a8e9a26f32906b3aa5dc2273573fe41a01a2f9cc4fd20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ad31b9f568c1ae2508dbd7832047874a8e29d149f52d346509244febdda763f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b882c8742426d278d387432a65220bd63ffd1670737aea43084994d2b638e5d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b78c857f8c1ae8a5b13dd914b08b118f39f0a2f7c0dc8b7df2b29ed353638acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10f8b31849feda8da595ebe9c8e83c6d75745d157b899451507fc730ddc6a677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e2013098c4a46adaa2d3531c23c9328b5b7b960d8d9135c50d6d0fbde4800b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36081cad622d6c897c3b299c903ca652729861019b7241045b5ae2b7b03a8a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:342a7b84a44cd59bea045f679309ef6145a235897dedb8a9afd2d015bc17f72a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aac9b4c1ccd942afaec19299880eb89e1889b4531e7cab751c3be6a66f9c5fa6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7df2f1b732dd9c6ae1edba61e11d3c1da9003af529130ea98c62980147104e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f19f01a6382b276a1930b95080a69a6734b6cf54b4f4b67661852d4aeb25e40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:eaa6b1a04ed162da5e5b1fcfe4e2618d2227fa980075e74ae15f11a38d939570",
                     "options": {
                       "metadata": {
@@ -129,6 +593,14 @@
                   },
                   {
                     "id": "sha256:1e4572080614db5c6940db3bbdbe9241bd179658e9c2cc76b1f304fed3118825",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f34596b206951c3c00c10df343614374ca0cc0955938de6ec68d7884a4caac7",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -376,6 +848,14 @@
                     }
                   },
                   {
+                    "id": "sha256:efe1c638da6ed71b4985ade0dacc7f3ae9ec41a1ee0bbbad75c5ace10d055eee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f801fe42eb6057abacd6d1f67ce9c87cd5df5a6f7e71384579af967cf97f31f5",
                     "options": {
                       "metadata": {
@@ -384,7 +864,31 @@
                     }
                   },
                   {
+                    "id": "sha256:3d3638132b7b9dfc387c71ec199f8bd0ae7e00725a43966068ea4f0e3bfffc1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d73d7bc2e7974b56df5f727ea5915a6d909e24db5a37830f5a3f84c7f50ef68a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:d7964cb337adb860a737828759fbd1c64a2ab2d2eb62411aa66525ece2ed62af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c72647810ee5826d0523f597af1f17b64905918f40b6ec20cabc57eed8ca6dc6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -465,6 +969,14 @@
                   },
                   {
                     "id": "sha256:b6b83738fc6afb9ba28d0c2c57eaf17cdbe5b26ff89a8da17812dd261045df3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21d30be749bc446799494a0671d12e76a2d03d26d0306a219d0dc8c14951402b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -673,6 +1185,14 @@
                   },
                   {
                     "id": "sha256:716716b688d4b702cee523a82d4ee035675f01ee404eb7dd7f2ef63d3389bb66",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:13cd29557725ee71c62724cc90d0347c00ca71117f01f3c2b843f251e7c32a71",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -896,6 +1416,14 @@
                     }
                   },
                   {
+                    "id": "sha256:276e1f87c77d8713387434dd1d5d9044743ba2a8574a917971e6923b7dcec4e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:e4cc4a4a479b8c27776debba5c20e8ef21dc4b513da62a25ed09f88386ac08a8",
                     "options": {
                       "metadata": {
@@ -1088,6 +1616,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bd5c4016683263c546f901f70436720c78b40815fccff6df449f8d21f7cabe11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7185b39912949fe56bc0a9bd6463b1c2dc1206efa00dadecfd6e37c9028e1575",
                     "options": {
                       "metadata": {
@@ -1113,6 +1649,22 @@
                   },
                   {
                     "id": "sha256:c0202712e8ec928cf61f3d777f23859ba6de2e85786e928ee5472fdde570aeee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d75a26e481988ac84f26998cb6c2df021ae4c6a1d7bf92e3bb2becbff20b44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11a90d19c3cf1fa06aa66835a845f448ef81f049407e0dd9797a2cdad38b9bed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1161,6 +1713,14 @@
                   },
                   {
                     "id": "sha256:3552f7cc9077d5831f859f6cf721d419eccc83cb381d14a7a1483512272bd586",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b1d21070de4d32d4ee8c6594232190ef844340daa2d68146dced5a78a01ca73b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1246,7 +1806,8 @@
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
               "labels": {
-                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
               }
             }
           }
@@ -6799,6 +7360,586 @@
         "check_gpg": true
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:fe3d9211cf713a58a8b4e10904742ef57b2dcfac97c895e9b784ccd0a30da78d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:34e7241407d72c2bad191133752d9e9d8a54299150ef6145e91a0da4fd310c47",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:f1ca6aaa47ef96d6b47f20f3a2df2ce530228790f2c0330ece567cc77ddd5063",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:1cfb719169e88332200502321bb2d6ba6a092e24efebd3ae9fcfa704eebac487",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:a6f4d668df3cff11aa488fab1eecdc13df798fa3eb577f378e971f014672b94b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:de4b71c1cf818d48940ca0f68f5d3c520a321affe9e33b5afd7976c811f1d741",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:032a7f8100c97e7225e5faeba4110bd57fb440aabc8f0c15b7134d63e55e99d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:9e7e6b0fc298782ee5c538f90343851ac0b3cefc868ed72a063c16f249d37b72",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:30696fa3556f587c3b5372956fe8bf9e99cb2eea024e40215b38c5052a11da81",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:098c570e4b7213ed4df7022a5d36bbe4c6947ac341f8018d739160da0eb24e0d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:1fefc5a7bc8cd31a853c090cdaa0758344cacc56561532dfef20ab70bd30bcab",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:62e316599585124817c5217e402bbbde48df6b6309d0b59af3ec4d8bc0fcf216",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:2ec3d80d08e7468dfeeec00d598c3015a3c0af2abc56b05a57557bcc84b01146",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:74b7f75cf3c8bf7191a8e6d88689d7aca1b1f60d56c890ead7d558a704a4a4cc",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:a1416670c051fdf7ea5e7ffac059d88e17b14a61cf75a95be6e3c6d2e730101b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:362bb253991b67fd82c6063483f2a2cb32b3c0198e9e42f7f8f8597433fe350b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:29afb66559fb138d410a2dd1acddd6ee210864bf654b43c8b0bb81c060c2e7a9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:0053d63a5eb0bc399e2e56a2599a1a09dca20c5bcac36f713a56fec46abac391",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:c1c61c0ebb588d0314ecba36879b53f2d7f0fc84375724bb282a48697be81bf5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:368b2e96ca6be6b79d0e3b4f580c1a73edd6ea966af40b7ffdaacb2fdeda3e62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:bf7e4138eafa78600420e0f1a5f5819affd45c59b1747bf6dc231e4f83882315",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:95babe1d96f2dfd85f161d3f82bb3ba4ad4a2591d0d90919132f1358377f53bf",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:888fb6d76d4d63b3d210a5da8b046c879fcfdaefb9fd00b2a34e65305596bb58",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:b33971afed2b744ce6f578d5c8c691099439d708869730f4cab7199ddc905c94",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:904abfa862ecd90ef5bf869619efe77555f67077edf2e38d2879182342983cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:27dfc72f604506654c671d164852668094da5e817e84b8192f21e29429a59838",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:25c28c9e3d5f2ec0ad1c3c7d3c2484284ef6aa31675f0cd2d347c6abadb6f2a8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Net-SSLeay-1.92-1.el9.s390x.rpm",
+        "checksum": "sha256:e8e5f72e9a15488ce18a59626f69400e8faab466812489f2b66a7b2307b3ca18",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:29a03f6ad794f171ed8aa7a991aede7f006e9667a32ff1cf592aefd99e4b8c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:eaf7ecd82cec96b7474850ae6de4d883e69fe531a66bdf74d2b93bf8f1c2c573",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:c32ad4f02ecad264d2337837848706cc44f0502f39d978a6c055166fcf8ce917",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:fb38583786c1d851fe160de0e436ae2bb332f60e072a6e58db02b2affb9aab6c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:4b70575a9f0ebc0f0026681112532243b0699ca7dc5dcb165cef856adc1ec0d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:2dded1efa254118c646affd59615237825f00e36b86a96a98fd59c8b6015612a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:73db2d64e46f08667c4ad5225da81942072b0411c30b030bf1dcd16f8cd59936",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:f15acb9fda15f0bb8cdd37d3763af70510554bf5f1cc99b679af94ee1065a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:b9ae0cdc8113ae9b80204cc26c12dd7a5f83c5d9e68b49a0517e418c007a3bea",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:dfd3a0e15c81442c7b5d8a52bd183374e4d2dcb7dc5f586484877d8331ab5d4f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:02186ed7d490b5d403c43282b8f448de509db85188c260378c5fb2cbe67a4353",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:d4e87c795780fa190baba5291c390e9af304e4f134e4aa4f2d03fc9b91ca5d60",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:5c38c53e562f24cbdb395b11358efaaf6aee82ccd385055c5ffcf1843593d8da",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:1264dd35d5deda51b4431955b2838cd18e0012dc27f0e0cb65061324216ff22c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:11966231d2834b2a9c2c0bf2af231e1257ce030da1cfecdd16d08a6a23222b24",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:53f9616f9c60c8fb7befeff87f5b76c61ee75686a6c289f394c4793d3692de3b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:745f84fc781c84763cad8001841711d6142eb13f50e55de928d3d051a0435ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:eeb8d0fd12dc02fa13dac763d7d035e7cb40ab2c3410e70a3c23467fafbc8f62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:6a25cfb9d83c69bd767be0e30de26dbc9ece902c9e848965c3378ef1405ceb6e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:7e961a7b4eeff849489a8e9a26f32906b3aa5dc2273573fe41a01a2f9cc4fd20",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:1ad31b9f568c1ae2508dbd7832047874a8e29d149f52d346509244febdda763f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:b882c8742426d278d387432a65220bd63ffd1670737aea43084994d2b638e5d4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:b78c857f8c1ae8a5b13dd914b08b118f39f0a2f7c0dc8b7df2b29ed353638acb",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:10f8b31849feda8da595ebe9c8e83c6d75745d157b899451507fc730ddc6a677",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:2e2013098c4a46adaa2d3531c23c9328b5b7b960d8d9135c50d6d0fbde4800b3",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:36081cad622d6c897c3b299c903ca652729861019b7241045b5ae2b7b03a8a57",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:342a7b84a44cd59bea045f679309ef6145a235897dedb8a9afd2d015bc17f72a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:aac9b4c1ccd942afaec19299880eb89e1889b4531e7cab751c3be6a66f9c5fa6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:b7df2f1b732dd9c6ae1edba61e11d3c1da9003af529130ea98c62980147104e8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:2f19f01a6382b276a1930b95080a69a6734b6cf54b4f4b67661852d4aeb25e40",
+        "check_gpg": true
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.10",
@@ -6816,6 +7957,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/qemu-img-6.2.0-5.el9.s390x.rpm",
         "checksum": "sha256:1e4572080614db5c6940db3bbdbe9241bd179658e9c2cc76b1f304fed3118825",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/s390utils-base-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:5f34596b206951c3c00c10df343614374ca0cc0955938de6ec68d7884a4caac7",
         "check_gpg": true
       },
       {
@@ -7119,6 +8270,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.10",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/ethtool-5.10-4.el9.s390x.rpm",
+        "checksum": "sha256:efe1c638da6ed71b4985ade0dacc7f3ae9ec41a1ee0bbbad75c5ace10d055eee",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.2.10",
@@ -7129,6 +8290,26 @@
         "check_gpg": true
       },
       {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/file-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:3d3638132b7b9dfc387c71ec199f8bd0ae7e00725a43966068ea4f0e3bfffc1d",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/file-libs-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:d73d7bc2e7974b56df5f727ea5915a6d909e24db5a37830f5a3f84c7f50ef68a",
+        "check_gpg": true
+      },
+      {
         "name": "filesystem",
         "epoch": 0,
         "version": "3.16",
@@ -7136,6 +8317,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/filesystem-3.16-2.el9.s390x.rpm",
         "checksum": "sha256:d7964cb337adb860a737828759fbd1c64a2ab2d2eb62411aa66525ece2ed62af",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/fuse-libs-2.9.9-15.el9.s390x.rpm",
+        "checksum": "sha256:c72647810ee5826d0523f597af1f17b64905918f40b6ec20cabc57eed8ca6dc6",
         "check_gpg": true
       },
       {
@@ -7236,6 +8427,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:b6b83738fc6afb9ba28d0c2c57eaf17cdbe5b26ff89a8da17812dd261045df3e",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:21d30be749bc446799494a0671d12e76a2d03d26d0306a219d0dc8c14951402b",
         "check_gpg": true
       },
       {
@@ -7496,6 +8697,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libidn2-2.3.0-7.el9.s390x.rpm",
         "checksum": "sha256:716716b688d4b702cee523a82d4ee035675f01ee404eb7dd7f2ef63d3389bb66",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:13cd29557725ee71c62724cc90d0347c00ca71117f01f3c2b843f251e7c32a71",
         "check_gpg": true
       },
       {
@@ -7769,6 +8980,16 @@
         "check_gpg": true
       },
       {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:276e1f87c77d8713387434dd1d5d9044743ba2a8574a917971e6923b7dcec4e7",
+        "check_gpg": true
+      },
+      {
         "name": "ncurses-base",
         "epoch": 0,
         "version": "6.2",
@@ -8009,6 +9230,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/s390utils-core-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:bd5c4016683263c546f901f70436720c78b40815fccff6df449f8d21f7cabe11",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -8046,6 +9277,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/setup-2.13.7-6.el9.noarch.rpm",
         "checksum": "sha256:c0202712e8ec928cf61f3d777f23859ba6de2e85786e928ee5472fdde570aeee",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/sg3_utils-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:c4d75a26e481988ac84f26998cb6c2df021ae4c6a1d7bf92e3bb2becbff20b44",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/sg3_utils-libs-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:11a90d19c3cf1fa06aa66835a845f448ef81f049407e0dd9797a2cdad38b9bed",
         "check_gpg": true
       },
       {
@@ -8106,6 +9357,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/systemd-rpm-macros-249-9.el9.noarch.rpm",
         "checksum": "sha256:3552f7cc9077d5831f859f6cf721d419eccc83cb381d14a7a1483512272bd586",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/tar-1.34-3.el9.s390x.rpm",
+        "checksum": "sha256:b1d21070de4d32d4ee8c6594232190ef844340daa2d68146dced5a78a01ca73b",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/centos_9-s390x-tar-boot.json
+++ b/test/data/manifests/centos_9-s390x-tar-boot.json
@@ -60,7 +60,479 @@
                     }
                   },
                   {
+                    "id": "sha256:fe3d9211cf713a58a8b4e10904742ef57b2dcfac97c895e9b784ccd0a30da78d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:34e7241407d72c2bad191133752d9e9d8a54299150ef6145e91a0da4fd310c47",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f1ca6aaa47ef96d6b47f20f3a2df2ce530228790f2c0330ece567cc77ddd5063",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1cfb719169e88332200502321bb2d6ba6a092e24efebd3ae9fcfa704eebac487",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6f4d668df3cff11aa488fab1eecdc13df798fa3eb577f378e971f014672b94b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de4b71c1cf818d48940ca0f68f5d3c520a321affe9e33b5afd7976c811f1d741",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:032a7f8100c97e7225e5faeba4110bd57fb440aabc8f0c15b7134d63e55e99d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9e7e6b0fc298782ee5c538f90343851ac0b3cefc868ed72a063c16f249d37b72",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:30696fa3556f587c3b5372956fe8bf9e99cb2eea024e40215b38c5052a11da81",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:098c570e4b7213ed4df7022a5d36bbe4c6947ac341f8018d739160da0eb24e0d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1fefc5a7bc8cd31a853c090cdaa0758344cacc56561532dfef20ab70bd30bcab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:62e316599585124817c5217e402bbbde48df6b6309d0b59af3ec4d8bc0fcf216",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2ec3d80d08e7468dfeeec00d598c3015a3c0af2abc56b05a57557bcc84b01146",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:74b7f75cf3c8bf7191a8e6d88689d7aca1b1f60d56c890ead7d558a704a4a4cc",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a1416670c051fdf7ea5e7ffac059d88e17b14a61cf75a95be6e3c6d2e730101b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:362bb253991b67fd82c6063483f2a2cb32b3c0198e9e42f7f8f8597433fe350b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29afb66559fb138d410a2dd1acddd6ee210864bf654b43c8b0bb81c060c2e7a9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0053d63a5eb0bc399e2e56a2599a1a09dca20c5bcac36f713a56fec46abac391",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c1c61c0ebb588d0314ecba36879b53f2d7f0fc84375724bb282a48697be81bf5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:368b2e96ca6be6b79d0e3b4f580c1a73edd6ea966af40b7ffdaacb2fdeda3e62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bf7e4138eafa78600420e0f1a5f5819affd45c59b1747bf6dc231e4f83882315",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:95babe1d96f2dfd85f161d3f82bb3ba4ad4a2591d0d90919132f1358377f53bf",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888fb6d76d4d63b3d210a5da8b046c879fcfdaefb9fd00b2a34e65305596bb58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b33971afed2b744ce6f578d5c8c691099439d708869730f4cab7199ddc905c94",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:904abfa862ecd90ef5bf869619efe77555f67077edf2e38d2879182342983cc9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:27dfc72f604506654c671d164852668094da5e817e84b8192f21e29429a59838",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:25c28c9e3d5f2ec0ad1c3c7d3c2484284ef6aa31675f0cd2d347c6abadb6f2a8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e5f72e9a15488ce18a59626f69400e8faab466812489f2b66a7b2307b3ca18",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29a03f6ad794f171ed8aa7a991aede7f006e9667a32ff1cf592aefd99e4b8c1a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eaf7ecd82cec96b7474850ae6de4d883e69fe531a66bdf74d2b93bf8f1c2c573",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c32ad4f02ecad264d2337837848706cc44f0502f39d978a6c055166fcf8ce917",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb38583786c1d851fe160de0e436ae2bb332f60e072a6e58db02b2affb9aab6c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4b70575a9f0ebc0f0026681112532243b0699ca7dc5dcb165cef856adc1ec0d8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2dded1efa254118c646affd59615237825f00e36b86a96a98fd59c8b6015612a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:73db2d64e46f08667c4ad5225da81942072b0411c30b030bf1dcd16f8cd59936",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f15acb9fda15f0bb8cdd37d3763af70510554bf5f1cc99b679af94ee1065a74a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b9ae0cdc8113ae9b80204cc26c12dd7a5f83c5d9e68b49a0517e418c007a3bea",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dfd3a0e15c81442c7b5d8a52bd183374e4d2dcb7dc5f586484877d8331ab5d4f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:02186ed7d490b5d403c43282b8f448de509db85188c260378c5fb2cbe67a4353",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d4e87c795780fa190baba5291c390e9af304e4f134e4aa4f2d03fc9b91ca5d60",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5c38c53e562f24cbdb395b11358efaaf6aee82ccd385055c5ffcf1843593d8da",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1264dd35d5deda51b4431955b2838cd18e0012dc27f0e0cb65061324216ff22c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11966231d2834b2a9c2c0bf2af231e1257ce030da1cfecdd16d08a6a23222b24",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:53f9616f9c60c8fb7befeff87f5b76c61ee75686a6c289f394c4793d3692de3b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:745f84fc781c84763cad8001841711d6142eb13f50e55de928d3d051a0435ef2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:eeb8d0fd12dc02fa13dac763d7d035e7cb40ab2c3410e70a3c23467fafbc8f62",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6a25cfb9d83c69bd767be0e30de26dbc9ece902c9e848965c3378ef1405ceb6e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7e961a7b4eeff849489a8e9a26f32906b3aa5dc2273573fe41a01a2f9cc4fd20",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1ad31b9f568c1ae2508dbd7832047874a8e29d149f52d346509244febdda763f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b882c8742426d278d387432a65220bd63ffd1670737aea43084994d2b638e5d4",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b78c857f8c1ae8a5b13dd914b08b118f39f0a2f7c0dc8b7df2b29ed353638acb",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:10f8b31849feda8da595ebe9c8e83c6d75745d157b899451507fc730ddc6a677",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2e2013098c4a46adaa2d3531c23c9328b5b7b960d8d9135c50d6d0fbde4800b3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:36081cad622d6c897c3b299c903ca652729861019b7241045b5ae2b7b03a8a57",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:342a7b84a44cd59bea045f679309ef6145a235897dedb8a9afd2d015bc17f72a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aac9b4c1ccd942afaec19299880eb89e1889b4531e7cab751c3be6a66f9c5fa6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b7df2f1b732dd9c6ae1edba61e11d3c1da9003af529130ea98c62980147104e8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2f19f01a6382b276a1930b95080a69a6734b6cf54b4f4b67661852d4aeb25e40",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:eaa6b1a04ed162da5e5b1fcfe4e2618d2227fa980075e74ae15f11a38d939570",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5f34596b206951c3c00c10df343614374ca0cc0955938de6ec68d7884a4caac7",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -284,6 +756,14 @@
                     }
                   },
                   {
+                    "id": "sha256:efe1c638da6ed71b4985ade0dacc7f3ae9ec41a1ee0bbbad75c5ace10d055eee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:f801fe42eb6057abacd6d1f67ce9c87cd5df5a6f7e71384579af967cf97f31f5",
                     "options": {
                       "metadata": {
@@ -292,7 +772,31 @@
                     }
                   },
                   {
+                    "id": "sha256:3d3638132b7b9dfc387c71ec199f8bd0ae7e00725a43966068ea4f0e3bfffc1d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d73d7bc2e7974b56df5f727ea5915a6d909e24db5a37830f5a3f84c7f50ef68a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:d7964cb337adb860a737828759fbd1c64a2ab2d2eb62411aa66525ece2ed62af",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c72647810ee5826d0523f597af1f17b64905918f40b6ec20cabc57eed8ca6dc6",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -309,6 +813,14 @@
                   },
                   {
                     "id": "sha256:e89a68ed69f39ef2cffbc37137d854966fa7fb5b9545774de7fb193aa67fb279",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d480d4efde0c605f4863133eb0f9bcbf3afd6f7912889d641d635018bbaf8a0",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -356,7 +868,23 @@
                     }
                   },
                   {
+                    "id": "sha256:2770fb71478e9effe5eb248a7ce01a93973c87fed8bd0381abbbe3fc2d243009",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:b6b83738fc6afb9ba28d0c2c57eaf17cdbe5b26ff89a8da17812dd261045df3e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:21d30be749bc446799494a0671d12e76a2d03d26d0306a219d0dc8c14951402b",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -540,6 +1068,14 @@
                     }
                   },
                   {
+                    "id": "sha256:13cd29557725ee71c62724cc90d0347c00ca71117f01f3c2b843f251e7c32a71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:613ac2b76e4c72b94a08e543413bdcf8a519ce337d761b2ef326b0d4f6862b32",
                     "options": {
                       "metadata": {
@@ -644,6 +1180,14 @@
                     }
                   },
                   {
+                    "id": "sha256:790e79118d14dc374eb682e5a54dff4555b669f9c28852c6caafbc9175011ece",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f5e75617bef4f791984c171fe4c0017894585519e4615cd3665a096b07fad09",
                     "options": {
                       "metadata": {
@@ -732,6 +1276,14 @@
                     }
                   },
                   {
+                    "id": "sha256:276e1f87c77d8713387434dd1d5d9044743ba2a8574a917971e6923b7dcec4e7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:e4cc4a4a479b8c27776debba5c20e8ef21dc4b513da62a25ed09f88386ac08a8",
                     "options": {
                       "metadata": {
@@ -741,6 +1293,14 @@
                   },
                   {
                     "id": "sha256:7024aa44c86c2c169ffb9d36a9684ddb86ce70f487034226a15751fd183afcd8",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:04c044bbfa6d4f9e6492d81cda97310200668cd0e3f3acea0b3fb299d10e4be2",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -916,6 +1476,14 @@
                     }
                   },
                   {
+                    "id": "sha256:bd5c4016683263c546f901f70436720c78b40815fccff6df449f8d21f7cabe11",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7185b39912949fe56bc0a9bd6463b1c2dc1206efa00dadecfd6e37c9028e1575",
                     "options": {
                       "metadata": {
@@ -941,6 +1509,22 @@
                   },
                   {
                     "id": "sha256:c0202712e8ec928cf61f3d777f23859ba6de2e85786e928ee5472fdde570aeee",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4d75a26e481988ac84f26998cb6c2df021ae4c6a1d7bf92e3bb2becbff20b44",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:11a90d19c3cf1fa06aa66835a845f448ef81f049407e0dd9797a2cdad38b9bed",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3497,6 +4081,586 @@
         "check_gpg": true
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:fe3d9211cf713a58a8b4e10904742ef57b2dcfac97c895e9b784ccd0a30da78d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:34e7241407d72c2bad191133752d9e9d8a54299150ef6145e91a0da4fd310c47",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:f1ca6aaa47ef96d6b47f20f3a2df2ce530228790f2c0330ece567cc77ddd5063",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:1cfb719169e88332200502321bb2d6ba6a092e24efebd3ae9fcfa704eebac487",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:a6f4d668df3cff11aa488fab1eecdc13df798fa3eb577f378e971f014672b94b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:de4b71c1cf818d48940ca0f68f5d3c520a321affe9e33b5afd7976c811f1d741",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:032a7f8100c97e7225e5faeba4110bd57fb440aabc8f0c15b7134d63e55e99d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:9e7e6b0fc298782ee5c538f90343851ac0b3cefc868ed72a063c16f249d37b72",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:30696fa3556f587c3b5372956fe8bf9e99cb2eea024e40215b38c5052a11da81",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:098c570e4b7213ed4df7022a5d36bbe4c6947ac341f8018d739160da0eb24e0d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:1fefc5a7bc8cd31a853c090cdaa0758344cacc56561532dfef20ab70bd30bcab",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:62e316599585124817c5217e402bbbde48df6b6309d0b59af3ec4d8bc0fcf216",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:2ec3d80d08e7468dfeeec00d598c3015a3c0af2abc56b05a57557bcc84b01146",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:74b7f75cf3c8bf7191a8e6d88689d7aca1b1f60d56c890ead7d558a704a4a4cc",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:a1416670c051fdf7ea5e7ffac059d88e17b14a61cf75a95be6e3c6d2e730101b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:362bb253991b67fd82c6063483f2a2cb32b3c0198e9e42f7f8f8597433fe350b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:29afb66559fb138d410a2dd1acddd6ee210864bf654b43c8b0bb81c060c2e7a9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:0053d63a5eb0bc399e2e56a2599a1a09dca20c5bcac36f713a56fec46abac391",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:c1c61c0ebb588d0314ecba36879b53f2d7f0fc84375724bb282a48697be81bf5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:368b2e96ca6be6b79d0e3b4f580c1a73edd6ea966af40b7ffdaacb2fdeda3e62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:bf7e4138eafa78600420e0f1a5f5819affd45c59b1747bf6dc231e4f83882315",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:95babe1d96f2dfd85f161d3f82bb3ba4ad4a2591d0d90919132f1358377f53bf",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:888fb6d76d4d63b3d210a5da8b046c879fcfdaefb9fd00b2a34e65305596bb58",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:b33971afed2b744ce6f578d5c8c691099439d708869730f4cab7199ddc905c94",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:904abfa862ecd90ef5bf869619efe77555f67077edf2e38d2879182342983cc9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:27dfc72f604506654c671d164852668094da5e817e84b8192f21e29429a59838",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:25c28c9e3d5f2ec0ad1c3c7d3c2484284ef6aa31675f0cd2d347c6abadb6f2a8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Net-SSLeay-1.92-1.el9.s390x.rpm",
+        "checksum": "sha256:e8e5f72e9a15488ce18a59626f69400e8faab466812489f2b66a7b2307b3ca18",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:29a03f6ad794f171ed8aa7a991aede7f006e9667a32ff1cf592aefd99e4b8c1a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:eaf7ecd82cec96b7474850ae6de4d883e69fe531a66bdf74d2b93bf8f1c2c573",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:c32ad4f02ecad264d2337837848706cc44f0502f39d978a6c055166fcf8ce917",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:fb38583786c1d851fe160de0e436ae2bb332f60e072a6e58db02b2affb9aab6c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:4b70575a9f0ebc0f0026681112532243b0699ca7dc5dcb165cef856adc1ec0d8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:2dded1efa254118c646affd59615237825f00e36b86a96a98fd59c8b6015612a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:73db2d64e46f08667c4ad5225da81942072b0411c30b030bf1dcd16f8cd59936",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:f15acb9fda15f0bb8cdd37d3763af70510554bf5f1cc99b679af94ee1065a74a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:b9ae0cdc8113ae9b80204cc26c12dd7a5f83c5d9e68b49a0517e418c007a3bea",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:dfd3a0e15c81442c7b5d8a52bd183374e4d2dcb7dc5f586484877d8331ab5d4f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:02186ed7d490b5d403c43282b8f448de509db85188c260378c5fb2cbe67a4353",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:d4e87c795780fa190baba5291c390e9af304e4f134e4aa4f2d03fc9b91ca5d60",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:5c38c53e562f24cbdb395b11358efaaf6aee82ccd385055c5ffcf1843593d8da",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:1264dd35d5deda51b4431955b2838cd18e0012dc27f0e0cb65061324216ff22c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:11966231d2834b2a9c2c0bf2af231e1257ce030da1cfecdd16d08a6a23222b24",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:53f9616f9c60c8fb7befeff87f5b76c61ee75686a6c289f394c4793d3692de3b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:745f84fc781c84763cad8001841711d6142eb13f50e55de928d3d051a0435ef2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:eeb8d0fd12dc02fa13dac763d7d035e7cb40ab2c3410e70a3c23467fafbc8f62",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:6a25cfb9d83c69bd767be0e30de26dbc9ece902c9e848965c3378ef1405ceb6e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:7e961a7b4eeff849489a8e9a26f32906b3aa5dc2273573fe41a01a2f9cc4fd20",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:1ad31b9f568c1ae2508dbd7832047874a8e29d149f52d346509244febdda763f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:b882c8742426d278d387432a65220bd63ffd1670737aea43084994d2b638e5d4",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:b78c857f8c1ae8a5b13dd914b08b118f39f0a2f7c0dc8b7df2b29ed353638acb",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:10f8b31849feda8da595ebe9c8e83c6d75745d157b899451507fc730ddc6a677",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:2e2013098c4a46adaa2d3531c23c9328b5b7b960d8d9135c50d6d0fbde4800b3",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:36081cad622d6c897c3b299c903ca652729861019b7241045b5ae2b7b03a8a57",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:342a7b84a44cd59bea045f679309ef6145a235897dedb8a9afd2d015bc17f72a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:aac9b4c1ccd942afaec19299880eb89e1889b4531e7cab751c3be6a66f9c5fa6",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:b7df2f1b732dd9c6ae1edba61e11d3c1da9003af529130ea98c62980147104e8",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:2f19f01a6382b276a1930b95080a69a6734b6cf54b4f4b67661852d4aeb25e40",
+        "check_gpg": true
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.10",
@@ -3504,6 +4668,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/python-unversioned-command-3.9.10-1.el9.noarch.rpm",
         "checksum": "sha256:eaa6b1a04ed162da5e5b1fcfe4e2618d2227fa980075e74ae15f11a38d939570",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-appstream-20220208/Packages/s390utils-base-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:5f34596b206951c3c00c10df343614374ca0cc0955938de6ec68d7884a4caac7",
         "check_gpg": true
       },
       {
@@ -3777,6 +4951,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.10",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/ethtool-5.10-4.el9.s390x.rpm",
+        "checksum": "sha256:efe1c638da6ed71b4985ade0dacc7f3ae9ec41a1ee0bbbad75c5ace10d055eee",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.2.10",
@@ -3787,6 +4971,26 @@
         "check_gpg": true
       },
       {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/file-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:3d3638132b7b9dfc387c71ec199f8bd0ae7e00725a43966068ea4f0e3bfffc1d",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/file-libs-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:d73d7bc2e7974b56df5f727ea5915a6d909e24db5a37830f5a3f84c7f50ef68a",
+        "check_gpg": true
+      },
+      {
         "name": "filesystem",
         "epoch": 0,
         "version": "3.16",
@@ -3794,6 +4998,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/filesystem-3.16-2.el9.s390x.rpm",
         "checksum": "sha256:d7964cb337adb860a737828759fbd1c64a2ab2d2eb62411aa66525ece2ed62af",
+        "check_gpg": true
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/fuse-libs-2.9.9-15.el9.s390x.rpm",
+        "checksum": "sha256:c72647810ee5826d0523f597af1f17b64905918f40b6ec20cabc57eed8ca6dc6",
         "check_gpg": true
       },
       {
@@ -3814,6 +5028,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/gdbm-libs-1.19-4.el9.s390x.rpm",
         "checksum": "sha256:e89a68ed69f39ef2cffbc37137d854966fa7fb5b9545774de7fb193aa67fb279",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/glib2-2.68.4-5.el9.s390x.rpm",
+        "checksum": "sha256:0d480d4efde0c605f4863133eb0f9bcbf3afd6f7912889d641d635018bbaf8a0",
         "check_gpg": true
       },
       {
@@ -3867,6 +5091,16 @@
         "check_gpg": true
       },
       {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/gnutls-3.7.3-1.el9.s390x.rpm",
+        "checksum": "sha256:2770fb71478e9effe5eb248a7ce01a93973c87fed8bd0381abbbe3fc2d243009",
+        "check_gpg": true
+      },
+      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -3874,6 +5108,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:b6b83738fc6afb9ba28d0c2c57eaf17cdbe5b26ff89a8da17812dd261045df3e",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:21d30be749bc446799494a0671d12e76a2d03d26d0306a219d0dc8c14951402b",
         "check_gpg": true
       },
       {
@@ -4097,6 +5341,16 @@
         "check_gpg": true
       },
       {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:13cd29557725ee71c62724cc90d0347c00ca71117f01f3c2b843f251e7c32a71",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.2",
@@ -4227,6 +5481,16 @@
         "check_gpg": true
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "9.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/libstdc++-11.2.1-9.1.el9.s390x.rpm",
+        "checksum": "sha256:790e79118d14dc374eb682e5a54dff4555b669f9c28852c6caafbc9175011ece",
+        "check_gpg": true
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -4337,6 +5601,16 @@
         "check_gpg": true
       },
       {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:276e1f87c77d8713387434dd1d5d9044743ba2a8574a917971e6923b7dcec4e7",
+        "check_gpg": true
+      },
+      {
         "name": "ncurses-base",
         "epoch": 0,
         "version": "6.2",
@@ -4354,6 +5628,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/ncurses-libs-6.2-8.20210508.el9.s390x.rpm",
         "checksum": "sha256:7024aa44c86c2c169ffb9d36a9684ddb86ce70f487034226a15751fd183afcd8",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/nettle-3.7.3-2.el9.s390x.rpm",
+        "checksum": "sha256:04c044bbfa6d4f9e6492d81cda97310200668cd0e3f3acea0b3fb299d10e4be2",
         "check_gpg": true
       },
       {
@@ -4567,6 +5851,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/s390utils-core-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:bd5c4016683263c546f901f70436720c78b40815fccff6df449f8d21f7cabe11",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -4604,6 +5898,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/setup-2.13.7-6.el9.noarch.rpm",
         "checksum": "sha256:c0202712e8ec928cf61f3d777f23859ba6de2e85786e928ee5472fdde570aeee",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/sg3_utils-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:c4d75a26e481988ac84f26998cb6c2df021ae4c6a1d7bf92e3bb2becbff20b44",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/public/el9/cs9-s390x-baseos-20220208/Packages/sg3_utils-libs-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:11a90d19c3cf1fa06aa66835a845f448ef81f049407e0dd9797a2cdad38b9bed",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_90-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2-boot.json
@@ -116,10 +116,22 @@
                     "id": "sha256:8bb508293d782c1d1d1a45961346667bb281d7d89a652983022c5459dbc9f06a"
                   },
                   {
+                    "id": "sha256:d63c9ac56091ee3f80624f134f39bd2d7017f990c500a2be070cda0b73aff9fe"
+                  },
+                  {
                     "id": "sha256:d2fa7ebad37509158419ac20edc99de22aea93b79377ac998e200669c7248230"
                   },
                   {
+                    "id": "sha256:dcdc82e4239e7d5a317b9368f02fd80cb35c61b0b7ae1a739bae84a6adf8fe0d"
+                  },
+                  {
+                    "id": "sha256:437d4266302085ec39fc52fa2bb6725afdf136fbca84e16295f3a326e8582600"
+                  },
+                  {
                     "id": "sha256:a3fcdaf06ba5d733aea9d852cd8f64e4baf30a4a3f0a415249fc75d3abf0a273"
+                  },
+                  {
+                    "id": "sha256:22aaf8d6a27e0481e293ab5e2f9c75cd3bcd5f0a78d6d9f74a26a173f3d2a8af"
                   },
                   {
                     "id": "sha256:1fa35800fa55d66fe154d9b35ac1d5332002f585ba8c6fdff20fdd435479aae3"
@@ -150,6 +162,9 @@
                   },
                   {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5"
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb"
                   },
                   {
                     "id": "sha256:9cadc9a644de6388a3ad0061a88a2962d02025e2411ddb8560a96eeefe6ea070"
@@ -227,6 +242,9 @@
                     "id": "sha256:7d534eadb4f019135e9e52ca8c96d2c7584b89cb691814421a0cfbc87356e2c4"
                   },
                   {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525"
+                  },
+                  {
                     "id": "sha256:e6a82ebed192578855f72a3c31d56a586129a5c8e847fde32b2c98f724ace862"
                   },
                   {
@@ -266,6 +284,9 @@
                     "id": "sha256:e7d4934722afbb69dc3f3e9a906ceb034fa2c518e5dec96a35d1442c013db359"
                   },
                   {
+                    "id": "sha256:7fe19cb350eaa0212e7825e625a1f930595f7bbcf5cbae1bc4a844055864a903"
+                  },
+                  {
                     "id": "sha256:24e4adda524a102c631b8b52ff895467edbb69a1fdc8f1f9c2ac9c2973ff2c65"
                   },
                   {
@@ -297,6 +318,9 @@
                   },
                   {
                     "id": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58"
+                  },
+                  {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9"
                   },
                   {
                     "id": "sha256:45cb0635b63c6adb54e252c0fb42eb6312d96c057e7eb770651539a787917b02"
@@ -383,6 +407,9 @@
                     "id": "sha256:166a43f9b239a07f726491ce485b190d878ffe7f5c19f701229ebe922a5f8b80"
                   },
                   {
+                    "id": "sha256:9480e7e761a3ce2c34d817c0a5e5818ab7ffbe3ba56b0ffabbea367dfd38e339"
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a"
                   },
                   {
@@ -393,6 +420,12 @@
                   },
                   {
                     "id": "sha256:eee3d14606c828e51397d52535c56cec7fe9423bbbbe7e7e1c738ffda73edefd"
+                  },
+                  {
+                    "id": "sha256:1207676f3a09a4ffb38d4169d22a468c4f1fb1f2a16332eee7a6b566d6d515c2"
+                  },
+                  {
+                    "id": "sha256:497603378bfaf195e6a6c1cda98771f21b0991318377189712451d8c33f4ba73"
                   },
                   {
                     "id": "sha256:193da1d11414ff9477461fecf911071132245cbd3e3e96a0ae7a5f0a785b713f"
@@ -411,6 +444,9 @@
                   },
                   {
                     "id": "sha256:90d042d6b6740a3fccf19a8cb0d77943b7a7de1bb3f20beefd3c1638ebda6446"
+                  },
+                  {
+                    "id": "sha256:e00ae4884ea2975787663cffbc68bcb3157d14a8bd40d33a23b5d39271e6dd12"
                   },
                   {
                     "id": "sha256:df9b0d96477ad46504c896d7994731ab6b1dc1cd9cc091493ea83e29b4d1bda5"
@@ -440,10 +476,187 @@
                     "id": "sha256:4bbd75dc44ebf17ded34b706bf82f02b0a9be512122f52d73bd36ca2cbadb1af"
                   },
                   {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c"
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae"
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2"
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5"
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29"
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9"
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033"
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b"
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53"
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92"
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409"
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0"
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1"
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41"
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03"
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d"
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42"
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14"
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd"
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0"
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175"
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f"
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f"
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7"
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71"
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7"
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462"
+                  },
+                  {
+                    "id": "sha256:f732b8719dd3061e5a018e44098b245087106564341edaa985f7793c3c87eb88"
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721"
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0"
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0"
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0"
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a"
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9"
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e"
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630"
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2"
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e"
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583"
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23"
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17"
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9"
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd"
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1"
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd"
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c"
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892"
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248"
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42"
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98"
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854"
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c"
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03"
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759"
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463"
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98"
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa"
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db"
+                  },
+                  {
                     "id": "sha256:266b865a39f7a256d48151f38e5871d55d9d2f49bfa4d666e4e16430a499c201"
                   },
                   {
                     "id": "sha256:4db25591b99cf497d739c4536cb3ef03861c4a6e381d77b95cace35eec64caae"
+                  },
+                  {
+                    "id": "sha256:c1a85863ae8ca49cdd46a6e9419361434299b6b4a044f0739922bbba8c3993c8"
                   }
                 ]
               }
@@ -460,7 +673,8 @@
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
               "labels": {
-                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
               }
             }
           }
@@ -3791,6 +4005,15 @@
         "checksum": "sha256:8bb508293d782c1d1d1a45961346667bb281d7d89a652983022c5459dbc9f06a"
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.10",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/ethtool-5.10-4.el9.s390x.rpm",
+        "checksum": "sha256:d63c9ac56091ee3f80624f134f39bd2d7017f990c500a2be070cda0b73aff9fe"
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.2.10",
@@ -3800,6 +4023,24 @@
         "checksum": "sha256:d2fa7ebad37509158419ac20edc99de22aea93b79377ac998e200669c7248230"
       },
       {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/file-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:dcdc82e4239e7d5a317b9368f02fd80cb35c61b0b7ae1a739bae84a6adf8fe0d"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:437d4266302085ec39fc52fa2bb6725afdf136fbca84e16295f3a326e8582600"
+      },
+      {
         "name": "filesystem",
         "epoch": 0,
         "version": "3.16",
@@ -3807,6 +4048,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/filesystem-3.16-2.el9.s390x.rpm",
         "checksum": "sha256:a3fcdaf06ba5d733aea9d852cd8f64e4baf30a4a3f0a415249fc75d3abf0a273"
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.s390x.rpm",
+        "checksum": "sha256:22aaf8d6a27e0481e293ab5e2f9c75cd3bcd5f0a78d6d9f74a26a173f3d2a8af"
       },
       {
         "name": "gawk",
@@ -3897,6 +4147,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5"
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb"
       },
       {
         "name": "gzip",
@@ -4124,6 +4383,15 @@
         "checksum": "sha256:7d534eadb4f019135e9e52ca8c96d2c7584b89cb691814421a0cfbc87356e2c4"
       },
       {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525"
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.2",
@@ -4241,6 +4509,15 @@
         "checksum": "sha256:e7d4934722afbb69dc3f3e9a906ceb034fa2c518e5dec96a35d1442c013db359"
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "9.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libstdc++-11.2.1-9.1.el9.s390x.rpm",
+        "checksum": "sha256:7fe19cb350eaa0212e7825e625a1f930595f7bbcf5cbae1bc4a844055864a903"
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -4338,6 +4615,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/mpfr-4.1.0-7.el9.s390x.rpm",
         "checksum": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9"
       },
       {
         "name": "ncurses-base",
@@ -4592,6 +4878,15 @@
         "checksum": "sha256:166a43f9b239a07f726491ce485b190d878ffe7f5c19f701229ebe922a5f8b80"
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/s390utils-core-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:9480e7e761a3ce2c34d817c0a5e5818ab7ffbe3ba56b0ffabbea367dfd38e339"
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -4626,6 +4921,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/setup-2.13.7-6.el9.noarch.rpm",
         "checksum": "sha256:eee3d14606c828e51397d52535c56cec7fe9423bbbbe7e7e1c738ffda73edefd"
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/sg3_utils-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:1207676f3a09a4ffb38d4169d22a468c4f1fb1f2a16332eee7a6b566d6d515c2"
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/sg3_utils-libs-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:497603378bfaf195e6a6c1cda98771f21b0991318377189712451d8c33f4ba73"
       },
       {
         "name": "shadow-utils",
@@ -4680,6 +4993,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/systemd-rpm-macros-249-9.el9.noarch.rpm",
         "checksum": "sha256:90d042d6b6740a3fccf19a8cb0d77943b7a7de1bb3f20beefd3c1638ebda6446"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/tar-1.34-3.el9.s390x.rpm",
+        "checksum": "sha256:e00ae4884ea2975787663cffbc68bcb3157d14a8bd40d33a23b5d39271e6dd12"
       },
       {
         "name": "tzdata",
@@ -4763,6 +5085,528 @@
         "checksum": "sha256:4bbd75dc44ebf17ded34b706bf82f02b0a9be512122f52d73bd36ca2cbadb1af"
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c"
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae"
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2"
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5"
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29"
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9"
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033"
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b"
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53"
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92"
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409"
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0"
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1"
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41"
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03"
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d"
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42"
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14"
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd"
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0"
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175"
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f"
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f"
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7"
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71"
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7"
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462"
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Net-SSLeay-1.92-1.el9.s390x.rpm",
+        "checksum": "sha256:f732b8719dd3061e5a018e44098b245087106564341edaa985f7793c3c87eb88"
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721"
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0"
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0"
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0"
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a"
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9"
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e"
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630"
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2"
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e"
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583"
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23"
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17"
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9"
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd"
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1"
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd"
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c"
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892"
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248"
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42"
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98"
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854"
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c"
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03"
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759"
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463"
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98"
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa"
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db"
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.10",
@@ -4779,6 +5623,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/qemu-img-6.2.0-5.el9.s390x.rpm",
         "checksum": "sha256:4db25591b99cf497d739c4536cb3ef03861c4a6e381d77b95cace35eec64caae"
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/s390utils-base-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:c1a85863ae8ca49cdd46a6e9419361434299b6b4a044f0739922bbba8c3993c8"
       }
     ],
     "os": [

--- a/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_90-s390x-qcow2_customize-boot.json
@@ -191,10 +191,22 @@
                     "id": "sha256:8bb508293d782c1d1d1a45961346667bb281d7d89a652983022c5459dbc9f06a"
                   },
                   {
+                    "id": "sha256:d63c9ac56091ee3f80624f134f39bd2d7017f990c500a2be070cda0b73aff9fe"
+                  },
+                  {
                     "id": "sha256:d2fa7ebad37509158419ac20edc99de22aea93b79377ac998e200669c7248230"
                   },
                   {
+                    "id": "sha256:dcdc82e4239e7d5a317b9368f02fd80cb35c61b0b7ae1a739bae84a6adf8fe0d"
+                  },
+                  {
+                    "id": "sha256:437d4266302085ec39fc52fa2bb6725afdf136fbca84e16295f3a326e8582600"
+                  },
+                  {
                     "id": "sha256:a3fcdaf06ba5d733aea9d852cd8f64e4baf30a4a3f0a415249fc75d3abf0a273"
+                  },
+                  {
+                    "id": "sha256:22aaf8d6a27e0481e293ab5e2f9c75cd3bcd5f0a78d6d9f74a26a173f3d2a8af"
                   },
                   {
                     "id": "sha256:1fa35800fa55d66fe154d9b35ac1d5332002f585ba8c6fdff20fdd435479aae3"
@@ -225,6 +237,9 @@
                   },
                   {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5"
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb"
                   },
                   {
                     "id": "sha256:9cadc9a644de6388a3ad0061a88a2962d02025e2411ddb8560a96eeefe6ea070"
@@ -303,6 +318,9 @@
                   },
                   {
                     "id": "sha256:7d534eadb4f019135e9e52ca8c96d2c7584b89cb691814421a0cfbc87356e2c4"
+                  },
+                  {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525"
                   },
                   {
                     "id": "sha256:e6a82ebed192578855f72a3c31d56a586129a5c8e847fde32b2c98f724ace862"
@@ -384,6 +402,9 @@
                   },
                   {
                     "id": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58"
+                  },
+                  {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9"
                   },
                   {
                     "id": "sha256:45cb0635b63c6adb54e252c0fb42eb6312d96c057e7eb770651539a787917b02"
@@ -470,6 +491,9 @@
                     "id": "sha256:166a43f9b239a07f726491ce485b190d878ffe7f5c19f701229ebe922a5f8b80"
                   },
                   {
+                    "id": "sha256:9480e7e761a3ce2c34d817c0a5e5818ab7ffbe3ba56b0ffabbea367dfd38e339"
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a"
                   },
                   {
@@ -480,6 +504,12 @@
                   },
                   {
                     "id": "sha256:eee3d14606c828e51397d52535c56cec7fe9423bbbbe7e7e1c738ffda73edefd"
+                  },
+                  {
+                    "id": "sha256:1207676f3a09a4ffb38d4169d22a468c4f1fb1f2a16332eee7a6b566d6d515c2"
+                  },
+                  {
+                    "id": "sha256:497603378bfaf195e6a6c1cda98771f21b0991318377189712451d8c33f4ba73"
                   },
                   {
                     "id": "sha256:193da1d11414ff9477461fecf911071132245cbd3e3e96a0ae7a5f0a785b713f"
@@ -498,6 +528,9 @@
                   },
                   {
                     "id": "sha256:90d042d6b6740a3fccf19a8cb0d77943b7a7de1bb3f20beefd3c1638ebda6446"
+                  },
+                  {
+                    "id": "sha256:e00ae4884ea2975787663cffbc68bcb3157d14a8bd40d33a23b5d39271e6dd12"
                   },
                   {
                     "id": "sha256:df9b0d96477ad46504c896d7994731ab6b1dc1cd9cc091493ea83e29b4d1bda5"
@@ -527,10 +560,187 @@
                     "id": "sha256:4bbd75dc44ebf17ded34b706bf82f02b0a9be512122f52d73bd36ca2cbadb1af"
                   },
                   {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c"
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae"
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2"
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5"
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29"
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9"
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033"
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b"
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53"
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92"
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409"
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0"
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1"
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41"
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03"
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d"
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42"
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14"
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd"
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0"
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175"
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f"
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f"
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7"
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71"
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7"
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462"
+                  },
+                  {
+                    "id": "sha256:f732b8719dd3061e5a018e44098b245087106564341edaa985f7793c3c87eb88"
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721"
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0"
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0"
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0"
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a"
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9"
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e"
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630"
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2"
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e"
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583"
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23"
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17"
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9"
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd"
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1"
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd"
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c"
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892"
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248"
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42"
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98"
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854"
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c"
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03"
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759"
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463"
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98"
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa"
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db"
+                  },
+                  {
                     "id": "sha256:266b865a39f7a256d48151f38e5871d55d9d2f49bfa4d666e4e16430a499c201"
                   },
                   {
                     "id": "sha256:4db25591b99cf497d739c4536cb3ef03861c4a6e381d77b95cace35eec64caae"
+                  },
+                  {
+                    "id": "sha256:c1a85863ae8ca49cdd46a6e9419361434299b6b4a044f0739922bbba8c3993c8"
                   }
                 ]
               }
@@ -547,7 +757,8 @@
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
               "labels": {
-                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
               }
             }
           }
@@ -4172,6 +4383,15 @@
         "checksum": "sha256:8bb508293d782c1d1d1a45961346667bb281d7d89a652983022c5459dbc9f06a"
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.10",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/ethtool-5.10-4.el9.s390x.rpm",
+        "checksum": "sha256:d63c9ac56091ee3f80624f134f39bd2d7017f990c500a2be070cda0b73aff9fe"
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.2.10",
@@ -4181,6 +4401,24 @@
         "checksum": "sha256:d2fa7ebad37509158419ac20edc99de22aea93b79377ac998e200669c7248230"
       },
       {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/file-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:dcdc82e4239e7d5a317b9368f02fd80cb35c61b0b7ae1a739bae84a6adf8fe0d"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:437d4266302085ec39fc52fa2bb6725afdf136fbca84e16295f3a326e8582600"
+      },
+      {
         "name": "filesystem",
         "epoch": 0,
         "version": "3.16",
@@ -4188,6 +4426,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/filesystem-3.16-2.el9.s390x.rpm",
         "checksum": "sha256:a3fcdaf06ba5d733aea9d852cd8f64e4baf30a4a3f0a415249fc75d3abf0a273"
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.s390x.rpm",
+        "checksum": "sha256:22aaf8d6a27e0481e293ab5e2f9c75cd3bcd5f0a78d6d9f74a26a173f3d2a8af"
       },
       {
         "name": "gawk",
@@ -4278,6 +4525,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5"
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb"
       },
       {
         "name": "gzip",
@@ -4512,6 +4768,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libidn2-2.3.0-7.el9.s390x.rpm",
         "checksum": "sha256:7d534eadb4f019135e9e52ca8c96d2c7584b89cb691814421a0cfbc87356e2c4"
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525"
       },
       {
         "name": "libmount",
@@ -4755,6 +5020,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/mpfr-4.1.0-7.el9.s390x.rpm",
         "checksum": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58"
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9"
       },
       {
         "name": "ncurses-base",
@@ -5009,6 +5283,15 @@
         "checksum": "sha256:166a43f9b239a07f726491ce485b190d878ffe7f5c19f701229ebe922a5f8b80"
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/s390utils-core-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:9480e7e761a3ce2c34d817c0a5e5818ab7ffbe3ba56b0ffabbea367dfd38e339"
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -5043,6 +5326,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/setup-2.13.7-6.el9.noarch.rpm",
         "checksum": "sha256:eee3d14606c828e51397d52535c56cec7fe9423bbbbe7e7e1c738ffda73edefd"
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/sg3_utils-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:1207676f3a09a4ffb38d4169d22a468c4f1fb1f2a16332eee7a6b566d6d515c2"
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/sg3_utils-libs-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:497603378bfaf195e6a6c1cda98771f21b0991318377189712451d8c33f4ba73"
       },
       {
         "name": "shadow-utils",
@@ -5097,6 +5398,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/systemd-rpm-macros-249-9.el9.noarch.rpm",
         "checksum": "sha256:90d042d6b6740a3fccf19a8cb0d77943b7a7de1bb3f20beefd3c1638ebda6446"
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "3.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/tar-1.34-3.el9.s390x.rpm",
+        "checksum": "sha256:e00ae4884ea2975787663cffbc68bcb3157d14a8bd40d33a23b5d39271e6dd12"
       },
       {
         "name": "tzdata",
@@ -5180,6 +5490,528 @@
         "checksum": "sha256:4bbd75dc44ebf17ded34b706bf82f02b0a9be512122f52d73bd36ca2cbadb1af"
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c"
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae"
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2"
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5"
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29"
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9"
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033"
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b"
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53"
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92"
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409"
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0"
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1"
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41"
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03"
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d"
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42"
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14"
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd"
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0"
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175"
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f"
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f"
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7"
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71"
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7"
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462"
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Net-SSLeay-1.92-1.el9.s390x.rpm",
+        "checksum": "sha256:f732b8719dd3061e5a018e44098b245087106564341edaa985f7793c3c87eb88"
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721"
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0"
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0"
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0"
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a"
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9"
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e"
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630"
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2"
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e"
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583"
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23"
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17"
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9"
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd"
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1"
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd"
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c"
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892"
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248"
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42"
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98"
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854"
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c"
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03"
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759"
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463"
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98"
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa"
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db"
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.10",
@@ -5196,6 +6028,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/qemu-img-6.2.0-5.el9.s390x.rpm",
         "checksum": "sha256:4db25591b99cf497d739c4536cb3ef03861c4a6e381d77b95cace35eec64caae"
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/s390utils-base-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:c1a85863ae8ca49cdd46a6e9419361434299b6b4a044f0739922bbba8c3993c8"
       }
     ],
     "os": [

--- a/test/data/manifests/rhel_90-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_90-s390x-tar-boot.json
@@ -122,16 +122,31 @@
                     "id": "sha256:8bb508293d782c1d1d1a45961346667bb281d7d89a652983022c5459dbc9f06a"
                   },
                   {
+                    "id": "sha256:d63c9ac56091ee3f80624f134f39bd2d7017f990c500a2be070cda0b73aff9fe"
+                  },
+                  {
                     "id": "sha256:d2fa7ebad37509158419ac20edc99de22aea93b79377ac998e200669c7248230"
                   },
                   {
+                    "id": "sha256:dcdc82e4239e7d5a317b9368f02fd80cb35c61b0b7ae1a739bae84a6adf8fe0d"
+                  },
+                  {
+                    "id": "sha256:437d4266302085ec39fc52fa2bb6725afdf136fbca84e16295f3a326e8582600"
+                  },
+                  {
                     "id": "sha256:a3fcdaf06ba5d733aea9d852cd8f64e4baf30a4a3f0a415249fc75d3abf0a273"
+                  },
+                  {
+                    "id": "sha256:22aaf8d6a27e0481e293ab5e2f9c75cd3bcd5f0a78d6d9f74a26a173f3d2a8af"
                   },
                   {
                     "id": "sha256:1fa35800fa55d66fe154d9b35ac1d5332002f585ba8c6fdff20fdd435479aae3"
                   },
                   {
                     "id": "sha256:fb0146ee86076019daa5a9fce4e4a769fa4b952d562489ef01bbe681c4122dcd"
+                  },
+                  {
+                    "id": "sha256:c4aafb6b56e4429ffb1556e556d8c42815ebb49177ceb7382ee8a09969e095d4"
                   },
                   {
                     "id": "sha256:74413ace709a0aab5ae291069f7370e7cd6556057120e23f37344f10b734b3ae"
@@ -149,7 +164,13 @@
                     "id": "sha256:1bb044f4ce497e9087d7f728dda7854126a0bfcc9ffbc3f84b4ed4c95908f6ec"
                   },
                   {
+                    "id": "sha256:b47ed3e4b92e5a397c01f91a6e33380c785412d9f2809b1990f6c089d3e54042"
+                  },
+                  {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5"
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb"
                   },
                   {
                     "id": "sha256:9cadc9a644de6388a3ad0061a88a2962d02025e2411ddb8560a96eeefe6ea070"
@@ -218,6 +239,9 @@
                     "id": "sha256:7d534eadb4f019135e9e52ca8c96d2c7584b89cb691814421a0cfbc87356e2c4"
                   },
                   {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525"
+                  },
+                  {
                     "id": "sha256:e6a82ebed192578855f72a3c31d56a586129a5c8e847fde32b2c98f724ace862"
                   },
                   {
@@ -257,6 +281,9 @@
                     "id": "sha256:e7d4934722afbb69dc3f3e9a906ceb034fa2c518e5dec96a35d1442c013db359"
                   },
                   {
+                    "id": "sha256:7fe19cb350eaa0212e7825e625a1f930595f7bbcf5cbae1bc4a844055864a903"
+                  },
+                  {
                     "id": "sha256:24e4adda524a102c631b8b52ff895467edbb69a1fdc8f1f9c2ac9c2973ff2c65"
                   },
                   {
@@ -290,10 +317,16 @@
                     "id": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58"
                   },
                   {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9"
+                  },
+                  {
                     "id": "sha256:45cb0635b63c6adb54e252c0fb42eb6312d96c057e7eb770651539a787917b02"
                   },
                   {
                     "id": "sha256:86ce6906625ebabae852a85217dc195779e6a3cefc7255e8a1b66de536fdd2f1"
+                  },
+                  {
+                    "id": "sha256:72ceb13455a5605fdfc3d29f8f7390801ebe783bd4273f738372374b81fd2308"
                   },
                   {
                     "id": "sha256:77e6a46b77368b7e7bb8a28933fffecb84f9547421246752c65d1f1893e0c3c9"
@@ -365,6 +398,9 @@
                     "id": "sha256:166a43f9b239a07f726491ce485b190d878ffe7f5c19f701229ebe922a5f8b80"
                   },
                   {
+                    "id": "sha256:9480e7e761a3ce2c34d817c0a5e5818ab7ffbe3ba56b0ffabbea367dfd38e339"
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a"
                   },
                   {
@@ -375,6 +411,12 @@
                   },
                   {
                     "id": "sha256:eee3d14606c828e51397d52535c56cec7fe9423bbbbe7e7e1c738ffda73edefd"
+                  },
+                  {
+                    "id": "sha256:1207676f3a09a4ffb38d4169d22a468c4f1fb1f2a16332eee7a6b566d6d515c2"
+                  },
+                  {
+                    "id": "sha256:497603378bfaf195e6a6c1cda98771f21b0991318377189712451d8c33f4ba73"
                   },
                   {
                     "id": "sha256:193da1d11414ff9477461fecf911071132245cbd3e3e96a0ae7a5f0a785b713f"
@@ -419,7 +461,184 @@
                     "id": "sha256:4bbd75dc44ebf17ded34b706bf82f02b0a9be512122f52d73bd36ca2cbadb1af"
                   },
                   {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c"
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae"
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2"
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5"
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29"
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9"
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033"
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b"
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53"
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92"
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409"
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0"
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1"
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41"
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03"
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d"
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42"
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14"
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd"
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0"
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175"
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f"
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f"
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7"
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71"
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7"
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462"
+                  },
+                  {
+                    "id": "sha256:f732b8719dd3061e5a018e44098b245087106564341edaa985f7793c3c87eb88"
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721"
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0"
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0"
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0"
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a"
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9"
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e"
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630"
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2"
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e"
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583"
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23"
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17"
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9"
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd"
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1"
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd"
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c"
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892"
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248"
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42"
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98"
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854"
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c"
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03"
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759"
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463"
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98"
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa"
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db"
+                  },
+                  {
                     "id": "sha256:266b865a39f7a256d48151f38e5871d55d9d2f49bfa4d666e4e16430a499c201"
+                  },
+                  {
+                    "id": "sha256:c1a85863ae8ca49cdd46a6e9419361434299b6b4a044f0739922bbba8c3993c8"
                   }
                 ]
               }
@@ -2030,6 +2249,15 @@
         "checksum": "sha256:8bb508293d782c1d1d1a45961346667bb281d7d89a652983022c5459dbc9f06a"
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.10",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/ethtool-5.10-4.el9.s390x.rpm",
+        "checksum": "sha256:d63c9ac56091ee3f80624f134f39bd2d7017f990c500a2be070cda0b73aff9fe"
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.2.10",
@@ -2039,6 +2267,24 @@
         "checksum": "sha256:d2fa7ebad37509158419ac20edc99de22aea93b79377ac998e200669c7248230"
       },
       {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/file-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:dcdc82e4239e7d5a317b9368f02fd80cb35c61b0b7ae1a739bae84a6adf8fe0d"
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "8.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/file-libs-5.39-8.el9.s390x.rpm",
+        "checksum": "sha256:437d4266302085ec39fc52fa2bb6725afdf136fbca84e16295f3a326e8582600"
+      },
+      {
         "name": "filesystem",
         "epoch": 0,
         "version": "3.16",
@@ -2046,6 +2292,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/filesystem-3.16-2.el9.s390x.rpm",
         "checksum": "sha256:a3fcdaf06ba5d733aea9d852cd8f64e4baf30a4a3f0a415249fc75d3abf0a273"
+      },
+      {
+        "name": "fuse-libs",
+        "epoch": 0,
+        "version": "2.9.9",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/fuse-libs-2.9.9-15.el9.s390x.rpm",
+        "checksum": "sha256:22aaf8d6a27e0481e293ab5e2f9c75cd3bcd5f0a78d6d9f74a26a173f3d2a8af"
       },
       {
         "name": "gawk",
@@ -2064,6 +2319,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/gdbm-libs-1.19-4.el9.s390x.rpm",
         "checksum": "sha256:fb0146ee86076019daa5a9fce4e4a769fa4b952d562489ef01bbe681c4122dcd"
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/glib2-2.68.4-5.el9.s390x.rpm",
+        "checksum": "sha256:c4aafb6b56e4429ffb1556e556d8c42815ebb49177ceb7382ee8a09969e095d4"
       },
       {
         "name": "glibc",
@@ -2111,6 +2375,15 @@
         "checksum": "sha256:1bb044f4ce497e9087d7f728dda7854126a0bfcc9ffbc3f84b4ed4c95908f6ec"
       },
       {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/gnutls-3.7.3-1.el9.s390x.rpm",
+        "checksum": "sha256:b47ed3e4b92e5a397c01f91a6e33380c785412d9f2809b1990f6c089d3e54042"
+      },
+      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -2118,6 +2391,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5"
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb"
       },
       {
         "name": "gzip",
@@ -2318,6 +2600,15 @@
         "checksum": "sha256:7d534eadb4f019135e9e52ca8c96d2c7584b89cb691814421a0cfbc87356e2c4"
       },
       {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525"
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.2",
@@ -2435,6 +2726,15 @@
         "checksum": "sha256:e7d4934722afbb69dc3f3e9a906ceb034fa2c518e5dec96a35d1442c013db359"
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.2.1",
+        "release": "9.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/libstdc++-11.2.1-9.1.el9.s390x.rpm",
+        "checksum": "sha256:7fe19cb350eaa0212e7825e625a1f930595f7bbcf5cbae1bc4a844055864a903"
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -2534,6 +2834,15 @@
         "checksum": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58"
       },
       {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9"
+      },
+      {
         "name": "ncurses-base",
         "epoch": 0,
         "version": "6.2",
@@ -2550,6 +2859,15 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/ncurses-libs-6.2-8.20210508.el9.s390x.rpm",
         "checksum": "sha256:86ce6906625ebabae852a85217dc195779e6a3cefc7255e8a1b66de536fdd2f1"
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.7.3",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/nettle-3.7.3-2.el9.s390x.rpm",
+        "checksum": "sha256:72ceb13455a5605fdfc3d29f8f7390801ebe783bd4273f738372374b81fd2308"
       },
       {
         "name": "openldap",
@@ -2759,6 +3077,15 @@
         "checksum": "sha256:166a43f9b239a07f726491ce485b190d878ffe7f5c19f701229ebe922a5f8b80"
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/s390utils-core-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:9480e7e761a3ce2c34d817c0a5e5818ab7ffbe3ba56b0ffabbea367dfd38e339"
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -2793,6 +3120,24 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/setup-2.13.7-6.el9.noarch.rpm",
         "checksum": "sha256:eee3d14606c828e51397d52535c56cec7fe9423bbbbe7e7e1c738ffda73edefd"
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/sg3_utils-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:1207676f3a09a4ffb38d4169d22a468c4f1fb1f2a16332eee7a6b566d6d515c2"
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "6.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.0-20220208/Packages/sg3_utils-libs-1.47-6.el9.s390x.rpm",
+        "checksum": "sha256:497603378bfaf195e6a6c1cda98771f21b0991318377189712451d8c33f4ba73"
       },
       {
         "name": "shadow-utils",
@@ -2921,6 +3266,528 @@
         "checksum": "sha256:4bbd75dc44ebf17ded34b706bf82f02b0a9be512122f52d73bd36ca2cbadb1af"
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c"
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae"
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2"
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5"
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29"
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9"
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033"
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b"
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53"
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92"
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409"
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0"
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1"
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41"
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03"
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d"
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42"
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14"
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd"
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0"
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175"
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f"
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f"
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7"
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71"
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7"
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462"
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Net-SSLeay-1.92-1.el9.s390x.rpm",
+        "checksum": "sha256:f732b8719dd3061e5a018e44098b245087106564341edaa985f7793c3c87eb88"
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721"
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0"
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0"
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0"
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a"
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9"
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e"
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630"
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2"
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e"
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583"
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23"
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17"
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9"
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd"
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1"
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd"
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c"
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892"
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248"
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42"
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98"
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854"
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c"
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03"
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759"
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463"
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98"
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa"
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db"
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.10",
@@ -2928,6 +3795,15 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/python-unversioned-command-3.9.10-1.el9.noarch.rpm",
         "checksum": "sha256:266b865a39f7a256d48151f38e5871d55d9d2f49bfa4d666e4e16430a499c201"
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.19.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.0-20220208/Packages/s390utils-base-2.19.0-2.el9.s390x.rpm",
+        "checksum": "sha256:c1a85863ae8ca49cdd46a6e9419361434299b6b4a044f0739922bbba8c3993c8"
       }
     ],
     "os": [

--- a/test/data/manifests/rhel_91-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2-boot.json
@@ -214,7 +214,31 @@
                     }
                   },
                   {
+                    "id": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -303,6 +327,14 @@
                   },
                   {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -518,6 +550,22 @@
                     }
                   },
                   {
+                    "id": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f600023944965bce1d121bbfb6630dc139963558eed8c96f8137f26018a711e",
                     "options": {
                       "metadata": {
@@ -622,6 +670,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:24e4adda524a102c631b8b52ff895467edbb69a1fdc8f1f9c2ac9c2973ff2c65",
                     "options": {
                       "metadata": {
@@ -703,6 +759,14 @@
                   },
                   {
                     "id": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -934,6 +998,14 @@
                     }
                   },
                   {
+                    "id": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a",
                     "options": {
                       "metadata": {
@@ -959,6 +1031,22 @@
                   },
                   {
                     "id": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1007,6 +1095,14 @@
                   },
                   {
                     "id": "sha256:1ac1513bcbefd241faa5de800412ae69df0ac0d65a0681a50f7cf3ce5497dec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de68fa5d611b91a76fad23e1b428451a91509685dee006c1dc9dbfbfe19228bf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1078,7 +1174,479 @@
                     }
                   },
                   {
+                    "id": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1100,6 +1668,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -1116,7 +1692,8 @@
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
               "labels": {
-                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
               }
             }
           }
@@ -6829,6 +7406,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.16",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/ethtool-5.16-1.el9.s390x.rpm",
+        "checksum": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.4.9",
@@ -6836,6 +7423,26 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/expat-2.4.9-1.el9_1.s390x.rpm",
         "checksum": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/file-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
         "check_gpg": true
       },
       {
@@ -6946,6 +7553,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
         "check_gpg": true
       },
       {
@@ -7209,6 +7826,26 @@
         "check_gpg": true
       },
       {
+        "name": "liblockfile",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/liblockfile-1.14-10.el9.s390x.rpm",
+        "checksum": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.4",
@@ -7339,6 +7976,16 @@
         "check_gpg": true
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.3.1",
+        "release": "2.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/libstdc++-11.3.1-2.1.el9.s390x.rpm",
+        "checksum": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+        "check_gpg": true
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -7446,6 +8093,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.s390x.rpm",
         "checksum": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
         "check_gpg": true
       },
       {
@@ -7729,6 +8386,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/s390utils-core-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -7766,6 +8433,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/setup-2.13.7-7.el9.noarch.rpm",
         "checksum": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/sg3_utils-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/sg3_utils-libs-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
         "check_gpg": true
       },
       {
@@ -7826,6 +8513,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/systemd-rpm-macros-250-12.el9_1.noarch.rpm",
         "checksum": "sha256:1ac1513bcbefd241faa5de800412ae69df0ac0d65a0681a50f7cf3ce5497dec0",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/tar-1.34-5.el9.s390x.rpm",
+        "checksum": "sha256:de68fa5d611b91a76fad23e1b428451a91509685dee006c1dc9dbfbfe19228bf",
         "check_gpg": true
       },
       {
@@ -7909,6 +8606,16 @@
         "check_gpg": true
       },
       {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.2",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/fuse3-libs-3.10.2-5.el9.s390x.rpm",
+        "checksum": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+        "check_gpg": true
+      },
+      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -7916,6 +8623,586 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/gawk-all-langpacks-5.1.0-6.el9.s390x.rpm",
         "checksum": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Net-SSLeay-1.92-2.el9.s390x.rpm",
+        "checksum": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
         "check_gpg": true
       },
       {
@@ -7936,6 +9223,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/qemu-img-7.0.0-13.el9.s390x.rpm",
         "checksum": "sha256:c611faaf40820cf5eb5090a81866e5d3e089a87633ee0f1eeaa8947e065eafe3",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/s390utils-base-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_91-s390x-qcow2_customize-boot.json
@@ -309,7 +309,31 @@
                     }
                   },
                   {
+                    "id": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -422,6 +446,14 @@
                   },
                   {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -661,6 +693,22 @@
                     }
                   },
                   {
+                    "id": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f600023944965bce1d121bbfb6630dc139963558eed8c96f8137f26018a711e",
                     "options": {
                       "metadata": {
@@ -878,6 +926,14 @@
                   },
                   {
                     "id": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1149,6 +1205,14 @@
                     }
                   },
                   {
+                    "id": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a",
                     "options": {
                       "metadata": {
@@ -1174,6 +1238,22 @@
                   },
                   {
                     "id": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1397,6 +1477,470 @@
                     }
                   },
                   {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:83f5c216d85ee981af49db6a99aae65418e1b57a2e6164254dd6a89d5f592d71",
                     "options": {
                       "metadata": {
@@ -1446,6 +1990,14 @@
                   },
                   {
                     "id": "sha256:c611faaf40820cf5eb5090a81866e5d3e089a87633ee0f1eeaa8947e065eafe3",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -7664,6 +8216,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.16",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/ethtool-5.16-1.el9.s390x.rpm",
+        "checksum": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.4.9",
@@ -7671,6 +8233,26 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/expat-2.4.9-1.el9_1.s390x.rpm",
         "checksum": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/file-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
         "check_gpg": true
       },
       {
@@ -7811,6 +8393,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
         "check_gpg": true
       },
       {
@@ -8104,6 +8696,26 @@
         "check_gpg": true
       },
       {
+        "name": "liblockfile",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/liblockfile-1.14-10.el9.s390x.rpm",
+        "checksum": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.4",
@@ -8381,6 +8993,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/mpfr-4.1.0-7.el9.s390x.rpm",
         "checksum": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
         "check_gpg": true
       },
       {
@@ -8714,6 +9336,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/s390utils-core-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -8751,6 +9383,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/setup-2.13.7-7.el9.noarch.rpm",
         "checksum": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/sg3_utils-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/sg3_utils-libs-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
         "check_gpg": true
       },
       {
@@ -9024,6 +9676,586 @@
         "check_gpg": true
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Net-SSLeay-1.92-2.el9.s390x.rpm",
+        "checksum": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
+        "check_gpg": true
+      },
+      {
         "name": "policycoreutils-python-utils",
         "epoch": 0,
         "version": "3.4",
@@ -9091,6 +10323,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/qemu-img-7.0.0-13.el9.s390x.rpm",
         "checksum": "sha256:c611faaf40820cf5eb5090a81866e5d3e089a87633ee0f1eeaa8947e065eafe3",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/s390utils-base-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
         "check_gpg": true
       },
       {

--- a/test/data/manifests/rhel_91-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_91-s390x-tar-boot.json
@@ -220,7 +220,31 @@
                     }
                   },
                   {
+                    "id": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -245,6 +269,14 @@
                   },
                   {
                     "id": "sha256:fb0146ee86076019daa5a9fce4e4a769fa4b952d562489ef01bbe681c4122dcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4aafb6b56e4429ffb1556e556d8c42815ebb49177ceb7382ee8a09969e095d4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -292,7 +324,23 @@
                     }
                   },
                   {
+                    "id": "sha256:bb180f74b9759a67ccb13e9b71e138f75e229177c83a4b47f500cb042b2bb6c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -484,6 +532,22 @@
                     }
                   },
                   {
+                    "id": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f600023944965bce1d121bbfb6630dc139963558eed8c96f8137f26018a711e",
                     "options": {
                       "metadata": {
@@ -588,6 +652,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:24e4adda524a102c631b8b52ff895467edbb69a1fdc8f1f9c2ac9c2973ff2c65",
                     "options": {
                       "metadata": {
@@ -676,6 +748,14 @@
                     }
                   },
                   {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:45cb0635b63c6adb54e252c0fb42eb6312d96c057e7eb770651539a787917b02",
                     "options": {
                       "metadata": {
@@ -685,6 +765,14 @@
                   },
                   {
                     "id": "sha256:86ce6906625ebabae852a85217dc195779e6a3cefc7255e8a1b66de536fdd2f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce991650ec6b4a6fb85c5174b6151ff58355e7a2b11d69b4362305355b681cda",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -876,6 +964,14 @@
                     }
                   },
                   {
+                    "id": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a",
                     "options": {
                       "metadata": {
@@ -901,6 +997,22 @@
                   },
                   {
                     "id": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1012,6 +1124,14 @@
                     }
                   },
                   {
+                    "id": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
                     "options": {
                       "metadata": {
@@ -1020,7 +1140,479 @@
                     }
                   },
                   {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7178c08f988a127d570a37ad630291bd773401b85de38cfb7b1855b9b8a13f1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3659,6 +4251,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.16",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/ethtool-5.16-1.el9.s390x.rpm",
+        "checksum": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.4.9",
@@ -3666,6 +4268,26 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/expat-2.4.9-1.el9_1.s390x.rpm",
         "checksum": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/file-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/file-libs-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
         "check_gpg": true
       },
       {
@@ -3696,6 +4318,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/gdbm-libs-1.19-4.el9.s390x.rpm",
         "checksum": "sha256:fb0146ee86076019daa5a9fce4e4a769fa4b952d562489ef01bbe681c4122dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/glib2-2.68.4-5.el9.s390x.rpm",
+        "checksum": "sha256:c4aafb6b56e4429ffb1556e556d8c42815ebb49177ceb7382ee8a09969e095d4",
         "check_gpg": true
       },
       {
@@ -3749,6 +4381,16 @@
         "check_gpg": true
       },
       {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "12.el9_0",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/gnutls-3.7.6-12.el9_0.s390x.rpm",
+        "checksum": "sha256:bb180f74b9759a67ccb13e9b71e138f75e229177c83a4b47f500cb042b2bb6c1",
+        "check_gpg": true
+      },
+      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -3756,6 +4398,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
         "check_gpg": true
       },
       {
@@ -3989,6 +4641,26 @@
         "check_gpg": true
       },
       {
+        "name": "liblockfile",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/liblockfile-1.14-10.el9.s390x.rpm",
+        "checksum": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.4",
@@ -4119,6 +4791,16 @@
         "check_gpg": true
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.3.1",
+        "release": "2.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/libstdc++-11.3.1-2.1.el9.s390x.rpm",
+        "checksum": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+        "check_gpg": true
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -4229,6 +4911,16 @@
         "check_gpg": true
       },
       {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
+        "check_gpg": true
+      },
+      {
         "name": "ncurses-base",
         "epoch": 0,
         "version": "6.2",
@@ -4246,6 +4938,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/ncurses-libs-6.2-8.20210508.el9.s390x.rpm",
         "checksum": "sha256:86ce6906625ebabae852a85217dc195779e6a3cefc7255e8a1b66de536fdd2f1",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.el9_0",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/nettle-3.8-3.el9_0.s390x.rpm",
+        "checksum": "sha256:ce991650ec6b4a6fb85c5174b6151ff58355e7a2b11d69b4362305355b681cda",
         "check_gpg": true
       },
       {
@@ -4479,6 +5181,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/s390utils-core-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -4516,6 +5228,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/setup-2.13.7-7.el9.noarch.rpm",
         "checksum": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/sg3_utils-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.1-20221015/Packages/sg3_utils-libs-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
         "check_gpg": true
       },
       {
@@ -4649,6 +5381,16 @@
         "check_gpg": true
       },
       {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.2",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/fuse3-libs-3.10.2-5.el9.s390x.rpm",
+        "checksum": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+        "check_gpg": true
+      },
+      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -4659,6 +5401,586 @@
         "check_gpg": true
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Net-SSLeay-1.92-2.el9.s390x.rpm",
+        "checksum": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
+        "check_gpg": true
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.14",
@@ -4666,6 +5988,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/python-unversioned-command-3.9.14-1.el9.noarch.rpm",
         "checksum": "sha256:7178c08f988a127d570a37ad630291bd773401b85de38cfb7b1855b9b8a13f1e",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.1-20221015/Packages/s390utils-base-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/rhel_92-s390x-qcow2-boot.json
+++ b/test/data/manifests/rhel_92-s390x-qcow2-boot.json
@@ -214,7 +214,31 @@
                     }
                   },
                   {
+                    "id": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -303,6 +327,14 @@
                   },
                   {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -518,6 +550,22 @@
                     }
                   },
                   {
+                    "id": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f600023944965bce1d121bbfb6630dc139963558eed8c96f8137f26018a711e",
                     "options": {
                       "metadata": {
@@ -622,6 +670,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:24e4adda524a102c631b8b52ff895467edbb69a1fdc8f1f9c2ac9c2973ff2c65",
                     "options": {
                       "metadata": {
@@ -703,6 +759,14 @@
                   },
                   {
                     "id": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -934,6 +998,14 @@
                     }
                   },
                   {
+                    "id": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a",
                     "options": {
                       "metadata": {
@@ -959,6 +1031,22 @@
                   },
                   {
                     "id": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1007,6 +1095,14 @@
                   },
                   {
                     "id": "sha256:1ac1513bcbefd241faa5de800412ae69df0ac0d65a0681a50f7cf3ce5497dec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de68fa5d611b91a76fad23e1b428451a91509685dee006c1dc9dbfbfe19228bf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1078,7 +1174,479 @@
                     }
                   },
                   {
+                    "id": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1100,6 +1668,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -1116,7 +1692,8 @@
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
               "labels": {
-                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
               }
             }
           }
@@ -6829,6 +7406,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.16",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/ethtool-5.16-1.el9.s390x.rpm",
+        "checksum": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.4.9",
@@ -6836,6 +7423,26 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/expat-2.4.9-1.el9_1.s390x.rpm",
         "checksum": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/file-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/file-libs-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
         "check_gpg": true
       },
       {
@@ -6946,6 +7553,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
         "check_gpg": true
       },
       {
@@ -7209,6 +7826,26 @@
         "check_gpg": true
       },
       {
+        "name": "liblockfile",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/liblockfile-1.14-10.el9.s390x.rpm",
+        "checksum": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.4",
@@ -7339,6 +7976,16 @@
         "check_gpg": true
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.3.1",
+        "release": "2.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/libstdc++-11.3.1-2.1.el9.s390x.rpm",
+        "checksum": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+        "check_gpg": true
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -7446,6 +8093,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/mpfr-4.1.0-7.el9.s390x.rpm",
         "checksum": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
         "check_gpg": true
       },
       {
@@ -7729,6 +8386,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/s390utils-core-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -7766,6 +8433,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/setup-2.13.7-7.el9.noarch.rpm",
         "checksum": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/sg3_utils-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/sg3_utils-libs-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
         "check_gpg": true
       },
       {
@@ -7826,6 +8513,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/systemd-rpm-macros-250-12.el9_1.noarch.rpm",
         "checksum": "sha256:1ac1513bcbefd241faa5de800412ae69df0ac0d65a0681a50f7cf3ce5497dec0",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/tar-1.34-5.el9.s390x.rpm",
+        "checksum": "sha256:de68fa5d611b91a76fad23e1b428451a91509685dee006c1dc9dbfbfe19228bf",
         "check_gpg": true
       },
       {
@@ -7909,6 +8606,16 @@
         "check_gpg": true
       },
       {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.2",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/fuse3-libs-3.10.2-5.el9.s390x.rpm",
+        "checksum": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+        "check_gpg": true
+      },
+      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -7916,6 +8623,586 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/gawk-all-langpacks-5.1.0-6.el9.s390x.rpm",
         "checksum": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Net-SSLeay-1.92-2.el9.s390x.rpm",
+        "checksum": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
         "check_gpg": true
       },
       {
@@ -7936,6 +9223,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/qemu-img-7.1.0-3.el9.s390x.rpm",
         "checksum": "sha256:02b70ece3ebd478cd545767875d6101c499c8cc7228e5a2e0bc19204d8a5ec48",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/s390utils-base-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
+++ b/test/data/manifests/rhel_92-s390x-qcow2_customize-boot.json
@@ -304,7 +304,31 @@
                     }
                   },
                   {
+                    "id": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -393,6 +417,14 @@
                   },
                   {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -616,6 +648,22 @@
                     }
                   },
                   {
+                    "id": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f600023944965bce1d121bbfb6630dc139963558eed8c96f8137f26018a711e",
                     "options": {
                       "metadata": {
@@ -825,6 +873,14 @@
                   },
                   {
                     "id": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1056,6 +1112,14 @@
                     }
                   },
                   {
+                    "id": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a",
                     "options": {
                       "metadata": {
@@ -1081,6 +1145,22 @@
                   },
                   {
                     "id": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1129,6 +1209,14 @@
                   },
                   {
                     "id": "sha256:1ac1513bcbefd241faa5de800412ae69df0ac0d65a0681a50f7cf3ce5497dec0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:de68fa5d611b91a76fad23e1b428451a91509685dee006c1dc9dbfbfe19228bf",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1200,7 +1288,479 @@
                     }
                   },
                   {
+                    "id": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1222,6 +1782,14 @@
                         "rpm.check_gpg": true
                       }
                     }
+                  },
+                  {
+                    "id": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
                   }
                 ]
               }
@@ -1238,7 +1806,8 @@
             "options": {
               "file_contexts": "etc/selinux/targeted/contexts/files/file_contexts",
               "labels": {
-                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0"
+                "/usr/bin/cp": "system_u:object_r:install_exec_t:s0",
+                "/usr/bin/tar": "system_u:object_r:install_exec_t:s0"
               }
             }
           }
@@ -7350,6 +7919,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.16",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/ethtool-5.16-1.el9.s390x.rpm",
+        "checksum": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.4.9",
@@ -7357,6 +7936,26 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/expat-2.4.9-1.el9_1.s390x.rpm",
         "checksum": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/file-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/file-libs-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
         "check_gpg": true
       },
       {
@@ -7467,6 +8066,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
         "check_gpg": true
       },
       {
@@ -7740,6 +8349,26 @@
         "check_gpg": true
       },
       {
+        "name": "liblockfile",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/liblockfile-1.14-10.el9.s390x.rpm",
+        "checksum": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.4",
@@ -8007,6 +8636,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/mpfr-4.1.0-7.el9.s390x.rpm",
         "checksum": "sha256:fad3617d5fb5bb5213df4251eb36b1a41ddd570a79f225e8e7cb7b6c2e8ccb58",
+        "check_gpg": true
+      },
+      {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
         "check_gpg": true
       },
       {
@@ -8290,6 +8929,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/s390utils-core-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -8327,6 +8976,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/setup-2.13.7-7.el9.noarch.rpm",
         "checksum": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/sg3_utils-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/sg3_utils-libs-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
         "check_gpg": true
       },
       {
@@ -8387,6 +9056,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/systemd-rpm-macros-250-12.el9_1.noarch.rpm",
         "checksum": "sha256:1ac1513bcbefd241faa5de800412ae69df0ac0d65a0681a50f7cf3ce5497dec0",
+        "check_gpg": true
+      },
+      {
+        "name": "tar",
+        "epoch": 2,
+        "version": "1.34",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/tar-1.34-5.el9.s390x.rpm",
+        "checksum": "sha256:de68fa5d611b91a76fad23e1b428451a91509685dee006c1dc9dbfbfe19228bf",
         "check_gpg": true
       },
       {
@@ -8470,6 +9149,16 @@
         "check_gpg": true
       },
       {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.2",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/fuse3-libs-3.10.2-5.el9.s390x.rpm",
+        "checksum": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+        "check_gpg": true
+      },
+      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -8477,6 +9166,586 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/gawk-all-langpacks-5.1.0-6.el9.s390x.rpm",
         "checksum": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Net-SSLeay-1.92-2.el9.s390x.rpm",
+        "checksum": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
         "check_gpg": true
       },
       {
@@ -8497,6 +9766,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/qemu-img-7.1.0-3.el9.s390x.rpm",
         "checksum": "sha256:02b70ece3ebd478cd545767875d6101c499c8cc7228e5a2e0bc19204d8a5ec48",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/s390utils-base-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
         "check_gpg": true
       }
     ],

--- a/test/data/manifests/rhel_92-s390x-tar-boot.json
+++ b/test/data/manifests/rhel_92-s390x-tar-boot.json
@@ -220,7 +220,31 @@
                     }
                   },
                   {
+                    "id": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -245,6 +269,14 @@
                   },
                   {
                     "id": "sha256:fb0146ee86076019daa5a9fce4e4a769fa4b952d562489ef01bbe681c4122dcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c4aafb6b56e4429ffb1556e556d8c42815ebb49177ceb7382ee8a09969e095d4",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -292,7 +324,23 @@
                     }
                   },
                   {
+                    "id": "sha256:bb180f74b9759a67ccb13e9b71e138f75e229177c83a4b47f500cb042b2bb6c1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -484,6 +532,22 @@
                     }
                   },
                   {
+                    "id": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:3f600023944965bce1d121bbfb6630dc139963558eed8c96f8137f26018a711e",
                     "options": {
                       "metadata": {
@@ -588,6 +652,14 @@
                     }
                   },
                   {
+                    "id": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:24e4adda524a102c631b8b52ff895467edbb69a1fdc8f1f9c2ac9c2973ff2c65",
                     "options": {
                       "metadata": {
@@ -676,6 +748,14 @@
                     }
                   },
                   {
+                    "id": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:45cb0635b63c6adb54e252c0fb42eb6312d96c057e7eb770651539a787917b02",
                     "options": {
                       "metadata": {
@@ -685,6 +765,14 @@
                   },
                   {
                     "id": "sha256:86ce6906625ebabae852a85217dc195779e6a3cefc7255e8a1b66de536fdd2f1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ce991650ec6b4a6fb85c5174b6151ff58355e7a2b11d69b4362305355b681cda",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -876,6 +964,14 @@
                     }
                   },
                   {
+                    "id": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7b168d834543330cf1c55693aea8c11f4bd87d25ce6369ce8b5ab0673678566a",
                     "options": {
                       "metadata": {
@@ -901,6 +997,22 @@
                   },
                   {
                     "id": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -1012,6 +1124,14 @@
                     }
                   },
                   {
+                    "id": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:fc71db041e9b749a3f8bcbc9f812509625cfaf5d4fa83d37324c4dbdeb00a36e",
                     "options": {
                       "metadata": {
@@ -1020,7 +1140,479 @@
                     }
                   },
                   {
+                    "id": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
                     "id": "sha256:7178c08f988a127d570a37ad630291bd773401b85de38cfb7b1855b9b8a13f1e",
+                    "options": {
+                      "metadata": {
+                        "rpm.check_gpg": true
+                      }
+                    }
+                  },
+                  {
+                    "id": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
                     "options": {
                       "metadata": {
                         "rpm.check_gpg": true
@@ -3659,6 +4251,16 @@
         "check_gpg": true
       },
       {
+        "name": "ethtool",
+        "epoch": 2,
+        "version": "5.16",
+        "release": "1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/ethtool-5.16-1.el9.s390x.rpm",
+        "checksum": "sha256:ff06fb4f209ba3fb486f66b032b71b70a988a48f79557436de36f0f710b96eab",
+        "check_gpg": true
+      },
+      {
         "name": "expat",
         "epoch": 0,
         "version": "2.4.9",
@@ -3666,6 +4268,26 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/expat-2.4.9-1.el9_1.s390x.rpm",
         "checksum": "sha256:419215e6dc7a509fd5217ab3b55aa928edee9adfcd6246912e87144fb2b6556c",
+        "check_gpg": true
+      },
+      {
+        "name": "file",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/file-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:abf6efccbdc226bc64cb2f41364632e59fc72e615e3218c2cc0a614a6c24c49e",
+        "check_gpg": true
+      },
+      {
+        "name": "file-libs",
+        "epoch": 0,
+        "version": "5.39",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/file-libs-5.39-10.el9.s390x.rpm",
+        "checksum": "sha256:e456cf986a95de811fa8e90b3abf311f1ab10c5683b4f52298f153f6539f8365",
         "check_gpg": true
       },
       {
@@ -3696,6 +4318,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/gdbm-libs-1.19-4.el9.s390x.rpm",
         "checksum": "sha256:fb0146ee86076019daa5a9fce4e4a769fa4b952d562489ef01bbe681c4122dcd",
+        "check_gpg": true
+      },
+      {
+        "name": "glib2",
+        "epoch": 0,
+        "version": "2.68.4",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/glib2-2.68.4-5.el9.s390x.rpm",
+        "checksum": "sha256:c4aafb6b56e4429ffb1556e556d8c42815ebb49177ceb7382ee8a09969e095d4",
         "check_gpg": true
       },
       {
@@ -3749,6 +4381,16 @@
         "check_gpg": true
       },
       {
+        "name": "gnutls",
+        "epoch": 0,
+        "version": "3.7.6",
+        "release": "12.el9_0",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/gnutls-3.7.6-12.el9_0.s390x.rpm",
+        "checksum": "sha256:bb180f74b9759a67ccb13e9b71e138f75e229177c83a4b47f500cb042b2bb6c1",
+        "check_gpg": true
+      },
+      {
         "name": "grep",
         "epoch": 0,
         "version": "3.6",
@@ -3756,6 +4398,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/grep-3.6-5.el9.s390x.rpm",
         "checksum": "sha256:282ef2512b0c14223fa788ecbc863895bc13e191d69f835fb9bba8aa37ce61a5",
+        "check_gpg": true
+      },
+      {
+        "name": "groff-base",
+        "epoch": 0,
+        "version": "1.22.4",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/groff-base-1.22.4-10.el9.s390x.rpm",
+        "checksum": "sha256:b71dbcd97e524881fe496c1c98db06bcae426f52ea27ce8c8e4107cb962287eb",
         "check_gpg": true
       },
       {
@@ -3989,6 +4641,26 @@
         "check_gpg": true
       },
       {
+        "name": "liblockfile",
+        "epoch": 0,
+        "version": "1.14",
+        "release": "10.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/liblockfile-1.14-10.el9.s390x.rpm",
+        "checksum": "sha256:e5f650c0a4194a010e0dc2325ef45878c358f28b54c80504d83d07cc12dbc238",
+        "check_gpg": true
+      },
+      {
+        "name": "libmnl",
+        "epoch": 0,
+        "version": "1.0.4",
+        "release": "15.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/libmnl-1.0.4-15.el9.s390x.rpm",
+        "checksum": "sha256:f47ed8417fcf2f65d120bc6ec76d3db26002065b60a69933208aec4372705525",
+        "check_gpg": true
+      },
+      {
         "name": "libmount",
         "epoch": 0,
         "version": "2.37.4",
@@ -4119,6 +4791,16 @@
         "check_gpg": true
       },
       {
+        "name": "libstdc++",
+        "epoch": 0,
+        "version": "11.3.1",
+        "release": "2.1.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/libstdc++-11.3.1-2.1.el9.s390x.rpm",
+        "checksum": "sha256:8ff9c1f77c9cbfc67641823b720280f53185279db34c60d60565083333b29cc2",
+        "check_gpg": true
+      },
+      {
         "name": "libtasn1",
         "epoch": 0,
         "version": "4.16.0",
@@ -4229,6 +4911,16 @@
         "check_gpg": true
       },
       {
+        "name": "ncurses",
+        "epoch": 0,
+        "version": "6.2",
+        "release": "8.20210508.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/ncurses-6.2-8.20210508.el9.s390x.rpm",
+        "checksum": "sha256:a4ee7db206cb38129194710496fc178596a4aac3cc21d87bcf5400618def43d9",
+        "check_gpg": true
+      },
+      {
         "name": "ncurses-base",
         "epoch": 0,
         "version": "6.2",
@@ -4246,6 +4938,16 @@
         "arch": "s390x",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/ncurses-libs-6.2-8.20210508.el9.s390x.rpm",
         "checksum": "sha256:86ce6906625ebabae852a85217dc195779e6a3cefc7255e8a1b66de536fdd2f1",
+        "check_gpg": true
+      },
+      {
+        "name": "nettle",
+        "epoch": 0,
+        "version": "3.8",
+        "release": "3.el9_0",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/nettle-3.8-3.el9_0.s390x.rpm",
+        "checksum": "sha256:ce991650ec6b4a6fb85c5174b6151ff58355e7a2b11d69b4362305355b681cda",
         "check_gpg": true
       },
       {
@@ -4479,6 +5181,16 @@
         "check_gpg": true
       },
       {
+        "name": "s390utils-core",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/s390utils-core-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:2853def8683658e327977a7dd276f03814ddb76248c38a0b91c41197f5d11e34",
+        "check_gpg": true
+      },
+      {
         "name": "sed",
         "epoch": 0,
         "version": "4.8",
@@ -4516,6 +5228,26 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/setup-2.13.7-7.el9.noarch.rpm",
         "checksum": "sha256:14162b1b53acc51885befd090bed2d6dc9a9991deecc473e24fc45721b9cf1c6",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/sg3_utils-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:7a47ea22990a2157bf03e03c7c441fe6a8659c80072804dc748b79e6211de4d1",
+        "check_gpg": true
+      },
+      {
+        "name": "sg3_utils-libs",
+        "epoch": 0,
+        "version": "1.47",
+        "release": "9.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-baseos-n9.2-20221025/Packages/sg3_utils-libs-1.47-9.el9.s390x.rpm",
+        "checksum": "sha256:97504fcfa40b995a37702d166afb51546ff5ee40a04292845680f93f25dde06c",
         "check_gpg": true
       },
       {
@@ -4649,6 +5381,16 @@
         "check_gpg": true
       },
       {
+        "name": "fuse3-libs",
+        "epoch": 0,
+        "version": "3.10.2",
+        "release": "5.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/fuse3-libs-3.10.2-5.el9.s390x.rpm",
+        "checksum": "sha256:da334934da90ebb081f892be11ce6d859e5f79af60f97596fef2b53b6a4a1333",
+        "check_gpg": true
+      },
+      {
         "name": "gawk-all-langpacks",
         "epoch": 0,
         "version": "5.1.0",
@@ -4659,6 +5401,586 @@
         "check_gpg": true
       },
       {
+        "name": "perl-AutoLoader",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-AutoLoader-5.74-479.el9.noarch.rpm",
+        "checksum": "sha256:0d82873bfbf607c09e91029c6715b20ac2c5ba63e1b4727a81d896c06681323c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-B",
+        "epoch": 0,
+        "version": "1.80",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-B-1.80-479.el9.s390x.rpm",
+        "checksum": "sha256:6f220d4241553f3615fd11631acf45aa8a65fd06293438e2572afecf3bf4ecae",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Carp",
+        "epoch": 0,
+        "version": "1.50",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Carp-1.50-460.el9.noarch.rpm",
+        "checksum": "sha256:c51470a55b1dce42f944bdea06a10469f5a42d55be898a33c2fed3a99843fbb2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Class-Struct",
+        "epoch": 0,
+        "version": "0.66",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Class-Struct-0.66-479.el9.noarch.rpm",
+        "checksum": "sha256:aeef28091240a4e14bb388c3a1ce56ce34d9eac259c4a608e8aa176be56a52c5",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Data-Dumper",
+        "epoch": 0,
+        "version": "2.174",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Data-Dumper-2.174-462.el9.s390x.rpm",
+        "checksum": "sha256:ff0d38ef2fba9f29f6a94f6241a674b131e8270c6b3c1a43c1209eb88d796b29",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest",
+        "epoch": 0,
+        "version": "1.19",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Digest-1.19-4.el9.noarch.rpm",
+        "checksum": "sha256:e0b8633f818467f9e1bf46b9c0012af7bf8a309ac64e903a2a9faf3fae7705f9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Digest-MD5",
+        "epoch": 0,
+        "version": "2.58",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Digest-MD5-2.58-4.el9.s390x.rpm",
+        "checksum": "sha256:038edb5a5a8fc94c33e75ff4e7b6b1332c645e6f516a2d86e420dd41758db033",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Encode",
+        "epoch": 4,
+        "version": "3.08",
+        "release": "462.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Encode-3.08-462.el9.s390x.rpm",
+        "checksum": "sha256:fc7d3f9d0c72ce6ae2b8725f933fe1dff4f2449eebb752a0d8f35b6e7275c31b",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-English",
+        "epoch": 0,
+        "version": "1.11",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-English-1.11-479.el9.noarch.rpm",
+        "checksum": "sha256:dbbda38ce865a6d70b82c928c711b2d9900c3c140f15348313398818b94d6d53",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Errno",
+        "epoch": 0,
+        "version": "1.30",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Errno-1.30-479.el9.s390x.rpm",
+        "checksum": "sha256:736de4f5ebcba45ef4b32ff59203c87b707360fd6e21779f6dd47d4f7693bd92",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Exporter",
+        "epoch": 0,
+        "version": "5.74",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Exporter-5.74-461.el9.noarch.rpm",
+        "checksum": "sha256:888e14ebd70c2b69150873236b0df7c3a29c9edd488fd8488527c179e798b409",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Fcntl",
+        "epoch": 0,
+        "version": "1.13",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Fcntl-1.13-479.el9.s390x.rpm",
+        "checksum": "sha256:76615ee81309c171a4a7c990c04188fdb3f6301b3041b4bba59eae4627b238c0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Basename",
+        "epoch": 0,
+        "version": "2.85",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Basename-2.85-479.el9.noarch.rpm",
+        "checksum": "sha256:470b13e3db540e4493fbfe0029ef334223b10c1a4f3b1612c07f385de3f06db1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Path",
+        "epoch": 0,
+        "version": "2.18",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Path-2.18-4.el9.noarch.rpm",
+        "checksum": "sha256:d1df5e509c10365eaa329a0b97e38bc2667874240d3942195eb6ce7a88985a41",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-Temp",
+        "epoch": 1,
+        "version": "0.231.100",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-Temp-0.231.100-4.el9.noarch.rpm",
+        "checksum": "sha256:0a81b062391ac6dac3ec28ff1e435001dd798cf1ff19fdb52cfe1e0720d5de03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-File-stat",
+        "epoch": 0,
+        "version": "1.09",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-File-stat-1.09-479.el9.noarch.rpm",
+        "checksum": "sha256:4c687f20bfbbfa067ad23533ccdbbf4e430718ebdd14b54632ae427f7e40c59d",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-FileHandle",
+        "epoch": 0,
+        "version": "2.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-FileHandle-2.03-479.el9.noarch.rpm",
+        "checksum": "sha256:fb914b67ee6a4b0f7f250369672ca003b0dd8256a68a5f06824cccb4268a6a42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Long",
+        "epoch": 1,
+        "version": "2.52",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Getopt-Long-2.52-4.el9.noarch.rpm",
+        "checksum": "sha256:055fe33d2a7a421c1de8902b86a2f246ef6457774239d04b604f2d0ec6a00a14",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Getopt-Std",
+        "epoch": 0,
+        "version": "1.12",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Getopt-Std-1.12-479.el9.noarch.rpm",
+        "checksum": "sha256:3068feb8601382da553a0dc200c63c2ccd1174025e8ab724d0eccdee58b2eecd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-HTTP-Tiny",
+        "epoch": 0,
+        "version": "0.076",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-HTTP-Tiny-0.076-460.el9.noarch.rpm",
+        "checksum": "sha256:af581a4dc464e1a9e2c09674ef4150ac90849817f422eb83d42889c02d9514d0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO",
+        "epoch": 0,
+        "version": "1.43",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-1.43-479.el9.s390x.rpm",
+        "checksum": "sha256:d9d41b21eb0db1ea4c3ac0c0111d2dfe5bcf892c1cef2725655633279a2a7175",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-IP",
+        "epoch": 0,
+        "version": "0.41",
+        "release": "5.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-Socket-IP-0.41-5.el9.noarch.rpm",
+        "checksum": "sha256:4c80030ce256198584c4a58171b9dfe3adb4a8d7593110229e40ece76786a32f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IO-Socket-SSL",
+        "epoch": 0,
+        "version": "2.073",
+        "release": "1.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IO-Socket-SSL-2.073-1.el9.noarch.rpm",
+        "checksum": "sha256:58f1531e7657118f32a08dec8bf1ace8de1892a560be6b9e395722dd070ed02f",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-IPC-Open3",
+        "epoch": 0,
+        "version": "1.21",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-IPC-Open3-1.21-479.el9.noarch.rpm",
+        "checksum": "sha256:e13d7e49aa9f407950680e48152f61ceb7decac6cd392f7c3aa481c06867d9d7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-MIME-Base64",
+        "epoch": 0,
+        "version": "3.16",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-MIME-Base64-3.16-4.el9.s390x.rpm",
+        "checksum": "sha256:8f97e46c1a3e84b84b9232f2f90a4b14193651907853c54453b3045ad2028d71",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Mozilla-CA",
+        "epoch": 0,
+        "version": "20200520",
+        "release": "6.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Mozilla-CA-20200520-6.el9.noarch.rpm",
+        "checksum": "sha256:99030bfb6a1a2ac41e0720841abaa8ba58c26e91640f4058cc6133e227e928a7",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-NDBM_File",
+        "epoch": 0,
+        "version": "1.15",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-NDBM_File-1.15-479.el9.s390x.rpm",
+        "checksum": "sha256:c5df6a6fd5a018f91a542dad52cf2f1afccdd07bc80193198a861cfc1b664462",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Net-SSLeay",
+        "epoch": 0,
+        "version": "1.92",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Net-SSLeay-1.92-2.el9.s390x.rpm",
+        "checksum": "sha256:a6c775718ac3d717b67a3ff9e3d302d0aad4d650ef07d19c4eac2022bcbbd307",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-POSIX",
+        "epoch": 0,
+        "version": "1.94",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-POSIX-1.94-479.el9.s390x.rpm",
+        "checksum": "sha256:df1f6645e39588b983d94f5ec7d0421148346f37746969ea60720b878c72c721",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-PathTools",
+        "epoch": 0,
+        "version": "3.78",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-PathTools-3.78-461.el9.s390x.rpm",
+        "checksum": "sha256:17e3e5683430884d109b66e962b48609e5373cb931508f1b33dd50cc723fb3f0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Escapes",
+        "epoch": 1,
+        "version": "1.07",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Escapes-1.07-460.el9.noarch.rpm",
+        "checksum": "sha256:42fa08cc02a405933395316610a56e2bff58f6f7be16e9a063ec634747199bc0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Perldoc",
+        "epoch": 0,
+        "version": "3.28.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Perldoc-3.28.01-461.el9.noarch.rpm",
+        "checksum": "sha256:db3285dbe77ddc822d6bb847f857ea7032786cf7996b26d6c01481903b6d26e0",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Simple",
+        "epoch": 1,
+        "version": "3.42",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Simple-3.42-4.el9.noarch.rpm",
+        "checksum": "sha256:2752454ce47a46227c6b7b98a5d9a25dcf3a992f27109a726744a66cd93c7b9a",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Pod-Usage",
+        "epoch": 4,
+        "version": "2.01",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Pod-Usage-2.01-4.el9.noarch.rpm",
+        "checksum": "sha256:c170870a2d1ff32048d13497fa67c382fe5aaf3d8d21bae639356ac28003dba9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Scalar-List-Utils",
+        "epoch": 4,
+        "version": "1.56",
+        "release": "461.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Scalar-List-Utils-1.56-461.el9.s390x.rpm",
+        "checksum": "sha256:8716d3c9f99b61c26d9cf7adb103094087759292f097bdbb958c05c0971a127e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-SelectSaver",
+        "epoch": 0,
+        "version": "1.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-SelectSaver-1.02-479.el9.noarch.rpm",
+        "checksum": "sha256:c3713e0ffb283367dfe1741477f140ec1d6b6d38158e1bb5294d485f12f30630",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Socket",
+        "epoch": 4,
+        "version": "2.031",
+        "release": "4.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Socket-2.031-4.el9.s390x.rpm",
+        "checksum": "sha256:fc509d48144bfdaf80b150ff406951d69b4d8c70ed6906a749907b20862b29c2",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Storable",
+        "epoch": 1,
+        "version": "3.21",
+        "release": "460.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Storable-3.21-460.el9.s390x.rpm",
+        "checksum": "sha256:9a59d8714da2398e22eb689f445e80c7e7842b87c49c6ff0112e8de30f2a738e",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Symbol",
+        "epoch": 0,
+        "version": "1.08",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Symbol-1.08-479.el9.noarch.rpm",
+        "checksum": "sha256:7a51c0a3015125a9ad48be64b8a605203a2c1bd44dece77af07231391b587583",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-ANSIColor",
+        "epoch": 0,
+        "version": "5.01",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Term-ANSIColor-5.01-461.el9.noarch.rpm",
+        "checksum": "sha256:996148d460395369394e9d4721e9000c5b2fa34ee800390a4a9d885b6db95b23",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Term-Cap",
+        "epoch": 0,
+        "version": "1.17",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Term-Cap-1.17-460.el9.noarch.rpm",
+        "checksum": "sha256:015a6d02b9c84bd353680d4bad61f3c8d297c53c3a43325e08e4ac4b48f97f17",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-ParseWords",
+        "epoch": 0,
+        "version": "3.30",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Text-ParseWords-3.30-460.el9.noarch.rpm",
+        "checksum": "sha256:4d47f3ba0ce454be5d781e968cfe15f01f393e68a47c415f35c0d88358ab4af9",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Text-Tabs+Wrap",
+        "epoch": 0,
+        "version": "2013.0523",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Text-Tabs+Wrap-2013.0523-460.el9.noarch.rpm",
+        "checksum": "sha256:5ad6ef70bbb4ba8d5cfd6ee0b3dda0ddc8cf0103199959499944019a66f7edcd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-Time-Local",
+        "epoch": 2,
+        "version": "1.300",
+        "release": "7.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-Time-Local-1.300-7.el9.noarch.rpm",
+        "checksum": "sha256:e8e1e692b6e52cdb69515b2ad44b84ca71917bea5f47908cb9ae89b2bbd145a1",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-URI",
+        "epoch": 0,
+        "version": "5.09",
+        "release": "3.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-URI-5.09-3.el9.noarch.rpm",
+        "checksum": "sha256:1635b7d818e4f70445f7207f13e058c63c5d1f5aa081cfd2583912ae45f8e1bd",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-base",
+        "epoch": 0,
+        "version": "2.27",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-base-2.27-479.el9.noarch.rpm",
+        "checksum": "sha256:2233c5ca2d9b132f78ee7c56ab1effcdb71cdd5a0b6cf302e2e71c6bc220e21c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-constant",
+        "epoch": 0,
+        "version": "1.33",
+        "release": "461.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-constant-1.33-461.el9.noarch.rpm",
+        "checksum": "sha256:8ab94e13cab4e7eee081c7618ea7738b072d8093631d97b8b1f83bff893cf892",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-if",
+        "epoch": 0,
+        "version": "0.60.800",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-if-0.60.800-479.el9.noarch.rpm",
+        "checksum": "sha256:67025fa14cafaf12129a343f803a14bdf582049f659b6d13194179671e335248",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-interpreter",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-interpreter-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:79ffab66b5c757425be2501ee90ac76ced72ddc76bb7ec4bd52b7ff09c0d1e42",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libnet",
+        "epoch": 0,
+        "version": "3.13",
+        "release": "4.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-libnet-3.13-4.el9.noarch.rpm",
+        "checksum": "sha256:79156f91a2ee21fb96f10e331047c55ff913e36f9a13ff89d0a479f0fc4dcb98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-libs",
+        "epoch": 4,
+        "version": "5.32.1",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-libs-5.32.1-479.el9.s390x.rpm",
+        "checksum": "sha256:7ac22ab62ddca31c8b95b91dbb2e3988c3115208c560bd9c9793a9972864c854",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-mro",
+        "epoch": 0,
+        "version": "1.23",
+        "release": "479.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-mro-1.23-479.el9.s390x.rpm",
+        "checksum": "sha256:29813925736d971977ad5efa4ab3db66540988eed431bec8007e439c0e1ca87c",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overload",
+        "epoch": 0,
+        "version": "1.31",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-overload-1.31-479.el9.noarch.rpm",
+        "checksum": "sha256:a7af18b9fa06a60035a943ede3a4c9472702f929f834dc293edb675c017d2d03",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-overloading",
+        "epoch": 0,
+        "version": "0.02",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-overloading-0.02-479.el9.noarch.rpm",
+        "checksum": "sha256:709cca3ba7d06e28ca8860806e2bec2c387a250d5ff0fac60ef2c26794703759",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-parent",
+        "epoch": 1,
+        "version": "0.238",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-parent-0.238-460.el9.noarch.rpm",
+        "checksum": "sha256:a9b2ccc25a5ed5cc024935ef573772e203ed363f67dd5acc0d2ad5907498c463",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-podlators",
+        "epoch": 1,
+        "version": "4.14",
+        "release": "460.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-podlators-4.14-460.el9.noarch.rpm",
+        "checksum": "sha256:0401f715522a14b53956bccb60954025ad18a73802f7144ab0160d8504951a98",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-subs",
+        "epoch": 0,
+        "version": "1.03",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-subs-1.03-479.el9.noarch.rpm",
+        "checksum": "sha256:bbd482b4444ad71d2ec9aee80b36a08f2145d0ced90856bd030d5c7806d9a5fa",
+        "check_gpg": true
+      },
+      {
+        "name": "perl-vars",
+        "epoch": 0,
+        "version": "1.05",
+        "release": "479.el9",
+        "arch": "noarch",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/perl-vars-1.05-479.el9.noarch.rpm",
+        "checksum": "sha256:7285b90be87c41754b9e525c512a23adc43540da25a576e5a571498e3120f0db",
+        "check_gpg": true
+      },
+      {
         "name": "python-unversioned-command",
         "epoch": 0,
         "version": "3.9.14",
@@ -4666,6 +5988,16 @@
         "arch": "noarch",
         "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/python-unversioned-command-3.9.14-1.el9.noarch.rpm",
         "checksum": "sha256:7178c08f988a127d570a37ad630291bd773401b85de38cfb7b1855b9b8a13f1e",
+        "check_gpg": true
+      },
+      {
+        "name": "s390utils-base",
+        "epoch": 2,
+        "version": "2.22.0",
+        "release": "2.el9",
+        "arch": "s390x",
+        "remote_location": "https://rpmrepo.osbuild.org/v2/mirror/rhvpn/el9/el9-s390x-appstream-n9.2-20221025/Packages/s390utils-base-2.22.0-2.el9.s390x.rpm",
+        "checksum": "sha256:ec1cb835e3cc82d427ad26e4302b53552de12d7b21e7a0d0b69a64f297292a54",
         "check_gpg": true
       }
     ],


### PR DESCRIPTION
The big rewrite of rhel9 distro omitted installing `s390utils-base` into the buildroot. This caused the `org.osbuild.zipl.inst` stage to fail because of missing `/usr/sbin/zipl`.

This commit introduces `s390utils-base` back into the buildroot which fixes building of the s390x images.

I verified it by building the RHEL 9.1 qcow2 image and booting it using libvirt.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`

Information regarding our GitLab pipeline (Schutzbot):

CI will not be ran automatically if WIP label is applied or the PR is in DRAFT state, instead only
a link will be provided to the pipeline which can then be triggered manually if desired. To run the
CI automatically either switch the PR to ready or apply WIP+test label.

Outside contributors need manual approval from one of the osbuild-composer maintainers.

Schutzbot will only be triggered if all Tests jobs in GitHub workflow succeed.
-->
