### PR TITLE
RHEL 9 & Fedora: Anaconda boot arguments

### DIFF
--- a/internal/image/image_installer.go
+++ b/internal/image/image_installer.go
@@ -116,11 +116,9 @@ func (img *ImageInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
 
-	kernelOpts := make([]string, 0)
+	kernelOpts := []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel)}
 	if img.ISORootKickstart {
 		kernelOpts = append(kernelOpts, fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath))
-	} else {
-		kernelOpts = append(kernelOpts, fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel))
 	}
 	kernelOpts = append(kernelOpts, img.AdditionalKernelOpts...)
 	bootTreePipeline.KernelOpts = kernelOpts

--- a/internal/image/ostree_installer.go
+++ b/internal/image/ostree_installer.go
@@ -93,7 +93,7 @@ func (img *OSTreeInstaller) InstantiateManifest(m *manifest.Manifest,
 	bootTreePipeline.Platform = img.Platform
 	bootTreePipeline.UEFIVendor = img.Platform.GetUEFIVendor()
 	bootTreePipeline.ISOLabel = isoLabel
-	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath)}
+	bootTreePipeline.KernelOpts = []string{fmt.Sprintf("inst.stage2=hd:LABEL=%s", isoLabel), fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", isoLabel, kspath)}
 
 	isoTreePipeline := manifest.NewAnacondaISOTree(m,
 		buildPipeline,

--- a/internal/manifest/efi_boot_tree.go
+++ b/internal/manifest/efi_boot_tree.go
@@ -44,11 +44,6 @@ func (p *EFIBootTree) serialize() osbuild.Pipeline {
 		panic("unsupported architecture")
 	}
 
-	kernelOpts := []string{}
-	if len(p.KernelOpts) > 0 {
-		kernelOpts = append(kernelOpts, p.KernelOpts...)
-	}
-
 	grubOptions := &osbuild.GrubISOStageOptions{
 		Product: osbuild.Product{
 			Name:    p.product,
@@ -56,7 +51,7 @@ func (p *EFIBootTree) serialize() osbuild.Pipeline {
 		},
 		Kernel: osbuild.ISOKernel{
 			Dir:  "/images/pxeboot",
-			Opts: kernelOpts,
+			Opts: p.KernelOpts,
 		},
 		ISOLabel:      p.ISOLabel,
 		Architectures: architectures,

--- a/internal/manifest/iso_tree.go
+++ b/internal/manifest/iso_tree.go
@@ -112,10 +112,9 @@ func (p *AnacondaISOTree) serialize() osbuild.Pipeline {
 
 	kernelOpts := []string{}
 
+	kernelOpts = append(kernelOpts, fmt.Sprintf("inst.stage2=hd:LABEL=%s", p.isoLabel))
 	if p.KSPath != "" {
 		kernelOpts = append(kernelOpts, fmt.Sprintf("inst.ks=hd:LABEL=%s:%s", p.isoLabel, p.KSPath))
-	} else {
-		kernelOpts = append(kernelOpts, fmt.Sprintf("inst.stage2=hd:LABEL=%s", p.isoLabel))
 	}
 
 	if len(p.KernelOpts) > 0 {

--- a/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer-boot.json
@@ -9511,6 +9511,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -9604,6 +9605,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-edge_installer_with_users-boot.json
@@ -9540,6 +9540,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -9633,6 +9634,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/centos_9-aarch64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer-boot.json
@@ -9290,6 +9290,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -13185,6 +13186,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-aarch64-image_installer_with_users-boot.json
@@ -9325,6 +9325,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -13372,6 +13373,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer-boot.json
@@ -9672,6 +9672,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -9765,6 +9766,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-edge_installer_with_users-boot.json
@@ -9701,6 +9701,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -9794,6 +9795,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/centos_9-x86_64-image_installer-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer-boot.json
@@ -9451,6 +9451,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -13411,6 +13412,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/centos_9-x86_64-image_installer_with_users-boot.json
@@ -9486,6 +9486,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -13598,6 +13599,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=CentOS-Stream-9-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer-boot.json
@@ -10078,6 +10078,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10168,6 +10169,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-aarch64-iot_installer_with_users-boot.json
@@ -10107,6 +10107,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10197,6 +10198,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_35-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_installer-boot.json
@@ -10271,6 +10271,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -10361,6 +10362,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_35-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_35-x86_64-iot_installer_with_users-boot.json
@@ -10300,6 +10300,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -10390,6 +10391,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-35-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-35-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer-boot.json
@@ -10599,6 +10599,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10689,6 +10690,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-aarch64-iot_installer_with_users-boot.json
@@ -10628,6 +10628,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10718,6 +10719,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer-boot.json
@@ -10784,6 +10784,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -10874,6 +10875,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_36-x86_64-iot_installer_with_users-boot.json
@@ -10813,6 +10813,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -10903,6 +10904,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-36-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-36-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer-boot.json
@@ -10725,6 +10725,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10815,6 +10816,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-aarch64-iot_installer_with_users-boot.json
@@ -10754,6 +10754,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10844,6 +10845,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer-boot.json
@@ -10918,6 +10918,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -11008,6 +11009,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_37-x86_64-iot_installer_with_users-boot.json
@@ -10947,6 +10947,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -11037,6 +11038,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-37-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-37-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer-boot.json
@@ -10364,6 +10364,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10454,6 +10455,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-aarch64-iot_installer_with_users-boot.json
@@ -10393,6 +10393,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -10483,6 +10484,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer-boot.json
@@ -10541,6 +10541,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -10631,6 +10632,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
+++ b/test/data/manifests/fedora_38-x86_64-iot_installer_with_users-boot.json
@@ -10570,6 +10570,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -10660,6 +10661,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=Fedora-38-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=Fedora-38-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer-boot.json
@@ -3646,6 +3646,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -3739,6 +3740,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-edge_installer_with_users-boot.json
@@ -3675,6 +3675,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -3768,6 +3769,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer-boot.json
@@ -3627,6 +3627,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -5205,6 +5206,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-aarch64-image_installer_with_users-boot.json
@@ -3662,6 +3662,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -5300,6 +5301,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer-boot.json
@@ -3710,6 +3710,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -3803,6 +3804,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-edge_installer_with_users-boot.json
@@ -3739,6 +3739,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -3832,6 +3833,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer-boot.json
@@ -3691,6 +3691,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -5296,6 +5297,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_90-x86_64-image_installer_with_users-boot.json
@@ -3726,6 +3726,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -5391,6 +5392,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-0-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer-boot.json
@@ -9623,6 +9623,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -9716,6 +9717,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-edge_installer_with_users-boot.json
@@ -9652,6 +9652,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -9745,6 +9746,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer-boot.json
@@ -9402,6 +9402,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -13401,6 +13402,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-aarch64-image_installer_with_users-boot.json
@@ -9437,6 +9437,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -13588,6 +13589,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer-boot.json
@@ -9768,6 +9768,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -9861,6 +9862,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-edge_installer_with_users-boot.json
@@ -9797,6 +9797,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -9890,6 +9891,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer-boot.json
@@ -9547,6 +9547,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -13602,6 +13603,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_91-x86_64-image_installer_with_users-boot.json
@@ -9582,6 +9582,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -13789,6 +13790,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-1-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer-boot.json
@@ -9639,6 +9639,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -9732,6 +9733,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-edge_installer_with_users-boot.json
@@ -9668,6 +9668,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -9761,6 +9762,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer-boot.json
@@ -9418,6 +9418,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -13425,6 +13426,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-aarch64-image_installer_with_users-boot.json
@@ -9453,6 +9453,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               },
@@ -13612,6 +13613,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-aarch64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-x86_64-edge_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_installer-boot.json
@@ -9784,6 +9784,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -9877,6 +9878,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-x86_64-edge_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-edge_installer_with_users-boot.json
@@ -9813,6 +9813,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -9906,6 +9907,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-x86_64-image_installer-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-image_installer-boot.json
@@ -9563,6 +9563,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -13626,6 +13627,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }

--- a/test/data/manifests/rhel_92-x86_64-image_installer_with_users-boot.json
+++ b/test/data/manifests/rhel_92-x86_64-image_installer_with_users-boot.json
@@ -9598,6 +9598,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               },
@@ -13813,6 +13814,7 @@
               "kernel": {
                 "dir": "/images/pxeboot",
                 "opts": [
+                  "inst.stage2=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64",
                   "inst.ks=hd:LABEL=RHEL-9-2-0-BaseOS-x86_64:/osbuild.ks"
                 ]
               }


### PR DESCRIPTION
The bootiso.mono stage in osbuild that we used until recently adds the inst.stage2 option unconditionally [1] whereas the current grub2.iso stage that we use now doesn't.

This addresses rhbz#2152192: the lack of `inst.stage2` broke a workflow that relied on it.

[1] https://github.com/osbuild/osbuild/blob/8511add1695c49cc7f3df2220044a4eed17ba1a5/stages/org.osbuild.bootiso.mono#L369